### PR TITLE
feat: 添加日志搜集上传功能 + 推送预览字数调整至64

### DIFF
--- a/android/app/src/main/java/com/clawbench/app/AppLog.java
+++ b/android/app/src/main/java/com/clawbench/app/AppLog.java
@@ -7,13 +7,18 @@ import android.util.Log;
 import org.json.JSONArray;
 import org.json.JSONObject;
 
+import java.io.BufferedInputStream;
 import java.io.BufferedReader;
+import java.io.ByteArrayOutputStream;
 import java.io.InputStreamReader;
 import java.io.OutputStream;
 import java.net.HttpURLConnection;
 import java.net.URL;
+import java.text.SimpleDateFormat;
 import java.util.ArrayList;
+import java.util.Date;
 import java.util.List;
+import java.util.Locale;
 
 import javax.net.ssl.HttpsURLConnection;
 import javax.net.ssl.SSLContext;
@@ -113,6 +118,112 @@ public class AppLog {
     /** Returns whether log capture is currently active. */
     public static boolean isCapturing() {
         return capturing;
+    }
+
+    /**
+     * Collect device info, AppLog buffer, and logcat dump into a single text file,
+     * then upload to the server via multipart POST.
+     * Must be called from a background thread.
+     *
+     * @param baseUrl     server base URL (e.g. "https://localhost:20000")
+     * @param deviceInfo  device info string (model, android version, app version)
+     * @return true if upload succeeded, false otherwise
+     */
+    public static boolean collectAndUploadLogs(String baseUrl, String deviceInfo) {
+        try {
+            StringBuilder sb = new StringBuilder();
+
+            // Header with device info and timestamp
+            String timestamp = new SimpleDateFormat("yyyy-MM-dd HH:mm:ss", Locale.US).format(new Date());
+            sb.append("=== ClawBench Android Log Dump ===\n");
+            sb.append("Time: ").append(timestamp).append("\n");
+            sb.append("Device: ").append(deviceInfo).append("\n");
+            sb.append("Server: ").append(baseUrl).append("\n\n");
+
+            // AppLog buffer snapshot
+            sb.append("--- AppLog Buffer ---\n");
+            synchronized (buffer) {
+                if (buffer.isEmpty()) {
+                    sb.append("(empty)\n");
+                } else {
+                    SimpleDateFormat fmt = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss.SSS", Locale.US);
+                    for (LogEntry e : buffer) {
+                        sb.append(fmt.format(new Date(e.ts)))
+                          .append(' ').append(e.level)
+                          .append('/').append(e.tag)
+                          .append(": ").append(e.msg).append('\n');
+                    }
+                }
+            }
+            sb.append('\n');
+
+            // logcat dump (last 500 lines)
+            sb.append("--- logcat (last 500 lines) ---\n");
+            try {
+                Process proc = Runtime.getRuntime().exec(new String[]{
+                        "logcat", "-d", "-v", "time", "-t", "500"
+                });
+                BufferedReader reader = new BufferedReader(
+                        new InputStreamReader(new BufferedInputStream(proc.getInputStream())));
+                String line;
+                while ((line = reader.readLine()) != null) {
+                    sb.append(line).append('\n');
+                }
+                reader.close();
+                proc.destroy();
+            } catch (Exception e) {
+                sb.append("(logcat unavailable: ").append(e.getMessage()).append(")\n");
+            }
+
+            // Upload via multipart POST
+            byte[] content = sb.toString().getBytes("UTF-8");
+            String boundary = "----ClawBenchLogUpload" + System.currentTimeMillis();
+
+            URL url = new URL(baseUrl + "/api/android-log/upload");
+            HttpURLConnection conn = (HttpURLConnection) url.openConnection();
+            try {
+                conn.setRequestMethod("POST");
+                conn.setRequestProperty("Content-Type", "multipart/form-data; boundary=" + boundary);
+                conn.setConnectTimeout(10000);
+                conn.setReadTimeout(30000);
+                conn.setDoOutput(true);
+
+                // Trust self-signed certs
+                if (conn instanceof HttpsURLConnection) {
+                    ((HttpsURLConnection) conn).setSSLSocketFactory(trustAllSSL.getSocketFactory());
+                    ((HttpsURLConnection) conn).setHostnameVerifier((hostname, session) -> true);
+                }
+
+                ByteArrayOutputStream body = new ByteArrayOutputStream();
+                // Part header
+                body.write(("--" + boundary + "\r\n").getBytes("UTF-8"));
+                body.write(("Content-Disposition: form-data; name=\"file\"; filename=\"android-log.txt\"\r\n").getBytes("UTF-8"));
+                body.write(("Content-Type: text/plain\r\n\r\n").getBytes("UTF-8"));
+                body.write(content);
+                body.write(("\r\n--" + boundary + "--\r\n").getBytes("UTF-8"));
+
+                byte[] bodyBytes = body.toByteArray();
+                conn.setFixedLengthStreamingMode(bodyBytes.length);
+                OutputStream os = conn.getOutputStream();
+                os.write(bodyBytes);
+                os.flush();
+                os.close();
+
+                int code = conn.getResponseCode();
+                if (code == 200) {
+                    Log.i(TAG, "Log dump uploaded successfully");
+                    return true;
+                } else {
+                    Log.w(TAG, "Log dump upload failed: HTTP " + code);
+                    return false;
+                }
+            } finally {
+                conn.disconnect();
+            }
+        } catch (Exception e) {
+            Log.e(TAG, "Log dump upload error: " + e.getMessage(), e);
+            return false;
+        }
     }
 
     // --- Internal ---

--- a/android/app/src/main/java/com/clawbench/app/MainActivity.java
+++ b/android/app/src/main/java/com/clawbench/app/MainActivity.java
@@ -1256,5 +1256,34 @@ public class MainActivity extends AppCompatActivity {
         public void stopLogCapture() {
             AppLog.stopCapture();
         }
+
+        /**
+         * Collect device info, AppLog buffer, and logcat, then upload as a file
+         * to the server. Called from the "Upload Logs" button in settings.
+         * Returns result via JS callback: window._logUploadResult(true|false).
+         */
+        @JavascriptInterface
+        public void collectLogs() {
+            new Thread(() -> {
+                String baseUrl = activity.prefs.getString(KEY_SERVER_URL, "");
+                if (baseUrl.isEmpty()) {
+                    activity.runOnUiThread(() ->
+                            activity.webView.evaluateJavascript("if(window._logUploadResult)window._logUploadResult(false)", null));
+                    return;
+                }
+                // Build device info string
+                String deviceInfo = Build.MODEL + " (android " + Build.VERSION.RELEASE
+                        + ", SDK " + Build.VERSION.SDK_INT + ")";
+                try {
+                    String versionName = activity.getPackageManager()
+                            .getPackageInfo(activity.getPackageName(), 0).versionName;
+                    deviceInfo += ", app " + versionName;
+                } catch (Exception ignored) {}
+                boolean ok = AppLog.collectAndUploadLogs(baseUrl, deviceInfo);
+                activity.runOnUiThread(() ->
+                        activity.webView.evaluateJavascript(
+                                "if(window._logUploadResult)window._logUploadResult(" + ok + ")", null));
+            }).start();
+        }
     }
 }

--- a/internal/handler/android_log.go
+++ b/internal/handler/android_log.go
@@ -2,6 +2,7 @@ package handler
 
 import (
 	"fmt"
+	"io"
 	"net/http"
 	"os"
 	"path/filepath"
@@ -95,4 +96,62 @@ func ServeAndroidLog(w http.ResponseWriter, r *http.Request) {
 	}
 
 	writeJSON(w, http.StatusOK, map[string]any{"written": len(req.Entries)})
+}
+
+// ServeAndroidLogUpload handles POST /api/android-log/upload.
+// It receives a multipart file upload from the Android app's "collect logs"
+// feature and saves it to .clawbench/logs/android-{timestamp}.log.
+// Unauthenticated (same as /api/android-log) — Android native HTTP has no WebView cookies.
+func ServeAndroidLogUpload(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodPost {
+		writeLocalizedErrorf(w, r, http.StatusMethodNotAllowed, "MethodNotAllowed")
+		return
+	}
+
+	// Parse multipart form (max 10MB)
+	if err := r.ParseMultipartForm(10 << 20); err != nil {
+		writeLocalizedErrorf(w, r, http.StatusBadRequest, "InvalidRequestBody")
+		return
+	}
+
+	file, header, err := r.FormFile("file")
+	if err != nil {
+		writeLocalizedErrorf(w, r, http.StatusBadRequest, "InvalidRequestBody")
+		return
+	}
+	defer file.Close()
+
+	// Read file content
+	data, err := io.ReadAll(file)
+	if err != nil {
+		model.WriteError(w, model.Internal(fmt.Errorf("read upload: %w", err)))
+		return
+	}
+
+	// Cap at 5MB
+	if len(data) > 5<<20 {
+		data = data[:5<<20]
+	}
+
+	// Save to .clawbench/logs/android-{timestamp}.log
+	logDir := filepath.Join(model.ConfigInstance.LogDir)
+	if err := os.MkdirAll(logDir, 0755); err != nil {
+		model.WriteError(w, model.Internal(fmt.Errorf("create log dir: %w", err)))
+		return
+	}
+
+	filename := fmt.Sprintf("android-%s.log", time.Now().Format("20060102-150405"))
+	path := filepath.Join(logDir, filename)
+
+	// Sanitize: avoid path traversal from header filename
+	safeName := filepath.Base(header.Filename)
+	_ = safeName // we use our own timestamped name, ignore client filename
+
+	if err := os.WriteFile(path, data, 0644); err != nil {
+		model.WriteError(w, model.Internal(fmt.Errorf("write log file: %w", err)))
+		return
+	}
+
+	relPath := filepath.Join(".clawbench", "logs", filename)
+	writeJSON(w, http.StatusOK, map[string]any{"ok": true, "path": relPath, "size": len(data)})
 }

--- a/internal/handler/android_log_test.go
+++ b/internal/handler/android_log_test.go
@@ -1,0 +1,114 @@
+package handler
+
+import (
+	"bytes"
+	"encoding/json"
+	"mime/multipart"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"clawbench/internal/model"
+)
+
+func TestServeAndroidLogUpload(t *testing.T) {
+	// Setup: create temp log dir
+	tmpDir := t.TempDir()
+	origLogDir := model.ConfigInstance.LogDir
+	model.ConfigInstance.LogDir = filepath.Join(tmpDir, ".clawbench", "logs")
+	defer func() { model.ConfigInstance.LogDir = origLogDir }()
+
+	t.Run("successful upload", func(t *testing.T) {
+		// Build multipart form
+		var buf bytes.Buffer
+		writer := multipart.NewWriter(&buf)
+		part, err := writer.CreateFormFile("file", "android-log.txt")
+		if err != nil {
+			t.Fatalf("CreateFormFile: %v", err)
+		}
+		content := "=== ClawBench Android Log Dump ===\nTime: 2026-05-20 14:00:00\nDevice: Pixel 7\n\n--- AppLog Buffer ---\n(empty)\n\n--- logcat ---\nhello world\n"
+		if _, err := part.Write([]byte(content)); err != nil {
+			t.Fatalf("Write: %v", err)
+		}
+		writer.Close()
+
+		req := httptest.NewRequest(http.MethodPost, "/api/android-log/upload", &buf)
+		req.Header.Set("Content-Type", writer.FormDataContentType())
+		w := httptest.NewRecorder()
+
+		ServeAndroidLogUpload(w, req)
+
+		if w.Code != http.StatusOK {
+			t.Fatalf("expected 200, got %d; body: %s", w.Code, w.Body.String())
+		}
+
+		var result map[string]interface{}
+		if err := json.Unmarshal(w.Body.Bytes(), &result); err != nil {
+			t.Fatalf("parse JSON: %v", err)
+		}
+		if result["ok"] != true {
+			t.Errorf("expected ok=true, got %v", result["ok"])
+		}
+		pathStr, ok := result["path"].(string)
+		if !ok || !strings.Contains(pathStr, "android-") {
+			t.Errorf("expected path with 'android-', got %v", result["path"])
+		}
+		if size, ok := result["size"].(float64); !ok || size < 1 {
+			t.Errorf("expected size > 0, got %v", result["size"])
+		}
+
+		// Verify file was actually written
+		files, err := os.ReadDir(model.ConfigInstance.LogDir)
+		if err != nil {
+			t.Fatalf("ReadDir: %v", err)
+		}
+		if len(files) != 1 {
+			t.Fatalf("expected 1 file, got %d", len(files))
+		}
+		data, err := os.ReadFile(filepath.Join(model.ConfigInstance.LogDir, files[0].Name()))
+		if err != nil {
+			t.Fatalf("ReadFile: %v", err)
+		}
+		if !strings.Contains(string(data), "ClawBench Android Log Dump") {
+			t.Errorf("file content doesn't contain expected header")
+		}
+	})
+
+	t.Run("rejects GET", func(t *testing.T) {
+		req := httptest.NewRequest(http.MethodGet, "/api/android-log/upload", nil)
+		w := httptest.NewRecorder()
+		ServeAndroidLogUpload(w, req)
+		if w.Code != http.StatusMethodNotAllowed {
+			t.Errorf("expected 405, got %d", w.Code)
+		}
+	})
+
+	t.Run("rejects missing file", func(t *testing.T) {
+		var buf bytes.Buffer
+		writer := multipart.NewWriter(&buf)
+		writer.Close() // no file part
+
+		req := httptest.NewRequest(http.MethodPost, "/api/android-log/upload", &buf)
+		req.Header.Set("Content-Type", writer.FormDataContentType())
+		w := httptest.NewRecorder()
+		ServeAndroidLogUpload(w, req)
+
+		if w.Code != http.StatusBadRequest {
+			t.Errorf("expected 400, got %d; body: %s", w.Code, w.Body.String())
+		}
+	})
+
+	t.Run("rejects invalid multipart", func(t *testing.T) {
+		req := httptest.NewRequest(http.MethodPost, "/api/android-log/upload", strings.NewReader("not multipart"))
+		req.Header.Set("Content-Type", "multipart/form-data; boundary=xxx")
+		w := httptest.NewRecorder()
+		ServeAndroidLogUpload(w, req)
+
+		if w.Code != http.StatusBadRequest {
+			t.Errorf("expected 400, got %d; body: %s", w.Code, w.Body.String())
+		}
+	})
+}

--- a/internal/handler/handler.go
+++ b/internal/handler/handler.go
@@ -274,6 +274,7 @@ func RegisterRoutes(mux *http.ServeMux) {
 	// This endpoint only accepts log entries (write-only, no read); the data is
 	// non-sensitive debug logs. Auth is unnecessary and would block the feature.
 	register("/api/android-log", ServeAndroidLog)
+	register("/api/android-log/upload", ServeAndroidLogUpload)
 
 	// File watch SSE (auto-refresh on file changes)
 	register("/api/file/watch", middleware.Auth(FileWatchSSE))

--- a/internal/service/session_runtime.go
+++ b/internal/service/session_runtime.go
@@ -51,7 +51,7 @@ func emitSessionEvent(sessionID, status string, hasNewMessages bool) {
 	})
 }
 
-// getSessionResponsePreview returns the first 16 runes of the AI's final reply text.
+// getSessionResponsePreview returns the first 64 runes of the AI's final reply text.
 func getSessionResponsePreview(sessionID string) string {
 	messages, err := GetMessagesBySessionID(sessionID)
 	if err != nil {
@@ -72,8 +72,8 @@ func getSessionResponsePreview(sessionID string) string {
 		// Extract text from text-type blocks
 		for _, b := range content.Blocks {
 			if b.Type == "text" && b.Text != "" {
-				if utf8.RuneCountInString(b.Text) > 16 {
-					return string([]rune(b.Text)[:16]) + "…"
+				if utf8.RuneCountInString(b.Text) > 64 {
+					return string([]rune(b.Text)[:64]) + "…"
 				}
 				return b.Text
 			}

--- a/internal/service/session_runtime_test.go
+++ b/internal/service/session_runtime_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"database/sql"
 	"encoding/json"
+	"strings"
 	"sync"
 	"testing"
 	"time"
@@ -463,7 +464,9 @@ func TestGetSessionResponsePreview_Truncation(t *testing.T) {
 	DB = db
 	defer func() { DB = origDB }()
 
-	longText := "这是一段超过十六个字符的长回复内容用于测试截断"
+	// 80 runes — should be truncated to 64 + …
+	longText := strings.Repeat("这是一段测试", 10) // 6*10 = 60 + more
+	longText += "追加更多文字直到超过六十四个字符的截断限制边界" // total > 64
 	content := model.ContentBlock{Type: "text", Text: longText}
 	blocks := map[string]any{"blocks": []model.ContentBlock{content}}
 	contentJSON, _ := json.Marshal(blocks)
@@ -471,7 +474,9 @@ func TestGetSessionResponsePreview_Truncation(t *testing.T) {
 	insertTestMessage(t, db, "session-preview-2", "assistant", string(contentJSON))
 
 	result := getSessionResponsePreview("session-preview-2")
-	assert.Equal(t, "这是一段超过十六个字符的长回复内…", result)
+	runes := []rune(longText)
+	assert.Equal(t, string(runes[:64])+"…", result)
+	assert.Equal(t, 65, utf8.RuneCountInString(result)) // 64 + ellipsis
 }
 
 func TestGetSessionResponsePreview_NoAssistantMessage(t *testing.T) {
@@ -564,14 +569,14 @@ func TestGetSessionResponsePreview_NoTextBlocks(t *testing.T) {
 	assert.Equal(t, "", result)
 }
 
-func TestGetSessionResponsePreview_Exact16Runes(t *testing.T) {
+func TestGetSessionResponsePreview_Exact64Runes(t *testing.T) {
 	origDB := DB
 	db := setupChatTestDB(t)
 	DB = db
 	defer func() { DB = origDB }()
 
-	// Exactly 16 runes — should NOT be truncated
-	exactText := "一二三四五六七八九零一二三四五六" // 16 chars
+	// Exactly 64 runes — should NOT be truncated
+	exactText := strings.Repeat("一二三四", 16) // 4*16 = 64 chars
 	content := model.ContentBlock{Type: "text", Text: exactText}
 	blocks := map[string]any{"blocks": []model.ContentBlock{content}}
 	contentJSON, _ := json.Marshal(blocks)
@@ -580,17 +585,17 @@ func TestGetSessionResponsePreview_Exact16Runes(t *testing.T) {
 
 	result := getSessionResponsePreview("session-preview-8")
 	assert.Equal(t, exactText, result)
-	assert.Equal(t, 16, utf8.RuneCountInString(result))
+	assert.Equal(t, 64, utf8.RuneCountInString(result))
 }
 
-func TestGetSessionResponsePreview_17Runes(t *testing.T) {
+func TestGetSessionResponsePreview_65Runes(t *testing.T) {
 	origDB := DB
 	db := setupChatTestDB(t)
 	DB = db
 	defer func() { DB = origDB }()
 
-	// 17 runes — should be truncated to 16 + …
-	longText := "一二三四五六七八九零一二三四五六七" // 17 chars
+	// 65 runes — should be truncated to 64 + …
+	longText := strings.Repeat("一二三四", 16) + "五" // 64+1 = 65 chars
 	content := model.ContentBlock{Type: "text", Text: longText}
 	blocks := map[string]any{"blocks": []model.ContentBlock{content}}
 	contentJSON, _ := json.Marshal(blocks)
@@ -598,7 +603,7 @@ func TestGetSessionResponsePreview_17Runes(t *testing.T) {
 	insertTestMessage(t, db, "session-preview-9", "assistant", string(contentJSON))
 
 	result := getSessionResponsePreview("session-preview-9")
-	assert.Equal(t, "一二三四五六七八九零一二三四五六…", result)
+	assert.Equal(t, strings.Repeat("一二三四", 16)+"…", result)
 }
 
 // --- emitSessionEvent with response preview ---

--- a/web/src/components/common/AppHeader.vue
+++ b/web/src/components/common/AppHeader.vue
@@ -79,6 +79,11 @@
           <span>{{ t('appHeader.debugLog') }}</span>
         </button>
         <div class="settings-menu-divider"></div>
+        <button class="settings-menu-item" @click="handleUploadLogs" :disabled="uploadingLogs">
+          <Upload :size="14" />
+          <span>{{ uploadingLogs ? t('common.loading') : t('appHeader.uploadLogs') }}</span>
+        </button>
+        <div class="settings-menu-divider"></div>
       </template>
       <button class="settings-menu-item" :class="{ active: currentLocale === 'zh' }" @click="handleLocaleSwitch('zh')">
           <Check v-if="currentLocale === 'zh'" :size="14" />
@@ -109,7 +114,7 @@
 </template>
 
 <script setup>
-import { Projector, ChevronDown, Search, Moon, Sun, Settings, Check, Server, Bug, GitBranch } from 'lucide-vue-next'
+import { Projector, ChevronDown, Search, Moon, Sun, Settings, Check, Server, Bug, Upload, GitBranch } from 'lucide-vue-next'
 import { ref, computed, onMounted, onUnmounted, inject, watch } from 'vue'
 import { useI18n } from 'vue-i18n'
 import { useLocale } from '@/composables/useLocale'
@@ -215,6 +220,34 @@ function toggleDebugLog() {
     // Don't close menu so user can see the toggle state
 }
 
+// Upload logs state
+const uploadingLogs = ref(false)
+let uploadLogsTimer = null
+
+function handleUploadLogs() {
+    if (uploadingLogs.value) return
+    if (!window.AndroidNative || !window.AndroidNative.collectLogs) return
+
+    // 3-second debounce
+    uploadingLogs.value = true
+    if (uploadLogsTimer) clearTimeout(uploadLogsTimer)
+    uploadLogsTimer = setTimeout(() => { uploadingLogs.value = false }, 3000)
+
+    // Register callback for result
+    window._logUploadResult = (ok) => {
+        uploadingLogs.value = false
+        if (uploadLogsTimer) clearTimeout(uploadLogsTimer)
+        toast?.show(
+            ok ? t('appHeader.logUploadSuccess') : t('appHeader.logUploadFailed'),
+            { icon: ok ? '✅' : '❌', type: ok ? 'success' : 'error', duration: 3000 }
+        )
+        delete window._logUploadResult
+    }
+
+    window.AndroidNative.collectLogs()
+    settingsMenuOpen.value = false
+}
+
 // Restore debug log capture state on mount
 function restoreDebugLogState() {
     if (!isAppMode.value || !window.AndroidNative) return
@@ -232,7 +265,7 @@ const settingsItemCount = computed(() => {
     // 4 interactive items: zh + en + dark + light (divider height negligible)
     let count = 4
     if (isAppMode.value) {
-        count += 4 // reconfigure item + divider + debug log item + divider
+        count += 6 // reconfigure item + divider + debug log item + divider + upload logs item + divider
     }
     return count
 })

--- a/web/src/i18n/locales/en.ts
+++ b/web/src/i18n/locales/en.ts
@@ -76,6 +76,9 @@ export default {
     websocket: 'WebSocket',
     jpush: 'Push Notifications',
     debugLog: 'Debug Log',
+    uploadLogs: 'Upload Logs',
+    logUploadSuccess: 'Logs uploaded successfully',
+    logUploadFailed: 'Log upload failed',
   },
   chat: {
     title: 'AI Chat',

--- a/web/src/i18n/locales/zh.ts
+++ b/web/src/i18n/locales/zh.ts
@@ -76,6 +76,9 @@ export default {
     websocket: 'WebSocket',
     jpush: '极光推送',
     debugLog: '调试日志',
+    uploadLogs: '上传日志',
+    logUploadSuccess: '日志上传成功',
+    logUploadFailed: '日志上传失败',
   },
   chat: {
     title: 'AI 对话',


### PR DESCRIPTION
## 变更内容

### 日志搜集上传
- **AppLog.java**：新增 `collectAndUploadLogs()` 方法，收集设备信息、AppLog 内存缓冲区、logcat 最近 500 行，打包为文本文件通过 multipart POST 上传到服务器
- **MainActivity.java**：新增 `collectLogs()` @JavascriptInterface，前端可通过 `window.AndroidNative.collectLogs()` 调用，结果通过 `window._logUploadResult(ok)` 回调
- **android_log.go**：新增 `ServeAndroidLogUpload` handler，接收 multipart 文件上传，保存到 `.clawbench/logs/android-{timestamp}.log`，无需认证（Android 原生 HTTP 无 WebView cookie）
- **handler.go**：注册路由 `/api/android-log/upload`
- **AppHeader.vue**：设置菜单新增「上传日志」按钮（Upload 图标），3 秒防抖，成功/失败 toast 提示
- **i18n**：中英文翻译 `uploadLogs` / `logUploadSuccess` / `logUploadFailed`

### 推送预览字数调整
- **session_runtime.go**：推送通知中的 AI 回复预览从 16 字符调整为 64 字符（UTF-8 rune 计数）

### 测试
- **android_log_test.go**（新文件）：4 个用例覆盖成功上传、GET 拒绝、缺少文件、无效 multipart
- **session_runtime_test.go**：截断测试从 16 更新为 64，新增 Exact64Runes / 65Runes 测试