### PR TITLE
refactor: 移除会话分页中未使用的 total/totalCount

### DIFF
--- a/internal/handler/chat_session.go
+++ b/internal/handler/chat_session.go
@@ -37,15 +37,13 @@ func ServeSessions(w http.ResponseWriter, r *http.Request) {
 		}
 
 		var sessions []model.ChatSession
-		var total int
 		var hasMore bool
 		var err error
 
 		if limit > 0 {
-			sessions, total, hasMore, err = service.GetSessionsPaged(projectPath, "", limit, cursor, cursorID)
+			sessions, hasMore, err = service.GetSessionsPaged(projectPath, "", limit, cursor, cursorID)
 		} else {
 			sessions, err = service.GetSessions(projectPath, "")
-			total = len(sessions)
 			hasMore = false
 		}
 		if err != nil {
@@ -57,7 +55,6 @@ func ServeSessions(w http.ResponseWriter, r *http.Request) {
 		}
 		writeJSON(w, http.StatusOK, map[string]interface{}{
 			"sessions": sessions,
-			"total":    total,
 			"hasMore":  hasMore,
 		})
 

--- a/internal/handler/chat_test.go
+++ b/internal/handler/chat_test.go
@@ -2015,7 +2015,6 @@ func TestServeSessions_Pagination_NoLimit(t *testing.T) {
 	assert.NoError(t, json.Unmarshal(w.Body.Bytes(), &result))
 	sessions := result["sessions"].([]interface{})
 	assert.Len(t, sessions, 5)
-	assert.Equal(t, float64(5), result["total"])
 	assert.Equal(t, false, result["hasMore"])
 }
 
@@ -2040,7 +2039,6 @@ func TestServeSessions_Pagination_WithLimit(t *testing.T) {
 	assert.NoError(t, json.Unmarshal(w.Body.Bytes(), &result))
 	sessions := result["sessions"].([]interface{})
 	assert.Len(t, sessions, 3)
-	assert.Equal(t, float64(5), result["total"])
 	assert.Equal(t, true, result["hasMore"])
 }
 
@@ -2062,7 +2060,6 @@ func TestServeSessions_Pagination_LimitExceedsTotal(t *testing.T) {
 	assert.NoError(t, json.Unmarshal(w.Body.Bytes(), &result))
 	sessions := result["sessions"].([]interface{})
 	assert.Len(t, sessions, 1)
-	assert.Equal(t, float64(1), result["total"])
 	assert.Equal(t, false, result["hasMore"])
 }
 
@@ -2107,7 +2104,6 @@ func TestServeSessions_Pagination_ZeroLimit(t *testing.T) {
 	assert.NoError(t, json.Unmarshal(w.Body.Bytes(), &result))
 	sessions := result["sessions"].([]interface{})
 	assert.Len(t, sessions, 3)
-	assert.Equal(t, float64(3), result["total"])
 	assert.Equal(t, false, result["hasMore"])
 }
 
@@ -2132,6 +2128,5 @@ func TestServeSessions_Pagination_EmptyProject(t *testing.T) {
 		sessions := sessionsRaw.([]interface{})
 		assert.Empty(t, sessions)
 	}
-	assert.Equal(t, float64(0), result["total"])
 	assert.Equal(t, false, result["hasMore"])
 }

--- a/internal/service/chat.go
+++ b/internal/service/chat.go
@@ -284,28 +284,15 @@ func GetSessions(projectPath, backend string) ([]model.ChatSession, error) {
 // limit=0 means no limit (returns all sessions, backward compatible).
 // cursor and cursorID: when non-empty, only return sessions with
 //   (updated_at < cursor) OR (updated_at = cursor AND id < cursorID)
-// Returns sessions, total count, hasMore flag.
-func GetSessionsPaged(projectPath, backend string, limit int, cursor string, cursorID string) ([]model.ChatSession, int, bool, error) {
+// Returns sessions and hasMore flag.
+func GetSessionsPaged(projectPath, backend string, limit int, cursor string, cursorID string) ([]model.ChatSession, bool, error) {
 	// No limit: return all sessions (backward compatible)
 	if limit <= 0 {
 		sessions, err := GetSessions(projectPath, backend)
 		if err != nil {
-			return nil, 0, false, err
+			return nil, false, err
 		}
-		return sessions, len(sessions), false, nil
-	}
-
-	// Get total count
-	total := 0
-	countQuery := `SELECT COUNT(*) FROM chat_sessions s WHERE s.project_path = ? AND s.deleted = 0 AND s.session_type = 'chat'`
-	countArgs := []interface{}{projectPath}
-	if backend != "" {
-		countQuery += " AND s.backend = ?"
-		countArgs = append(countArgs, backend)
-	}
-	err := DB.QueryRow(countQuery, countArgs...).Scan(&total)
-	if err != nil {
-		return nil, 0, false, err
+		return sessions, false, nil
 	}
 
 	// Build main query with cursor and limit+1
@@ -327,7 +314,7 @@ func GetSessionsPaged(projectPath, backend string, limit int, cursor string, cur
 
 	rows, err := DB.Query(query, args...)
 	if err != nil {
-		return nil, 0, false, err
+		return nil, false, err
 	}
 	defer rows.Close()
 
@@ -336,7 +323,7 @@ func GetSessionsPaged(projectPath, backend string, limit int, cursor string, cur
 		var s model.ChatSession
 		var lastRead sql.NullTime
 		if err := rows.Scan(&s.ID, &s.Title, &s.Backend, &s.AgentID, &s.AgentSource, &s.Model, &s.SessionType, &s.CreatedAt, &s.UpdatedAt, &lastRead, &s.UnreadCount); err != nil {
-			return nil, 0, false, err
+			return nil, false, err
 		}
 		if lastRead.Valid {
 			s.LastReadAt = &lastRead.Time
@@ -344,7 +331,7 @@ func GetSessionsPaged(projectPath, backend string, limit int, cursor string, cur
 		sessions = append(sessions, s)
 	}
 	if err := rows.Err(); err != nil {
-		return nil, 0, false, err
+		return nil, false, err
 	}
 
 	hasMore := len(sessions) > limit
@@ -352,7 +339,7 @@ func GetSessionsPaged(projectPath, backend string, limit int, cursor string, cur
 		sessions = sessions[:limit]
 	}
 
-	return sessions, total, hasMore, nil
+	return sessions, hasMore, nil
 }
 
 // UpdateLastRead sets the last_read_at timestamp for a session to now.

--- a/internal/service/chat_test.go
+++ b/internal/service/chat_test.go
@@ -1497,10 +1497,9 @@ func TestGetSessionsPaged_NoLimit_ReturnsAll(t *testing.T) {
 	helperCreateSession(t, "/project", "claude", "S2")
 	helperCreateSession(t, "/project", "claude", "S3")
 
-	sessions, total, hasMore, err := service.GetSessionsPaged("/project", "", 0, "", "")
+	sessions, hasMore, err := service.GetSessionsPaged("/project", "", 0, "", "")
 	assert.NoError(t, err)
 	assert.Len(t, sessions, 3)
-	assert.Equal(t, 3, total)
 	assert.False(t, hasMore)
 }
 
@@ -1510,10 +1509,9 @@ func TestGetSessionsPaged_LimitGreaterThanTotal(t *testing.T) {
 	helperCreateSession(t, "/project", "claude", "S1")
 	helperCreateSession(t, "/project", "claude", "S2")
 
-	sessions, total, hasMore, err := service.GetSessionsPaged("/project", "", 10, "", "")
+	sessions, hasMore, err := service.GetSessionsPaged("/project", "", 10, "", "")
 	assert.NoError(t, err)
 	assert.Len(t, sessions, 2)
-	assert.Equal(t, 2, total)
 	assert.False(t, hasMore)
 }
 
@@ -1524,10 +1522,9 @@ func TestGetSessionsPaged_LimitEqualsTotal(t *testing.T) {
 	helperCreateSession(t, "/project", "claude", "S2")
 	helperCreateSession(t, "/project", "claude", "S3")
 
-	sessions, total, hasMore, err := service.GetSessionsPaged("/project", "", 3, "", "")
+	sessions, hasMore, err := service.GetSessionsPaged("/project", "", 3, "", "")
 	assert.NoError(t, err)
 	assert.Len(t, sessions, 3)
-	assert.Equal(t, 3, total)
 	assert.False(t, hasMore) // limit+1=4, only 3 exist, so no more
 }
 
@@ -1538,10 +1535,9 @@ func TestGetSessionsPaged_LimitLessThanTotal_HasMore(t *testing.T) {
 		helperCreateSession(t, "/project", "claude", fmt.Sprintf("S%d", i))
 	}
 
-	sessions, total, hasMore, err := service.GetSessionsPaged("/project", "", 3, "", "")
+	sessions, hasMore, err := service.GetSessionsPaged("/project", "", 3, "", "")
 	assert.NoError(t, err)
 	assert.Len(t, sessions, 3)
-	assert.Equal(t, 5, total)
 	assert.True(t, hasMore)
 }
 
@@ -1559,10 +1555,9 @@ func TestGetSessionsPaged_CursorSecondPage(t *testing.T) {
 	}
 
 	// First page: limit=2, no cursor
-	sessions, total, hasMore, err := service.GetSessionsPaged("/project", "", 2, "", "")
+	sessions, hasMore, err := service.GetSessionsPaged("/project", "", 2, "", "")
 	assert.NoError(t, err)
 	assert.Len(t, sessions, 2)
-	assert.Equal(t, 5, total)
 	assert.True(t, hasMore)
 
 	// Use last session as cursor
@@ -1571,10 +1566,9 @@ func TestGetSessionsPaged_CursorSecondPage(t *testing.T) {
 	cursorID := lastSession.ID
 
 	// Second page: cursor from last session of first page
-	sessions2, total2, hasMore2, err := service.GetSessionsPaged("/project", "", 2, cursor, cursorID)
+	sessions2, hasMore2, err := service.GetSessionsPaged("/project", "", 2, cursor, cursorID)
 	assert.NoError(t, err)
 	assert.Len(t, sessions2, 2)
-	assert.Equal(t, 5, total2)
 	assert.True(t, hasMore2)
 
 	// Verify no overlap between page 1 and page 2
@@ -1597,7 +1591,7 @@ func TestGetSessionsPaged_CursorLastPage(t *testing.T) {
 	}
 
 	// First page: limit=3
-	sessions, _, hasMore, err := service.GetSessionsPaged("/project", "", 3, "", "")
+	sessions, hasMore, err := service.GetSessionsPaged("/project", "", 3, "", "")
 	assert.NoError(t, err)
 	assert.True(t, hasMore)
 
@@ -1606,7 +1600,7 @@ func TestGetSessionsPaged_CursorLastPage(t *testing.T) {
 	cursor := lastSession.UpdatedAt.Format("2006-01-02 15:04:05")
 	cursorID := lastSession.ID
 
-	sessions2, _, hasMore2, err := service.GetSessionsPaged("/project", "", 3, cursor, cursorID)
+	sessions2, hasMore2, err := service.GetSessionsPaged("/project", "", 3, cursor, cursorID)
 	assert.NoError(t, err)
 	assert.Len(t, sessions2, 2) // only 2 remaining
 	assert.False(t, hasMore2)
@@ -1615,10 +1609,9 @@ func TestGetSessionsPaged_CursorLastPage(t *testing.T) {
 func TestGetSessionsPaged_EmptyProject(t *testing.T) {
 	setupDB(t)
 
-	sessions, total, hasMore, err := service.GetSessionsPaged("/project", "", 10, "", "")
+	sessions, hasMore, err := service.GetSessionsPaged("/project", "", 10, "", "")
 	assert.NoError(t, err)
 	assert.Empty(t, sessions)
-	assert.Equal(t, 0, total)
 	assert.False(t, hasMore)
 }
 
@@ -1629,10 +1622,9 @@ func TestGetSessionsPaged_FiltersByProject(t *testing.T) {
 	helperCreateSession(t, "/proj1", "claude", "P1-S2")
 	helperCreateSession(t, "/proj2", "claude", "P2-S1")
 
-	sessions, total, hasMore, err := service.GetSessionsPaged("/proj1", "", 10, "", "")
+	sessions, hasMore, err := service.GetSessionsPaged("/proj1", "", 10, "", "")
 	assert.NoError(t, err)
 	assert.Len(t, sessions, 2)
-	assert.Equal(t, 2, total)
 	assert.False(t, hasMore)
 }
 
@@ -1644,10 +1636,9 @@ func TestGetSessionsPaged_ExcludesDeletedSessions(t *testing.T) {
 	err := service.DeleteSession("/project", "claude", deletedSID)
 	assert.NoError(t, err)
 
-	sessions, total, hasMore, err := service.GetSessionsPaged("/project", "", 10, "", "")
+	sessions, hasMore, err := service.GetSessionsPaged("/project", "", 10, "", "")
 	assert.NoError(t, err)
 	assert.Len(t, sessions, 1)
-	assert.Equal(t, 1, total)
 	assert.False(t, hasMore)
 	assert.Equal(t, "Active", sessions[0].Title)
 }
@@ -1658,10 +1649,9 @@ func TestGetSessionsPaged_ExcludesScheduledSessions(t *testing.T) {
 	helperCreateSession(t, "/project", "claude", "Chat")
 	helperCreateScheduledSession(t, "/project", "claude", "Scheduled")
 
-	sessions, total, _, err := service.GetSessionsPaged("/project", "", 10, "", "")
+	sessions, _, err := service.GetSessionsPaged("/project", "", 10, "", "")
 	assert.NoError(t, err)
 	assert.Len(t, sessions, 1)
-	assert.Equal(t, 1, total)
 	assert.Equal(t, "Chat", sessions[0].Title)
 }
 
@@ -1677,7 +1667,7 @@ func TestGetSessionsPaged_OrderedByUpdatedDesc(t *testing.T) {
 	_, err = service.DB.Exec("UPDATE chat_sessions SET updated_at = datetime('now') WHERE id = ?", sid2)
 	assert.NoError(t, err)
 
-	sessions, _, _, err := service.GetSessionsPaged("/project", "", 10, "", "")
+	sessions, _, err := service.GetSessionsPaged("/project", "", 10, "", "")
 	assert.NoError(t, err)
 	assert.Len(t, sessions, 2)
 	assert.Equal(t, sid2, sessions[0].ID) // most recently updated first
@@ -1704,7 +1694,7 @@ func TestGetSessionsPaged_AllPagesCoverAllSessions(t *testing.T) {
 	page := 0
 
 	for {
-		sessions, _, hasMore, err := service.GetSessionsPaged("/project", "", limit, cursor, cursorID)
+		sessions, hasMore, err := service.GetSessionsPaged("/project", "", limit, cursor, cursorID)
 		assert.NoError(t, err)
 		assert.NotEmpty(t, sessions, "page %d should not be empty", page)
 
@@ -1758,10 +1748,9 @@ func TestGetSessionsPaged_SameTimestampTiebreaker(t *testing.T) {
 	assert.NoError(t, err)
 
 	// First page: limit=2 — should get sid3 (newest) and one of sid1/sid2
-	sessions, total, hasMore, err := service.GetSessionsPaged("/project", "", 2, "", "")
+	sessions, hasMore, err := service.GetSessionsPaged("/project", "", 2, "", "")
 	assert.NoError(t, err)
 	assert.Len(t, sessions, 2)
-	assert.Equal(t, 3, total)
 	assert.True(t, hasMore)
 
 	// Second page: cursor from last session of page 1
@@ -1769,7 +1758,7 @@ func TestGetSessionsPaged_SameTimestampTiebreaker(t *testing.T) {
 	cursor := lastSession.UpdatedAt.Format("2006-01-02 15:04:05")
 	cursorID := lastSession.ID
 
-	sessions2, _, hasMore2, err := service.GetSessionsPaged("/project", "", 2, cursor, cursorID)
+	sessions2, hasMore2, err := service.GetSessionsPaged("/project", "", 2, cursor, cursorID)
 	assert.NoError(t, err)
 	assert.Len(t, sessions2, 1) // only 1 remaining
 	assert.False(t, hasMore2)

--- a/web/src/components/session/SessionDrawer.vue
+++ b/web/src/components/session/SessionDrawer.vue
@@ -107,7 +107,6 @@ const sessions = ref([])
 const loading = ref(false)
 const loadingMore = ref(false)
 const hasMore = ref(false)
-const totalCount = ref(0)
 const listRef = ref(null)
 const sentinelRef = ref(null)
 let observer = null
@@ -167,12 +166,10 @@ async function handleCreateClick() {
 async function loadSessions() {
   loading.value = true
   hasMore.value = false
-  totalCount.value = 0
   try {
     const resp = await fetch(`/api/ai/sessions?limit=${pageSize.value}`)
     const data = await resp.json()
     sessions.value = data.sessions || []
-    totalCount.value = data.total || 0
     hasMore.value = !!data.hasMore
   } catch (err) {
     console.error('Failed to load sessions:', err)
@@ -198,7 +195,6 @@ async function loadMoreSessions() {
     if (more.length > 0) {
       sessions.value = [...sessions.value, ...more]
     }
-    totalCount.value = data.total || 0
     hasMore.value = !!data.hasMore
   } catch (err) {
     console.error('Failed to load more sessions:', err)


### PR DESCRIPTION
## 变更内容

移除 PR #8 中未使用的 `total`/`totalCount` 字段：

### 后端
- `GetSessionsPaged` 签名从 4 返回值简化为 3：`(sessions, total, hasMore, err)` → `(sessions, hasMore, err)`
- 移除每次分页请求的 `SELECT COUNT(*)` 查询（每次请求省一次 DB 查询）
- API 响应中移除 `total` 字段，仅保留 `sessions` + `hasMore`

### 前端
- 移除 `SessionDrawer.vue` 中声明但从未读取的 `totalCount` ref

### 测试
- 更新所有 13 个 `GetSessionsPaged` service 测试
- 更新所有 6 个 `ServeSessions_Pagination` handler 测试
- 全部通过 ✅

### 原因
Code review 发现 `totalCount` 在前端只赋值不使用，后端的 COUNT 查询完全浪费。