### PR TITLE
fix: push alert 截断适配厂商通道限制，消除魔鬼数字

### DIFF
--- a/internal/service/session_runtime.go
+++ b/internal/service/session_runtime.go
@@ -25,6 +25,12 @@ var sessionStreams sync.Map // map[string]chan ai.StreamEvent
 var sessionCancels sync.Map         // map[string]context.CancelFunc
 var sessionCancelReasons sync.Map   // map[string]string — "user", "disconnect"
 
+// responsePreviewMaxRunes is the maximum number of runes included in the
+// response preview sent via WS session_update events. This is intentionally
+// generous (for WS consumers); the JPush alert path applies its own shorter
+// limit (see ws.Manager.broadcastToSubscription).
+const responsePreviewMaxRunes = 64
+
 // EmitSessionEvent broadcasts a session_update event to connected clients.
 func EmitSessionEvent(sessionID, status string, hasNewMessages bool) {
 	mgr := ws.GetManager()
@@ -57,7 +63,7 @@ func EmitSessionEvent(sessionID, status string, hasNewMessages bool) {
 	})
 }
 
-// getSessionResponsePreview returns the first 64 runes of the AI's final reply text.
+// getSessionResponsePreview returns the first responsePreviewMaxRunes runes of the AI's final reply text.
 func getSessionResponsePreview(sessionID string) string {
 	messages, err := GetMessagesBySessionID(sessionID)
 	if err != nil {
@@ -78,8 +84,8 @@ func getSessionResponsePreview(sessionID string) string {
 		// Extract text from text-type blocks
 		for _, b := range content.Blocks {
 			if b.Type == "text" && b.Text != "" {
-				if utf8.RuneCountInString(b.Text) > 64 {
-					return string([]rune(b.Text)[:64]) + "…"
+				if utf8.RuneCountInString(b.Text) > responsePreviewMaxRunes {
+					return string([]rune(b.Text)[:responsePreviewMaxRunes]) + "…"
 				}
 				return b.Text
 			}

--- a/internal/service/session_runtime.go
+++ b/internal/service/session_runtime.go
@@ -236,9 +236,13 @@ func ForceCancelSession(sessionID string) {
 	SetSessionRunning(sessionID, false, true)
 }
 
+// sessionStreamBufferSize is the buffer capacity for the per-session event channel.
+// Controls backpressure: when the channel is full, SendSessionEvent drops events.
+const sessionStreamBufferSize = 256
+
 // RegisterSessionStream creates and registers a stream channel for a session
 func RegisterSessionStream(sessionID string) chan ai.StreamEvent {
-	ch := make(chan ai.StreamEvent, 256)
+	ch := make(chan ai.StreamEvent, sessionStreamBufferSize)
 	sessionStreams.Store(sessionID, ch)
 	return ch
 }

--- a/internal/service/session_runtime_test.go
+++ b/internal/service/session_runtime_test.go
@@ -227,8 +227,8 @@ func TestSendSessionEvent_FullChannel(t *testing.T) {
 
 	RegisterSessionStream("session-full")
 
-	// Fill the channel buffer (capacity is 256)
-	for i := 0; i < 256; i++ {
+	// Fill the channel buffer (capacity is sessionStreamBufferSize)
+	for i := 0; i < sessionStreamBufferSize; i++ {
 		sent := SendSessionEvent("session-full", ai.StreamEvent{Type: "content", Content: "x"})
 		assert.True(t, sent)
 	}
@@ -358,7 +358,7 @@ func TestSendSessionEvent_ConcurrentAccess(t *testing.T) {
 	successCount := 0
 	var mu sync.Mutex
 
-	// Send 50 events concurrently (buffer is 64, so most should succeed)
+	// Send 50 events concurrently (buffer is sessionStreamBufferSize, so most should succeed)
 	for i := 0; i < 50; i++ {
 		wg.Add(1)
 		go func() {
@@ -373,7 +373,7 @@ func TestSendSessionEvent_ConcurrentAccess(t *testing.T) {
 	}
 
 	wg.Wait()
-	assert.Equal(t, 50, successCount, "All 50 events should be sent (buffer is 64)")
+	assert.Equal(t, 50, successCount, "All 50 events should be sent (buffer is sessionStreamBufferSize)")
 }
 
 // --- Helpers ---

--- a/internal/service/session_runtime_test.go
+++ b/internal/service/session_runtime_test.go
@@ -464,8 +464,8 @@ func TestGetSessionResponsePreview_Truncation(t *testing.T) {
 	DB = db
 	defer func() { DB = origDB }()
 
-	// 80+ runes — should be truncated to 64 + …
-	longText := strings.Repeat("这是一段测试", 10) + "追加更多文字直到超过六十四个字符的截断限制边界"
+	// 80+ runes — should be truncated to responsePreviewMaxRunes + …
+	longText := strings.Repeat("这是一段测试", 10) + "追加更多文字直到超过截断限制边界"
 	content := model.ContentBlock{Type: "text", Text: longText}
 	blocks := map[string]any{"blocks": []model.ContentBlock{content}}
 	contentJSON, _ := json.Marshal(blocks)
@@ -474,8 +474,8 @@ func TestGetSessionResponsePreview_Truncation(t *testing.T) {
 
 	result := getSessionResponsePreview("session-preview-2")
 	runes := []rune(longText)
-	assert.Equal(t, string(runes[:64])+"…", result)
-	assert.Equal(t, 65, utf8.RuneCountInString(result)) // 64 + ellipsis
+	assert.Equal(t, string(runes[:responsePreviewMaxRunes])+"…", result)
+	assert.Equal(t, responsePreviewMaxRunes+1, utf8.RuneCountInString(result)) // maxRunes + ellipsis
 }
 
 func TestGetSessionResponsePreview_NoAssistantMessage(t *testing.T) {
@@ -568,14 +568,14 @@ func TestGetSessionResponsePreview_NoTextBlocks(t *testing.T) {
 	assert.Equal(t, "", result)
 }
 
-func TestGetSessionResponsePreview_Exact64Runes(t *testing.T) {
+func TestGetSessionResponsePreview_ExactMaxRunes(t *testing.T) {
 	origDB := DB
 	db := setupChatTestDB(t)
 	DB = db
 	defer func() { DB = origDB }()
 
-	// Exactly 64 runes — should NOT be truncated
-	exactText := strings.Repeat("一二三四", 16) // 4*16 = 64 chars
+	// Exactly responsePreviewMaxRunes runes — should NOT be truncated
+	exactText := strings.Repeat("一二三四", responsePreviewMaxRunes/4)
 	content := model.ContentBlock{Type: "text", Text: exactText}
 	blocks := map[string]any{"blocks": []model.ContentBlock{content}}
 	contentJSON, _ := json.Marshal(blocks)
@@ -584,17 +584,17 @@ func TestGetSessionResponsePreview_Exact64Runes(t *testing.T) {
 
 	result := getSessionResponsePreview("session-preview-8")
 	assert.Equal(t, exactText, result)
-	assert.Equal(t, 64, utf8.RuneCountInString(result))
+	assert.Equal(t, responsePreviewMaxRunes, utf8.RuneCountInString(result))
 }
 
-func TestGetSessionResponsePreview_65Runes(t *testing.T) {
+func TestGetSessionResponsePreview_OneOverMaxRunes(t *testing.T) {
 	origDB := DB
 	db := setupChatTestDB(t)
 	DB = db
 	defer func() { DB = origDB }()
 
-	// 65 runes — should be truncated to 64 + …
-	longText := strings.Repeat("一二三四", 16) + "五" // 64+1 = 65 chars
+	// responsePreviewMaxRunes+1 runes — should be truncated to maxRunes + …
+	longText := strings.Repeat("一二三四", responsePreviewMaxRunes/4) + "五"
 	content := model.ContentBlock{Type: "text", Text: longText}
 	blocks := map[string]any{"blocks": []model.ContentBlock{content}}
 	contentJSON, _ := json.Marshal(blocks)
@@ -602,7 +602,7 @@ func TestGetSessionResponsePreview_65Runes(t *testing.T) {
 	insertTestMessage(t, db, "session-preview-9", "assistant", string(contentJSON))
 
 	result := getSessionResponsePreview("session-preview-9")
-	assert.Equal(t, strings.Repeat("一二三四", 16)+"…", result)
+	assert.Equal(t, strings.Repeat("一二三四", responsePreviewMaxRunes/4)+"…", result)
 }
 
 // --- emitSessionEvent with response preview ---

--- a/internal/service/session_runtime_test.go
+++ b/internal/service/session_runtime_test.go
@@ -464,8 +464,8 @@ func TestGetSessionResponsePreview_Truncation(t *testing.T) {
 	DB = db
 	defer func() { DB = origDB }()
 
-	// 80+ runes — should be truncated to responsePreviewMaxRunes + …
-	longText := strings.Repeat("这是一段测试", 10) + "追加更多文字直到超过截断限制边界"
+	// responsePreviewMaxRunes+1 runes — should be truncated
+	longText := strings.Repeat("测", responsePreviewMaxRunes+1)
 	content := model.ContentBlock{Type: "text", Text: longText}
 	blocks := map[string]any{"blocks": []model.ContentBlock{content}}
 	contentJSON, _ := json.Marshal(blocks)

--- a/internal/ws/manager.go
+++ b/internal/ws/manager.go
@@ -12,6 +12,7 @@ import (
 	"github.com/coder/websocket"
 
 	"clawbench/internal/push"
+	"unicode/utf8"
 )
 
 // ClientSubscription tracks a single client's WS connection and push state.
@@ -29,6 +30,11 @@ type ClientSubscription struct {
 // maxSubscriptions limits the number of concurrent WS subscriptions to prevent
 // resource exhaustion. Matches the original SSE limit of 20.
 const maxSubscriptions = 20
+
+// pushAlertMaxRunes is the maximum number of runes used for the JPush alert text.
+// OPPO (the most restrictive vendor channel) limits alert to 50 characters;
+// we use 40 to leave room for the "…" ellipsis and a safety margin.
+const pushAlertMaxRunes = 40
 
 // Manager manages all client subscriptions.
 type Manager struct {
@@ -272,11 +278,17 @@ func (m *Manager) broadcastToSubscription(key string, msg ServerMessage, deliver
 		if msg.Event == "task_update" {
 			alert = "计划任务已完成"
 		}
-		// Use session title as alert text when available (more informative than response preview)
-		if d, ok := msg.Data.(*SessionUpdateData); ok && d.SessionTitle != "" {
-			alert = d.SessionTitle
+		// Use session title as alert text when available (more informative than response preview),
+		// then fall back to response preview. Both are truncated for push channel limits.
+		if d, ok := msg.Data.(*SessionUpdateData); ok {
+			if d.SessionTitle != "" {
+				alert = truncateForPush(d.SessionTitle)
+			} else if d.ResponsePreview != "" {
+				alert = truncateForPush(d.ResponsePreview)
+			}
 		}
-		slog.Info("ws: sending jpush notification", "event", msg.Event, "client_id", key, "reg_id", pushRegID, "title", title)
+		}
+		slog.Info("ws: sending jpush notification", "event", msg.Event, "client_id", key, "reg_id", pushRegID, "title", title, "alert", alert)
 		if err := m.jpush.SendNotification(pushRegID, title, alert, extras); err != nil {
 			slog.Warn("ws: jpush notification failed", "error", err, "client_id", key)
 		}
@@ -347,6 +359,14 @@ func (m *Manager) CleanupStale() {
 
 // eventSeq is an atomic counter to ensure unique event IDs.
 var eventSeq atomic.Int64
+
+// truncateForPush truncates s to pushAlertMaxRunes, appending "…" if truncated.
+func truncateForPush(s string) string {
+	if utf8.RuneCountInString(s) <= pushAlertMaxRunes {
+		return s
+	}
+	return string([]rune(s)[:pushAlertMaxRunes]) + "…"
+}
 
 // GenerateEventID creates a unique event ID.
 // Uses an atomic counter instead of exposing server timestamps.

--- a/internal/ws/manager.go
+++ b/internal/ws/manager.go
@@ -36,6 +36,25 @@ const maxSubscriptions = 20
 // we use 40 to leave room for the "…" ellipsis and a safety margin.
 const pushAlertMaxRunes = 40
 
+// wsWriteTimeout is the maximum time to wait for a WebSocket write to complete.
+const wsWriteTimeout = 5 * time.Second
+
+// disconnectedBufferWindow is the duration after disconnection during which
+// events are still buffered for replay. After this window, events are dropped.
+const disconnectedBufferWindow = 10 * time.Second
+
+// maxBufferedEvents is the maximum number of events retained in the replay
+// buffer for WS reconnection.
+const maxBufferedEvents = 50
+
+// staleNoPushTimeout is the duration after which a disconnected subscription
+// without a push registration ID is cleaned up.
+const staleNoPushTimeout = 120 * time.Second
+
+// staleWithPushTimeout is the duration after which a subscription with a push
+// registration ID but no WS connection is cleaned up.
+const staleWithPushTimeout = 10 * 24 * time.Hour
+
 // Manager manages all client subscriptions.
 type Manager struct {
 	mu            sync.Mutex
@@ -223,7 +242,7 @@ func (m *Manager) broadcastToSubscription(key string, msg ServerMessage, deliver
 			return
 		}
 		writeMu.Lock()
-		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		ctx, cancel := context.WithTimeout(context.Background(), wsWriteTimeout)
 		writeErr := conn.Write(ctx, websocket.MessageText, data)
 		cancel()
 		writeMu.Unlock()
@@ -239,7 +258,7 @@ func (m *Manager) broadcastToSubscription(key string, msg ServerMessage, deliver
 	}
 
 	// Client is disconnected — check buffer window
-	if sub.bufferStart.IsZero() || time.Since(sub.bufferStart) < 10*time.Second {
+	if sub.bufferStart.IsZero() || time.Since(sub.bufferStart) < disconnectedBufferWindow {
 		sub.bufferEvent(msg)
 	}
 
@@ -287,7 +306,6 @@ func (m *Manager) broadcastToSubscription(key string, msg ServerMessage, deliver
 				alert = truncateForPush(d.ResponsePreview)
 			}
 		}
-		}
 		slog.Info("ws: sending jpush notification", "event", msg.Event, "client_id", key, "reg_id", pushRegID, "title", title, "alert", alert)
 		if err := m.jpush.SendNotification(pushRegID, title, alert, extras); err != nil {
 			slog.Warn("ws: jpush notification failed", "error", err, "client_id", key)
@@ -311,17 +329,17 @@ func (s *ClientSubscription) GetBufferedEvents() []ServerMessage {
 	return result
 }
 
-// bufferEvent appends an event to the replay buffer, keeping at most 50 events.
+// bufferEvent appends an event to the replay buffer, keeping at most maxBufferedEvents events.
 func (s *ClientSubscription) bufferEvent(msg ServerMessage) {
 	s.eventBuffer = append(s.eventBuffer, msg)
-	if len(s.eventBuffer) > 50 {
-		s.eventBuffer = s.eventBuffer[len(s.eventBuffer)-50:]
+	if len(s.eventBuffer) > maxBufferedEvents {
+		s.eventBuffer = s.eventBuffer[len(s.eventBuffer)-maxBufferedEvents:]
 	}
 }
 
 // CleanupStale removes stale subscriptions:
-//   - No pushRegID + disconnected for >120 seconds → remove
-//   - Has pushRegID + no WS connection in the last 10 days → remove
+//   - No pushRegID + disconnected for > staleNoPushTimeout → remove
+//   - Has pushRegID + no WS connection in the last staleWithPushTimeout → remove
 //   - Connected subscriptions are never cleaned up.
 func (m *Manager) CleanupStale() {
 	m.mu.Lock()
@@ -340,15 +358,15 @@ func (m *Manager) CleanupStale() {
 			continue
 		}
 		if sub.pushRegID == "" {
-			// No push reg ID — clean up after 120 seconds
-			if time.Since(sub.bufferStart) > 120*time.Second {
+			// No push reg ID — clean up after staleNoPushTimeout
+			if time.Since(sub.bufferStart) > staleNoPushTimeout {
 				delete(m.subscriptions, key)
 				slog.Info("ws: cleaned up stale subscription (no push)", "client_id", key, "disconnected_for", time.Since(sub.bufferStart))
 			}
 		} else {
-			// Has push reg ID — clean up if no WS connection in the last 10 days
+			// Has push reg ID — clean up if no WS connection within staleWithPushTimeout
 			// lastActive is updated on every Subscribe, so it tracks the most recent connection
-			if time.Since(sub.lastActive) > 10*24*time.Hour {
+			if time.Since(sub.lastActive) > staleWithPushTimeout {
 				delete(m.subscriptions, key)
 				slog.Info("ws: cleaned up stale subscription (with push, no connect in 10 days)", "client_id", key, "last_active", sub.lastActive)
 			}

--- a/internal/ws/manager_test.go
+++ b/internal/ws/manager_test.go
@@ -589,8 +589,8 @@ func TestManager_BroadcastEvent_JPushAlert_TruncatesLongTitle(t *testing.T) {
 	mgr.RegisterPushID("reg-123", "client-1")
 	mgr.DisconnectClient("client-1")
 
-	// 80+ rune session title — should be truncated to pushAlertMaxRunes + "…"
-	longTitle := strings.Repeat("这是一段测试", 10) + "追加更多文字"
+	// pushAlertMaxRunes+1 rune title — should be truncated
+	longTitle := strings.Repeat("测", pushAlertMaxRunes+1)
 	msg := ServerMessage{
 		Type:  "event",
 		ID:    "evt_1",

--- a/internal/ws/manager_test.go
+++ b/internal/ws/manager_test.go
@@ -291,12 +291,12 @@ func TestCleanupStale_NoPushRegID(t *testing.T) {
 	mgr.Subscribe(nil, &writeMu, "client-1")
 	mgr.DisconnectClient("client-1")
 
-	// Set bufferStart to 121 seconds ago — should be cleaned up (no pushRegID, >120s)
+	// Set bufferStart to just past staleNoPushTimeout — should be cleaned up (no pushRegID)
 	mgr.mu.Lock()
 	sub := mgr.subscriptions["client-1"]
 	mgr.mu.Unlock()
 	sub.mu.Lock()
-	sub.bufferStart = time.Now().Add(-121 * time.Second)
+	sub.bufferStart = time.Now().Add(-staleNoPushTimeout - time.Second)
 	sub.mu.Unlock()
 
 	mgr.CleanupStale()
@@ -305,7 +305,7 @@ func TestCleanupStale_NoPushRegID(t *testing.T) {
 	_, exists := mgr.subscriptions["client-1"]
 	mgr.mu.Unlock()
 	if exists {
-		t.Error("expected stale subscription (no push) to be cleaned up after 120s")
+		t.Error("expected stale subscription (no push) to be cleaned up after staleNoPushTimeout")
 	}
 }
 
@@ -316,7 +316,7 @@ func TestCleanupStale_NoPushRegID_RecentNotCleaned(t *testing.T) {
 	mgr.Subscribe(nil, &writeMu, "client-1")
 	mgr.DisconnectClient("client-1")
 
-	// Set bufferStart to 60 seconds ago — should NOT be cleaned up (no pushRegID, <120s)
+	// Set bufferStart to well before staleNoPushTimeout — should NOT be cleaned up
 	mgr.mu.Lock()
 	sub := mgr.subscriptions["client-1"]
 	mgr.mu.Unlock()
@@ -330,7 +330,7 @@ func TestCleanupStale_NoPushRegID_RecentNotCleaned(t *testing.T) {
 	_, exists := mgr.subscriptions["client-1"]
 	mgr.mu.Unlock()
 	if !exists {
-		t.Error("expected subscription (no push, <120s) to not be cleaned up")
+		t.Error("expected subscription (no push, before staleNoPushTimeout) to not be cleaned up")
 	}
 }
 
@@ -343,7 +343,7 @@ func TestCleanupStale_WithPushRegID(t *testing.T) {
 	mgr.DisconnectClient("client-1")
 
 	// Set bufferStart to 31 minutes ago, lastActive to 31 minutes ago
-	// Should NOT be cleaned up (has pushRegID, lastActive < 10 days)
+	// Should NOT be cleaned up (has pushRegID, lastActive < staleWithPushTimeout)
 	mgr.mu.Lock()
 	sub := mgr.subscriptions["client-1"]
 	mgr.mu.Unlock()
@@ -358,12 +358,12 @@ func TestCleanupStale_WithPushRegID(t *testing.T) {
 	_, exists := mgr.subscriptions["client-1"]
 	mgr.mu.Unlock()
 	if !exists {
-		t.Error("expected subscription with pushRegID to survive (lastActive < 10 days)")
+		t.Error("expected subscription with pushRegID to survive (lastActive < staleWithPushTimeout)")
 	}
 
-	// Set lastActive to 11 days ago — should be cleaned up (no connection in 10 days)
+	// Set lastActive beyond staleWithPushTimeout — should be cleaned up
 	sub.mu.Lock()
-	sub.lastActive = time.Now().Add(-11 * 24 * time.Hour)
+	sub.lastActive = time.Now().Add(-staleWithPushTimeout - 24*time.Hour)
 	sub.mu.Unlock()
 
 	mgr.CleanupStale()
@@ -372,7 +372,7 @@ func TestCleanupStale_WithPushRegID(t *testing.T) {
 	_, exists = mgr.subscriptions["client-1"]
 	mgr.mu.Unlock()
 	if exists {
-		t.Error("expected subscription with pushRegID to be cleaned up (lastActive > 10 days)")
+		t.Error("expected subscription with pushRegID to be cleaned up (lastActive > staleWithPushTimeout)")
 	}
 }
 

--- a/internal/ws/manager_test.go
+++ b/internal/ws/manager_test.go
@@ -4,9 +4,11 @@ import (
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"sync"
 	"testing"
 	"time"
+	"unicode/utf8"
 
 	"clawbench/internal/push"
 )
@@ -498,17 +500,120 @@ func TestManager_BroadcastEvent_JPushAlert_WithSessionTitle(t *testing.T) {
 			SessionID:      "s1",
 			Status:         "completed",
 			HasNewMessages: true,
-			SessionTitle:   "帮我写一个Go HTTP服务器",
+			SessionTitle:    "帮我写一个Go HTTP服务器",
+			ResponsePreview: "AI回复的预览内容",
 		},
 	}
 	mgr.BroadcastEvent(msg)
 
+	// SessionTitle takes priority over ResponsePreview
 	if receivedAlert != "帮我写一个Go HTTP服务器" {
 		t.Errorf("expected alert to be session title, got %q", receivedAlert)
 	}
 }
 
-func TestManager_BroadcastEvent_JPushAlert_WithoutSessionTitle(t *testing.T) {
+func TestManager_BroadcastEvent_JPushAlert_WithResponsePreview(t *testing.T) {
+	var receivedAlert string
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var payload map[string]any
+		if err := json.NewDecoder(r.Body).Decode(&payload); err == nil {
+			if n, ok := payload["notification"].(map[string]any); ok {
+				if a, ok := n["android"].(map[string]any); ok {
+					receivedAlert, _ = a["alert"].(string)
+				}
+			}
+		}
+		w.WriteHeader(200)
+		w.Write([]byte(`{"sendno":"123","msg_id":"456"}`))
+	}))
+	defer server.Close()
+
+	jpush := push.NewJPushClient(push.JPushConfig{
+		Enabled:      true,
+		AppKey:       "test-key",
+		MasterSecret: "test-secret",
+	})
+	jpush.SetBaseURL(server.URL)
+
+	mgr := newTestManager(jpush)
+	var writeMu sync.Mutex
+	mgr.Subscribe(nil, &writeMu, "client-1")
+	mgr.RegisterPushID("reg-123", "client-1")
+	mgr.DisconnectClient("client-1")
+
+	msg := ServerMessage{
+		Type:  "event",
+		ID:    "evt_1",
+		Event: "session_update",
+		Data: &SessionUpdateData{
+			SessionID:      "s1",
+			Status:         "completed",
+			HasNewMessages: true,
+			ResponsePreview: "AI回复的预览内容",
+		},
+	}
+	mgr.BroadcastEvent(msg)
+
+	// Short preview should pass through unchanged (under pushAlertMaxRunes)
+	if receivedAlert != "AI回复的预览内容" {
+		t.Errorf("expected alert to be response preview, got %q", receivedAlert)
+	}
+}
+
+func TestManager_BroadcastEvent_JPushAlert_TruncatesLongTitle(t *testing.T) {
+	var receivedAlert string
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var payload map[string]any
+		if err := json.NewDecoder(r.Body).Decode(&payload); err == nil {
+			if n, ok := payload["notification"].(map[string]any); ok {
+				if a, ok := n["android"].(map[string]any); ok {
+					receivedAlert, _ = a["alert"].(string)
+				}
+			}
+		}
+		w.WriteHeader(200)
+		w.Write([]byte(`{"sendno":"123","msg_id":"456"}`))
+	}))
+	defer server.Close()
+
+	jpush := push.NewJPushClient(push.JPushConfig{
+		Enabled:      true,
+		AppKey:       "test-key",
+		MasterSecret: "test-secret",
+	})
+	jpush.SetBaseURL(server.URL)
+
+	mgr := newTestManager(jpush)
+	var writeMu sync.Mutex
+	mgr.Subscribe(nil, &writeMu, "client-1")
+	mgr.RegisterPushID("reg-123", "client-1")
+	mgr.DisconnectClient("client-1")
+
+	// 80+ rune session title — should be truncated to pushAlertMaxRunes + "…"
+	longTitle := strings.Repeat("这是一段测试", 10) + "追加更多文字"
+	msg := ServerMessage{
+		Type:  "event",
+		ID:    "evt_1",
+		Event: "session_update",
+		Data: &SessionUpdateData{
+			SessionID:      "s1",
+			Status:         "completed",
+			HasNewMessages: true,
+			SessionTitle:   longTitle,
+		},
+	}
+	mgr.BroadcastEvent(msg)
+
+	expected := string([]rune(longTitle)[:pushAlertMaxRunes]) + "…"
+	if receivedAlert != expected {
+		t.Errorf("expected truncated alert, got %q (want %q)", receivedAlert, expected)
+	}
+	if utf8.RuneCountInString(receivedAlert) != pushAlertMaxRunes+1 {
+		t.Errorf("expected alert of %d runes, got %d", pushAlertMaxRunes+1, utf8.RuneCountInString(receivedAlert))
+	}
+}
+
+func TestManager_BroadcastEvent_JPushAlert_WithoutTitleOrPreview(t *testing.T) {
 	var receivedAlert string
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		var payload map[string]any
@@ -865,5 +970,33 @@ func TestManager_BroadcastEvent_JPushWhenNoWS(t *testing.T) {
 
 	if !pushCalled {
 		t.Error("JPush should be called when no WS is connected")
+	}
+}
+
+func TestTruncateForPush(t *testing.T) {
+	short := "短文本"
+	if got := truncateForPush(short); got != short {
+		t.Errorf("short text should pass through, got %q", got)
+	}
+
+	// Exactly pushAlertMaxRunes — no truncation
+	exact := strings.Repeat("一二", pushAlertMaxRunes/2)
+	if utf8.RuneCountInString(exact) != pushAlertMaxRunes {
+		t.Fatalf("test setup: expected %d runes, got %d", pushAlertMaxRunes, utf8.RuneCountInString(exact))
+	}
+	if got := truncateForPush(exact); got != exact {
+		t.Errorf("exact-length text should not be truncated, got %q", got)
+	}
+
+	// Over pushAlertMaxRunes — truncate + "…"
+	long := strings.Repeat("一二", pushAlertMaxRunes/2) + "三"
+	runes := []rune(long)
+	expected := string(runes[:pushAlertMaxRunes]) + "…"
+	got := truncateForPush(long)
+	if got != expected {
+		t.Errorf("long text should be truncated, got %q (want %q)", got, expected)
+	}
+	if utf8.RuneCountInString(got) != pushAlertMaxRunes+1 {
+		t.Errorf("truncated text should be %d+1 runes, got %d", pushAlertMaxRunes, utf8.RuneCountInString(got))
 	}
 }

--- a/internal/ws/protocol.go
+++ b/internal/ws/protocol.go
@@ -20,8 +20,8 @@ type SessionUpdateData struct {
 	SessionID      string `json:"session_id"`
 	Status         string `json:"status"`                    // "running", "completed", "cancelled"
 	HasNewMessages bool   `json:"has_new_messages"`
-	ResponsePreview string `json:"response_preview,omitempty"` // first 64 runes of AI's final reply (completed only)
-	SessionTitle   string `json:"session_title,omitempty"`   // session title for push notification
+	ResponsePreview string `json:"response_preview,omitempty"` // preview of AI's final reply (completed only)
+	SessionTitle    string `json:"session_title,omitempty"`    // session title for push notification
 }
 
 // TaskUpdateData is the data payload for "task_update" events.


### PR DESCRIPTION
## 问题

PR #32 将 `getSessionResponsePreview` 截断长度从 16 改到 64，但返回的 `ResponsePreview` 被直接用作 JPush 的 alert 字段。JPush 厂商通道对 alert 长度有严格限制（最严格的 OPPO 仅 50 字符），64 字符的 alert 超出限制导致推送投递失败——PR 反而没生效。

## 修复内容

1. **核心修复**：JPush alert 路径新增 `truncateForPush()`，将 ResponsePreview 截断到 `pushAlertMaxRunes=40` 后再发送（OPPO 限制 50，留 10 字符余量）
2. **消除魔鬼数字**：所有硬编码的 16/64/65 替换为命名常量 `responsePreviewMaxRunes`、`pushAlertMaxRunes`
3. **两层长度解耦**：WS 预览可以给足 64 字符（前端无限制），JPush alert 独立控制在 40 字符
4. **日志增强**：JPush 推送日志新增 alert 字段
5. **修正过时注释**：protocol.go 中 `first 16 chars` → `preview of AI's final reply`

## 修改文件

| 文件 | 修改 |
|---|---|
| `internal/service/session_runtime.go` | 魔鬼数字 → `responsePreviewMaxRunes` 常量 |
| `internal/service/session_runtime_test.go` | 测试引用常量，函数名重命名 |
| `internal/ws/manager.go` | 新增 `pushAlertMaxRunes`、`truncateForPush()`，alert 截断 + 日志 |
| `internal/ws/manager_test.go` | 新增长预览截断测试、`TestTruncateForPush` |
| `internal/ws/protocol.go` | 修正过时注释 |