### PR TITLE
perf(android): remove FLAG_KEEP_SCREEN_ON and pause WebView in background

### DIFF
--- a/android/app/src/main/java/com/clawbench/app/BrowserActivity.java
+++ b/android/app/src/main/java/com/clawbench/app/BrowserActivity.java
@@ -216,6 +216,30 @@ public class BrowserActivity extends AppCompatActivity {
     }
 
     @Override
+    protected void onPause() {
+        super.onPause();
+        pauseWebView();
+    }
+
+    @Override
+    protected void onResume() {
+        super.onResume();
+        resumeWebView();
+    }
+
+    /** Pause WebView rendering and JS timers to release CPU/GPU resources. */
+    void pauseWebView() {
+        webView.onPause();
+        webView.pauseTimers();
+    }
+
+    /** Resume WebView rendering and JS timers when returning to foreground. */
+    void resumeWebView() {
+        webView.onResume();
+        webView.resumeTimers();
+    }
+
+    @Override
     public void onBackPressed() {
         if (webView.canGoBack()) {
             webView.goBack();

--- a/android/app/src/main/java/com/clawbench/app/MainActivity.java
+++ b/android/app/src/main/java/com/clawbench/app/MainActivity.java
@@ -186,9 +186,6 @@ public class MainActivity extends AppCompatActivity {
         // Check if launched from notification
         logLaunchIntent(getIntent());
 
-        // Keep screen on while app is in foreground (AI may take time to respond)
-        getWindow().addFlags(WindowManager.LayoutParams.FLAG_KEEP_SCREEN_ON);
-
         // Initialize trust-all SSL for self-signed HTTPS servers (used by BackgroundService)
         BackgroundService.initTrustAllSSL();
 
@@ -639,6 +636,7 @@ public class MainActivity extends AppCompatActivity {
     @Override
     protected void onPause() {
         super.onPause();
+        pauseWebView();
         // App going to background — if JPush is not available, start native WS
         // so we still get notifications when Android kills the WebView process.
         // Check both pushAvailable (SDK ready) and jpushEnabledOnServer (config fetched)
@@ -651,10 +649,23 @@ public class MainActivity extends AppCompatActivity {
     @Override
     protected void onResume() {
         super.onResume();
+        resumeWebView();
         // App returning to foreground — stop native WS (WebView WS handles events)
         BackgroundService.stopNativeEventWs(this);
         // Handle notification tap intent + re-dispatch pending navigation
         handleResumeIntent();
+    }
+
+    /** Pause WebView rendering and JS timers to release CPU/GPU resources. */
+    void pauseWebView() {
+        webView.onPause();
+        webView.pauseTimers();
+    }
+
+    /** Resume WebView rendering and JS timers when returning to foreground. */
+    void resumeWebView() {
+        webView.onResume();
+        webView.resumeTimers();
     }
 
     /**

--- a/android/app/src/test/java/com/clawbench/app/WebViewLifecycleTest.java
+++ b/android/app/src/test/java/com/clawbench/app/WebViewLifecycleTest.java
@@ -1,0 +1,151 @@
+package com.clawbench.app;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.lang.reflect.Constructor;
+import java.lang.reflect.Field;
+import java.lang.reflect.Method;
+
+import static org.mockito.Mockito.*;
+
+/**
+ * Unit tests for BrowserActivity and MainActivity WebView lifecycle methods
+ * (pauseWebView/resumeWebView) that pause/resume WebView to save resources.
+ *
+ * Uses Unsafe.allocateInstance() to create Activities without triggering
+ * AppCompatActivity's constructor. Uses Mockito to mock WebView.
+ * With returnDefaultValues = true, android.jar stubs are no-ops.
+ */
+public class WebViewLifecycleTest {
+
+    private MainActivity mainActivity;
+    private BrowserActivity browserActivity;
+
+    @Before
+    public void setUp() throws Exception {
+        mainActivity = allocate(MainActivity.class);
+        // Set the static instance field
+        Field instanceField = MainActivity.class.getDeclaredField("instance");
+        instanceField.setAccessible(true);
+        instanceField.set(null, mainActivity);
+
+        browserActivity = allocate(BrowserActivity.class);
+    }
+
+    @After
+    public void tearDown() throws Exception {
+        try {
+            Field instanceField = MainActivity.class.getDeclaredField("instance");
+            instanceField.setAccessible(true);
+            instanceField.set(null, null);
+        } catch (Exception ignored) {}
+    }
+
+    // =====================================================
+    // BrowserActivity.pauseWebView / resumeWebView tests
+    // =====================================================
+
+    @Test
+    public void browserActivity_pauseWebView_callsWebViewPauseAndPauseTimers() throws Exception {
+        android.webkit.WebView mockWebView = mock(android.webkit.WebView.class);
+        setField(browserActivity, "webView", mockWebView);
+
+        invokeMethod(browserActivity, "pauseWebView");
+
+        verify(mockWebView).onPause();
+        verify(mockWebView).pauseTimers();
+    }
+
+    @Test
+    public void browserActivity_resumeWebView_callsWebViewResumeAndResumeTimers() throws Exception {
+        android.webkit.WebView mockWebView = mock(android.webkit.WebView.class);
+        setField(browserActivity, "webView", mockWebView);
+
+        invokeMethod(browserActivity, "resumeWebView");
+
+        verify(mockWebView).onResume();
+        verify(mockWebView).resumeTimers();
+    }
+
+    // =====================================================
+    // MainActivity.pauseWebView / resumeWebView tests
+    // =====================================================
+
+    @Test
+    public void mainActivity_pauseWebView_callsWebViewPauseAndPauseTimers() throws Exception {
+        android.webkit.WebView mockWebView = mock(android.webkit.WebView.class);
+        setField(mainActivity, "webView", mockWebView);
+
+        invokeMethod(mainActivity, "pauseWebView");
+
+        verify(mockWebView).onPause();
+        verify(mockWebView).pauseTimers();
+    }
+
+    @Test
+    public void mainActivity_resumeWebView_callsWebViewResumeAndResumeTimers() throws Exception {
+        android.webkit.WebView mockWebView = mock(android.webkit.WebView.class);
+        setField(mainActivity, "webView", mockWebView);
+
+        invokeMethod(mainActivity, "resumeWebView");
+
+        verify(mockWebView).onResume();
+        verify(mockWebView).resumeTimers();
+    }
+
+    // --- Helper methods ---
+
+    @SuppressWarnings("unchecked")
+    private static <T> T allocate(Class<T> clazz) throws Exception {
+        // Try default constructor first (works for most classes with returnDefaultValues=true)
+        try {
+            Constructor<T> ctor = clazz.getDeclaredConstructor();
+            ctor.setAccessible(true);
+            return ctor.newInstance();
+        } catch (Exception e) {
+            // Fallback: Unsafe allocation for classes without no-arg constructors
+            var unsafeField = Class.forName("sun.misc.Unsafe").getDeclaredField("theUnsafe");
+            unsafeField.setAccessible(true);
+            Object unsafe = unsafeField.get(null);
+            Method allocate = unsafe.getClass().getDeclaredMethod("allocateInstance", Class.class);
+            allocate.setAccessible(true);
+            return (T) allocate.invoke(unsafe, clazz);
+        }
+    }
+
+    private static void setField(Object target, String fieldName, Object value) throws Exception {
+        Field field = null;
+        Class<?> clazz = target.getClass();
+        while (clazz != null) {
+            try {
+                field = clazz.getDeclaredField(fieldName);
+                break;
+            } catch (NoSuchFieldException e) {
+                clazz = clazz.getSuperclass();
+            }
+        }
+        if (field == null) throw new NoSuchFieldException(fieldName);
+        field.setAccessible(true);
+        field.set(target, value);
+    }
+
+    private static void invokeMethod(Object target, String methodName) throws Exception {
+        Method method = findMethod(target.getClass(), methodName);
+        method.setAccessible(true);
+        method.invoke(target);
+    }
+
+    private static Method findMethod(Class<?> clazz, String methodName, Class<?>... paramTypes) throws Exception {
+        Class<?> c = clazz;
+        while (c != null) {
+            try {
+                return c.getDeclaredMethod(methodName, paramTypes);
+            } catch (NoSuchMethodException e) {
+                c = c.getSuperclass();
+            }
+        }
+        throw new NoSuchMethodException(methodName);
+    }
+}


### PR DESCRIPTION
## 改动

- **移除 `FLAG_KEEP_SCREEN_ON`**：不再需要屏幕常亮，删掉 `MainActivity.onCreate()` 中的 flag 设置
- **后台暂停 WebView**：在 `MainActivity` 和 `BrowserActivity` 的 `onPause()` 中添加 `webView.onPause()` + `webView.pauseTimers()`，释放 CPU/GPU 资源并停止 JS 定时器
- **前台恢复 WebView**：在 `onResume()` 中对应添加 `webView.onResume()` + `webView.resumeTimers()`

## 动机

配合后台推送通知机制，App 进入后台时由 JPush 或 native WS 接管通知，WebView 不再需要持续运行。暂停 WebView 可显著减少后台 CPU/GPU 占用和耗电。

## 注意

`pauseTimers()` 是进程级全局操作（影响同进程所有 WebView），当前两个 Activity 不会同时前台运行，无冲突。

Closes #20