### PR TITLE
fix(android): 下载文件名被附加查询参数后缀

### DIFF
--- a/android/app/src/main/java/com/clawbench/app/MainActivity.java
+++ b/android/app/src/main/java/com/clawbench/app/MainActivity.java
@@ -375,13 +375,14 @@ public class MainActivity extends AppCompatActivity {
                     request.addRequestHeader("Cookie", cookies);
                 }
                 request.setMimeType(mimetype);
-                request.setTitle(getFileNameFromUrl(url));
+                String fileName = getDownloadFileName(url, contentDisposition);
+                request.setTitle(fileName);
                 request.setDescription(getString(R.string.download_description));
                 request.allowScanningByMediaScanner();
                 request.setNotificationVisibility(
                         DownloadManager.Request.VISIBILITY_VISIBLE_NOTIFY_COMPLETED);
                 request.setDestinationInExternalPublicDir(
-                        Environment.DIRECTORY_DOWNLOADS, "ClawBench/" + getFileNameFromUrl(url));
+                        Environment.DIRECTORY_DOWNLOADS, "ClawBench/" + fileName);
 
                 DownloadManager dm = (DownloadManager) getSystemService(Context.DOWNLOAD_SERVICE);
                 dm.enqueue(request);
@@ -394,16 +395,50 @@ public class MainActivity extends AppCompatActivity {
     }
 
     /**
-     * Extract a file name from a /api/local-file/ URL.
-     * Falls back to "download" if parsing fails.
+     * Determine the download file name.
+     * Priority: Content-Disposition header > URL path (without query params) > "download".
      */
-    private String getFileNameFromUrl(String url) {
+    private String getDownloadFileName(String url, String contentDisposition) {
+        // 1. Try Content-Disposition header (sent by server with attachment; filename="...")
+        if (contentDisposition != null && !contentDisposition.isEmpty()) {
+            String name = parseContentDispositionFilename(contentDisposition);
+            if (name != null && !name.isEmpty()) return name;
+        }
+        // 2. Fallback: extract from URL path, stripping query parameters
         String decoded = Uri.decode(url);
+        int queryIdx = decoded.indexOf('?');
+        if (queryIdx >= 0) decoded = decoded.substring(0, queryIdx);
+        int fragmentIdx = decoded.indexOf('#');
+        if (fragmentIdx >= 0) decoded = decoded.substring(0, fragmentIdx);
         int lastSlash = decoded.lastIndexOf('/');
         if (lastSlash >= 0 && lastSlash < decoded.length() - 1) {
             return decoded.substring(lastSlash + 1);
         }
         return "download";
+    }
+
+    /**
+     * Parse filename from Content-Disposition header.
+     * Supports: filename="..." and filename*=UTF-8''... (RFC 5987)
+     */
+    private String parseContentDispositionFilename(String contentDisposition) {
+        // Try filename*= (RFC 5987 encoded) first
+        java.util.regex.Matcher extMatcher = java.util.regex.Pattern.compile(
+                "filename\\*\\s*=\\s*(?:UTF-8|utf-8)''(.+?)(?:\\s*;|$)")
+                .matcher(contentDisposition);
+        if (extMatcher.find()) {
+            try {
+                return java.net.URLDecoder.decode(extMatcher.group(1), "UTF-8");
+            } catch (Exception ignored) {}
+        }
+        // Then try filename="..."
+        java.util.regex.Matcher matcher = java.util.regex.Pattern.compile(
+                "filename\\s*=\\s*\"?([^\";]+)\"?")
+                .matcher(contentDisposition);
+        if (matcher.find()) {
+            return matcher.group(1).trim();
+        }
+        return null;
     }
 
     /**


### PR DESCRIPTION
## 问题

Android APP 在文件预览界面下载文件时，文件名会被附加 URL 查询参数。例如下载 `clawbench-android.apk` 实际保存为 `clawbench-android.apkdownload=1`。

**根因：** `getFileNameFromUrl()` 从 URL 提取文件名时取最后一个 `/` 之后的所有内容，包含了 `?download=1` 查询参数。浏览器不受影响是因为浏览器会优先从 `Content-Disposition` 头解析文件名，但 Android 端忽略了该参数。

## 修复

1. **优先使用 `Content-Disposition` 头**解析文件名（与浏览器行为一致），`DownloadListener` 回调本身就提供了该参数
2. **URL fallback 时先去掉 `?` 和 `#` 后面的内容**再提取文件名
3. 支持 RFC 5987 `filename*=UTF-8...` 编码的非 ASCII 文件名

## 测试

- [x] 小米手机 APK 下载文件名正确，无多余后缀