### PR TITLE
perf: 读写分离 + 覆盖索引 + 批量 git verify — P0/P1/P2 性能优化

### DIFF
--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -454,6 +454,7 @@ func main() {
 		slog.Error("failed to initialize database", slog.String("err", err.Error()))
 		os.Exit(1)
 	}
+	defer service.CloseDB()
 
 	// Initialize RAG history memory system (always enabled)
 	if err := rag.Init(cfg.RAG); err != nil {

--- a/internal/handler/chat.go
+++ b/internal/handler/chat.go
@@ -79,35 +79,29 @@ func AIChat(w http.ResponseWriter, r *http.Request) {
 				writeLocalizedErrorf(w, r, http.StatusNotFound, "SessionNotFound")
 				return
 			}
-		} else {
-			// No specific session requested, get the most recent session across all backends
-			allSessions, err := service.GetSessions(projectPath, "")
-			if err != nil {
-				model.WriteError(w, model.Internal(fmt.Errorf("failed to load sessions")))
+	} else {
+		// No specific session requested — use lightweight query to find the most recent session
+		latestID, latestBackend, err := service.GetLatestSessionID(projectPath)
+		if err != nil {
+			// No sessions exist, create a new one with default agent.
+			// Don't pre-fill agent default model — leave empty so frontend
+			// falls back to global localStorage preference (cross-project).
+			agentID := model.GetDefaultAgentID()
+			sessionBackend2, _, _, _, ok := resolveAgentConfig(agentID)
+			if !ok {
+				writeLocalizedErrorf(w, r, http.StatusServiceUnavailable, "NoAgentsAvailable")
 				return
 			}
-
-			if len(allSessions) == 0 {
-				// No sessions exist, create a new one with default agent.
-				// Don't pre-fill agent default model — leave empty so frontend
-				// falls back to global localStorage preference (cross-project).
-				agentID := model.GetDefaultAgentID()
-				sessionBackend2, _, _, _, ok := resolveAgentConfig(agentID)
-				if !ok {
-					writeLocalizedErrorf(w, r, http.StatusServiceUnavailable, "NoAgentsAvailable")
-					return
-				}
-				sessionID, err = service.CreateSession(projectPath, sessionBackend2, T(r, "NewSession"), agentID, "", "default", "chat")
-				if err != nil {
-					model.WriteError(w, model.Internal(fmt.Errorf("failed to create session")))
-					return
-				}
-			} else {
-				// Use the most recent session (already sorted by updated_at DESC)
-				sessionID = allSessions[0].ID
-				sessionBackend = allSessions[0].Backend
+			sessionID, err = service.CreateSession(projectPath, sessionBackend2, T(r, "NewSession"), agentID, "", "default", "chat")
+			if err != nil {
+				model.WriteError(w, model.Internal(fmt.Errorf("failed to create session")))
+				return
 			}
+		} else {
+			sessionID = latestID
+			sessionBackend = latestBackend
 		}
+	}
 
 		// Always update cookie with current session ID
 		setSessionID(w, sessionID)

--- a/internal/handler/chat.go
+++ b/internal/handler/chat.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"database/sql"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"log/slog"
 	"net/http"
@@ -84,7 +85,7 @@ func AIChat(w http.ResponseWriter, r *http.Request) {
 		// No specific session requested — use lightweight query to find the most recent session
 		latestID, latestBackend, err := service.GetLatestSessionID(projectPath)
 		if err != nil {
-			if err != sql.ErrNoRows {
+			if !errors.Is(err, sql.ErrNoRows) {
 				model.WriteError(w, model.Internal(fmt.Errorf("failed to find latest session")))
 				return
 			}
@@ -114,6 +115,8 @@ func AIChat(w http.ResponseWriter, r *http.Request) {
 		service.UpdateLastRead(sessionID)
 
 		// Parse pagination params
+		// Supports both before_id (preferred, integer cursor) and before (legacy, timestamp cursor).
+		// before_id takes priority when both are provided.
 		limit := 0
 		beforeID := 0
 		if limitStr := r.URL.Query().Get("limit"); limitStr != "" {
@@ -124,6 +127,15 @@ func AIChat(w http.ResponseWriter, r *http.Request) {
 		if bid := r.URL.Query().Get("before_id"); bid != "" {
 			if id, err := strconv.Atoi(bid); err == nil && id > 0 {
 				beforeID = id
+			}
+		}
+		// Legacy: accept "before" (timestamp) for backward compatibility with older clients.
+		// When before_id is absent and before is present, fall back to timestamp-based lookup.
+		if beforeID == 0 {
+			if bt := r.URL.Query().Get("before"); bt != "" {
+				if id, err := service.GetMessageIDBeforeTime(projectPath, sessionBackend, sessionID, bt); err == nil && id > 0 {
+					beforeID = id
+				}
 			}
 		}
 

--- a/internal/handler/chat.go
+++ b/internal/handler/chat.go
@@ -115,14 +115,16 @@ func AIChat(w http.ResponseWriter, r *http.Request) {
 
 		// Parse pagination params
 		limit := 0
-		beforeTime := ""
+		beforeID := 0
 		if limitStr := r.URL.Query().Get("limit"); limitStr != "" {
 			if l, err := strconv.Atoi(limitStr); err == nil && l > 0 {
 				limit = l
 			}
 		}
-		if bt := r.URL.Query().Get("before"); bt != "" {
-			beforeTime = bt
+		if bid := r.URL.Query().Get("before_id"); bid != "" {
+			if id, err := strconv.Atoi(bid); err == nil && id > 0 {
+				beforeID = id
+			}
 		}
 
 		// If limit not specified, use config default
@@ -135,7 +137,7 @@ func AIChat(w http.ResponseWriter, r *http.Request) {
 		}
 
 		totalCount := service.GetChatMessageCount(sessionID)
-		messages, err := service.GetChatHistoryPaged(projectPath, sessionBackend, sessionID, limit, beforeTime)
+		messages, err := service.GetChatHistoryPaged(projectPath, sessionBackend, sessionID, limit, beforeID)
 		// Get session metadata in a single query
 		sessionInfo, _ := service.GetSessionInfo(sessionID)
 		var sessionTitle, sessionAgentID, sessionModelID, sessionThinkingEffort string

--- a/internal/handler/chat.go
+++ b/internal/handler/chat.go
@@ -131,11 +131,20 @@ func AIChat(w http.ResponseWriter, r *http.Request) {
 
 		totalCount := service.GetChatMessageCount(sessionID)
 		messages, err := service.GetChatHistoryPaged(projectPath, sessionBackend, sessionID, limit, beforeTime)
-		// Get session title and agent info
-		sessionTitle, _ := service.GetSessionTitle(sessionID)
-		sessionAgentID := service.GetSessionAgentID(sessionID)
-		sessionModelID := service.GetSessionModel(sessionID)
-		sessionThinkingEffort := service.GetSessionThinkingEffort(sessionID)
+		// Get session metadata in a single query
+		sessionInfo, _ := service.GetSessionInfo(sessionID)
+		var sessionTitle, sessionAgentID, sessionModelID, sessionThinkingEffort string
+		var sessionInfoBackend string
+		if sessionInfo != nil {
+			sessionTitle = sessionInfo.Title
+			sessionInfoBackend = sessionInfo.Backend
+			sessionAgentID = sessionInfo.AgentID
+			sessionModelID = sessionInfo.Model
+			sessionThinkingEffort = sessionInfo.ThinkingEffort
+		}
+		if sessionInfoBackend != "" {
+			sessionBackend = sessionInfoBackend
+		}
 		running := service.IsSessionRunning(sessionID)
 		if err != nil {
 			writeJSON(w, http.StatusOK, map[string]any{"messages": []any{}, "running": running, "sessionId": sessionID, "sessionTitle": sessionTitle, "backend": sessionBackend, "agentId": sessionAgentID, "modelId": sessionModelID, "thinkingEffort": sessionThinkingEffort, "total": totalCount})

--- a/internal/handler/chat.go
+++ b/internal/handler/chat.go
@@ -2,6 +2,7 @@ package handler
 
 import (
 	"context"
+	"database/sql"
 	"encoding/json"
 	"fmt"
 	"log/slog"
@@ -83,6 +84,10 @@ func AIChat(w http.ResponseWriter, r *http.Request) {
 		// No specific session requested — use lightweight query to find the most recent session
 		latestID, latestBackend, err := service.GetLatestSessionID(projectPath)
 		if err != nil {
+			if err != sql.ErrNoRows {
+				model.WriteError(w, model.Internal(fmt.Errorf("failed to find latest session")))
+				return
+			}
 			// No sessions exist, create a new one with default agent.
 			// Don't pre-fill agent default model — leave empty so frontend
 			// falls back to global localStorage preference (cross-project).

--- a/internal/handler/chat_test.go
+++ b/internal/handler/chat_test.go
@@ -2328,3 +2328,144 @@ func TestAIChat_Get_NoSessionID_UsesLatestSession(t *testing.T) {
 	// Verify s1 is NOT returned (proves it's using latest, not first)
 	assert.NotEqual(t, s1, resp["sessionId"])
 }
+
+// TestAIChat_Get_NoSessionID_NoSessionsCreatesNew verifies that when AIChat GET
+// is called without a session_id and no sessions exist, a new session is created.
+func TestAIChat_Get_NoSessionID_NoSessionsCreatesNew(t *testing.T) {
+	env, teardown := setupTestEnv(t)
+	defer teardown()
+
+	// No sessions exist — GET without session_id should auto-create one
+	req := newRequest(t, http.MethodGet, "/api/ai/chat?limit=20", nil)
+	withProjectCookie(req, env.ProjectDir)
+	withAuthCookie(req, "")
+
+	w := callHandlerWithAuth(AIChat, req)
+	assert.Equal(t, http.StatusOK, w.Code)
+
+	var resp map[string]interface{}
+	json.Unmarshal(w.Body.Bytes(), &resp)
+	assert.NotNil(t, resp["sessionId"], "should auto-create a session when none exist")
+	assert.NotEmpty(t, resp["sessionId"])
+}
+
+// TestAIChat_Get_WithSessionID_ReturnsSessionInfo verifies that when AIChat GET
+// is called with a specific session_id, the sessionInfo fields (title, backend,
+// agentId, modelId, thinkingEffort) are populated from the single GetSessionInfo query.
+func TestAIChat_Get_WithSessionID_ReturnsSessionInfo(t *testing.T) {
+	env, teardown := setupTestEnv(t)
+	defer teardown()
+
+	// Create a session with specific agent and model
+	sessionID, err := service.CreateSession(env.ProjectDir, "codebuddy", "My Test Session", "codebuddy", "glm-5.1", "default", "chat")
+	assert.NoError(t, err)
+
+	req := newRequest(t, http.MethodGet, "/api/ai/chat?session_id="+sessionID+"&limit=20", nil)
+	withProjectCookie(req, env.ProjectDir)
+	withAuthCookie(req, "")
+
+	w := callHandlerWithAuth(AIChat, req)
+	assert.Equal(t, http.StatusOK, w.Code)
+
+	var resp map[string]interface{}
+	json.Unmarshal(w.Body.Bytes(), &resp)
+	assert.Equal(t, sessionID, resp["sessionId"])
+	assert.Equal(t, "My Test Session", resp["sessionTitle"])
+	assert.Equal(t, "codebuddy", resp["backend"])
+	assert.Equal(t, "codebuddy", resp["agentId"])
+}
+
+// TestAIChat_Get_SessionInfoBackendOverride verifies that when GetSessionInfo
+// returns a backend that differs from the one initially resolved (e.g., from
+// GetSessionBackend or GetLatestSessionID), the sessionInfo backend takes priority.
+func TestAIChat_Get_SessionInfoBackendOverride(t *testing.T) {
+	env, teardown := setupTestEnv(t)
+	defer teardown()
+
+	// Create a session with backend "claude"
+	sessionID, err := service.CreateSession(env.ProjectDir, "claude", "Backend Test", "claude", "", "default", "chat")
+	assert.NoError(t, err)
+
+	// Add a message so the session has history
+	_, err = service.AddChatMessage(env.ProjectDir, "claude", sessionID, "user", "hello", nil, false, "NewSession")
+	assert.NoError(t, err)
+
+	// Request with session_id — GetSessionBackend returns "claude",
+	// GetSessionInfo should also return "claude", and the response should reflect it
+	req := newRequest(t, http.MethodGet, "/api/ai/chat?session_id="+sessionID+"&limit=20", nil)
+	withProjectCookie(req, env.ProjectDir)
+	withAuthCookie(req, "")
+
+	w := callHandlerWithAuth(AIChat, req)
+	assert.Equal(t, http.StatusOK, w.Code)
+
+	var resp map[string]interface{}
+	json.Unmarshal(w.Body.Bytes(), &resp)
+	assert.Equal(t, "claude", resp["backend"])
+}
+
+// TestAIChat_Get_NoSessionID_SessionInfoFieldsPopulated verifies that the
+// GetLatestSessionID + GetSessionInfo path (no session_id in request) still
+// populates all sessionInfo fields correctly.
+func TestAIChat_Get_NoSessionID_SessionInfoFieldsPopulated(t *testing.T) {
+	env, teardown := setupTestEnv(t)
+	defer teardown()
+
+	// Create a session
+	sessionID, err := service.CreateSession(env.ProjectDir, "codebuddy", "Info Session", "codebuddy", "", "default", "chat")
+	assert.NoError(t, err)
+	// Set model explicitly
+	service.UpdateSessionModel(sessionID, "glm-5.1")
+
+	// GET without session_id — should find this session via GetLatestSessionID
+	req := newRequest(t, http.MethodGet, "/api/ai/chat?limit=20", nil)
+	withProjectCookie(req, env.ProjectDir)
+	withAuthCookie(req, "")
+
+	w := callHandlerWithAuth(AIChat, req)
+	assert.Equal(t, http.StatusOK, w.Code)
+
+	var resp map[string]interface{}
+	json.Unmarshal(w.Body.Bytes(), &resp)
+	assert.Equal(t, sessionID, resp["sessionId"])
+	assert.Equal(t, "Info Session", resp["sessionTitle"])
+	assert.Equal(t, "codebuddy", resp["backend"])
+	assert.Equal(t, "codebuddy", resp["agentId"])
+	assert.Equal(t, "glm-5.1", resp["modelId"])
+}
+
+// TestAIChat_Get_NoSessionID_NoAgentsAvailable verifies that when no sessions
+// exist and no agents are available, the handler returns NoAgentsAvailable error.
+func TestAIChat_Get_NoSessionID_NoAgentsAvailable(t *testing.T) {
+	env, teardown := setupTestEnv(t)
+	defer teardown()
+
+	// Remove all agents so resolveAgentConfig fails
+	model.Agents = map[string]*model.Agent{}
+	model.AgentList = []*model.Agent{}
+
+	req := newRequest(t, http.MethodGet, "/api/ai/chat?limit=20", nil)
+	withProjectCookie(req, env.ProjectDir)
+	withAuthCookie(req, "")
+
+	w := callHandlerWithAuth(AIChat, req)
+	assert.Equal(t, http.StatusServiceUnavailable, w.Code)
+}
+
+// TestAIChat_Get_NoSessionID_CreateSessionError verifies that when no sessions
+// exist and CreateSession fails (e.g., DB closed), the handler returns
+// an internal error.
+func TestAIChat_Get_NoSessionID_CreateSessionError(t *testing.T) {
+	env, teardown := setupTestEnv(t)
+	defer teardown()
+
+	// Close the DB to force CreateSession to fail
+	service.DB.Close()
+
+	req := newRequest(t, http.MethodGet, "/api/ai/chat?limit=20", nil)
+	withProjectCookie(req, env.ProjectDir)
+	withAuthCookie(req, "")
+
+	w := callHandlerWithAuth(AIChat, req)
+	assert.Equal(t, http.StatusInternalServerError, w.Code)
+}

--- a/internal/handler/chat_test.go
+++ b/internal/handler/chat_test.go
@@ -2293,3 +2293,38 @@ func TestServeSessions_Post_NewSessionEmptyModel(t *testing.T) {
 	assert.Equal(t, "", modelID,
 		"newly created session should have empty model field for global preference resolution")
 }
+
+// ============================================================================
+// AIChat GET — no session_id path (GetLatestSessionID)
+// ============================================================================
+
+// TestAIChat_Get_NoSessionID_UsesLatestSession verifies that when AIChat GET
+// is called without a session_id, the handler uses GetLatestSessionID to find
+// the most recent session instead of loading all sessions via GetSessions.
+func TestAIChat_Get_NoSessionID_UsesLatestSession(t *testing.T) {
+	env, teardown := setupTestEnv(t)
+	defer teardown()
+
+	// Create two sessions. Directly set s2's updated_at to be newer than s1's
+	// (both sessions created in the same second would have identical timestamps,
+	// making the tie-breaker depend on UUID sort order which is non-deterministic).
+	s1, _ := service.CreateSession(env.ProjectDir, "claude", "First", "claude", "", "default", "chat")
+	s2, _ := service.CreateSession(env.ProjectDir, "codebuddy", "Second", "codebuddy", "", "default", "chat")
+	// Force s2 to be more recent by setting its updated_at 1 second ahead
+	service.DB.Exec("UPDATE chat_sessions SET updated_at = datetime(updated_at, '+1 second') WHERE id = ?", s2)
+
+	// GET without session_id should use the latest session
+	req := newRequest(t, http.MethodGet, "/api/ai/chat?limit=20", nil)
+	withProjectCookie(req, env.ProjectDir)
+	withAuthCookie(req, "")
+
+	w := callHandlerWithAuth(AIChat, req)
+	assert.Equal(t, http.StatusOK, w.Code)
+
+	var resp map[string]interface{}
+	json.Unmarshal(w.Body.Bytes(), &resp)
+	assert.Equal(t, s2, resp["sessionId"])
+
+	// Verify s1 is NOT returned (proves it's using latest, not first)
+	assert.NotEqual(t, s1, resp["sessionId"])
+}

--- a/internal/handler/chat_test.go
+++ b/internal/handler/chat_test.go
@@ -2457,10 +2457,11 @@ func TestAIChat_Get_NoSessionID_NoAgentsAvailable(t *testing.T) {
 // an internal error.
 func TestAIChat_Get_NoSessionID_CreateSessionError(t *testing.T) {
 	env, teardown := setupTestEnv(t)
-	defer teardown()
 
-	// Close the DB to force CreateSession to fail
-	service.DB.Close()
+	// Close the DB to force errors. Both DB and DBRead point to the same
+	// :memory: instance, so closing either closes both. After closing,
+	// queries will return errors rather than panic (nil dereference).
+	service.CloseDB()
 
 	req := newRequest(t, http.MethodGet, "/api/ai/chat?limit=20", nil)
 	withProjectCookie(req, env.ProjectDir)
@@ -2468,4 +2469,10 @@ func TestAIChat_Get_NoSessionID_CreateSessionError(t *testing.T) {
 
 	w := callHandlerWithAuth(AIChat, req)
 	assert.Equal(t, http.StatusInternalServerError, w.Code)
+
+	// Prevent teardown from double-closing the already-closed db.
+	// Restore globals so teardown's db.Close() becomes a safe no-op on
+	// the original (pre-setupTestEnv) values.
+	_ = env
+	teardown()
 }

--- a/internal/handler/git.go
+++ b/internal/handler/git.go
@@ -799,32 +799,34 @@ func ServeGitVerifyCommits(w http.ResponseWriter, r *http.Request) {
 	}
 
 	results := make(map[string]interface{}, len(body.SHAs))
+
+	// Batch: use git log --no-walk=sorted to fetch all commit info in one command
+	// --ignore-missing skips invalid SHAs instead of erroring out
+	logArgs := []string{
+		"log", "--no-walk=sorted", "--ignore-missing",
+		"--format=%H|%P|%s|%ad|%an%d",
+		"--date=iso",
+	}
+	logArgs = append(logArgs, body.SHAs...)
+
+	logCmd := exec.Command("git", logArgs...)
+	logCmd.Dir = projectPath
+	logOutput, _ := logCmd.Output()
+
+	// Parse git log output — only valid commits appear
+	foundSHAs := map[string]bool{}
+	if len(logOutput) > 0 {
+		commits := parseGitLog(string(logOutput))
+		for _, c := range commits {
+			results[c.SHA] = c
+			foundSHAs[c.SHA] = true
+		}
+	}
+
+	// For SHAs not found in git log, mark as nil (not a valid commit)
 	for _, sha := range body.SHAs {
-		cmd := exec.Command("git", "cat-file", "-t", sha)
-		cmd.Dir = projectPath
-		output, err := cmd.Output()
-		if err != nil {
+		if !foundSHAs[sha] {
 			results[sha] = nil
-		} else {
-			objType := strings.TrimSpace(string(output))
-			if objType == "commit" {
-				// Fetch commit info for breadcrumb display
-				logCmd := exec.Command("git", "log", "-1", "--format=%H|%P|%s|%ad|%an%d", "--date=iso", sha)
-				logCmd.Dir = projectPath
-				logOutput, logErr := logCmd.Output()
-				if logErr == nil && len(logOutput) > 0 {
-					parsed := parseGitLog(string(logOutput))
-					if len(parsed) > 0 {
-						results[sha] = parsed[0]
-					} else {
-						results[sha] = sha // fallback
-					}
-				} else {
-					results[sha] = sha // fallback
-				}
-			} else {
-				results[sha] = nil
-			}
 		}
 	}
 

--- a/internal/handler/git.go
+++ b/internal/handler/git.go
@@ -798,6 +798,13 @@ func ServeGitVerifyCommits(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	// Cap SHA count to prevent exceeding OS ARG_MAX (~2MB on Linux).
+	// 500 SHAs × 40 chars each ≈ 20KB — well within safe limits.
+	const maxSHAs = 500
+	if len(body.SHAs) > maxSHAs {
+		body.SHAs = body.SHAs[:maxSHAs]
+	}
+
 	results := make(map[string]interface{}, len(body.SHAs))
 
 	// Batch: use git log --no-walk=sorted to fetch all commit info in one command
@@ -815,13 +822,24 @@ func ServeGitVerifyCommits(w http.ResponseWriter, r *http.Request) {
 
 	// Parse git log output — only valid commits appear
 	// Map full SHA → requested SHA for key normalization (frontend may send abbreviated SHAs)
+	// Build a prefix lookup map from requested SHAs for O(1) matching instead of O(N×M) scan.
+	reqSHAMap := make(map[string]string, len(body.SHAs)) // prefix→original
+	for _, sha := range body.SHAs {
+		// Index by the minimum unique prefix length (at least 7 chars for abbreviated SHAs)
+		prefixLen := len(sha)
+		if prefixLen > 40 {
+			prefixLen = 40
+		}
+		reqSHAMap[sha[:prefixLen]] = sha
+	}
+
 	fullToRequested := map[string]string{}
 	if len(logOutput) > 0 {
 		commits := parseGitLog(string(logOutput))
 		for _, c := range commits {
-			// Find which requested SHA matches this full SHA (by prefix)
-			for _, reqSHA := range body.SHAs {
-				if strings.HasPrefix(c.SHA, reqSHA) {
+			// Find which requested SHA matches this full SHA (by prefix lookup)
+			for prefixLen := 7; prefixLen <= len(c.SHA); prefixLen++ {
+				if reqSHA, ok := reqSHAMap[c.SHA[:prefixLen]]; ok {
 					fullToRequested[c.SHA] = reqSHA
 					break
 				}

--- a/internal/handler/git.go
+++ b/internal/handler/git.go
@@ -814,18 +814,37 @@ func ServeGitVerifyCommits(w http.ResponseWriter, r *http.Request) {
 	logOutput, _ := logCmd.Output()
 
 	// Parse git log output — only valid commits appear
-	foundSHAs := map[string]bool{}
+	// Map full SHA → requested SHA for key normalization (frontend may send abbreviated SHAs)
+	fullToRequested := map[string]string{}
 	if len(logOutput) > 0 {
 		commits := parseGitLog(string(logOutput))
 		for _, c := range commits {
+			// Find which requested SHA matches this full SHA (by prefix)
+			for _, reqSHA := range body.SHAs {
+				if strings.HasPrefix(c.SHA, reqSHA) {
+					fullToRequested[c.SHA] = reqSHA
+					break
+				}
+			}
+			// Store under both full SHA and (if matched) requested SHA
 			results[c.SHA] = c
-			foundSHAs[c.SHA] = true
 		}
 	}
 
-	// For SHAs not found in git log, mark as nil (not a valid commit)
+	// Re-key results under the original requested SHAs and mark unmatched as nil
 	for _, sha := range body.SHAs {
-		if !foundSHAs[sha] {
+		matched := false
+		for fullSHA, reqSHA := range fullToRequested {
+			if reqSHA == sha {
+				if fullSHA != sha {
+					results[sha] = results[fullSHA]
+					delete(results, fullSHA)
+				}
+				matched = true
+				break
+			}
+		}
+		if !matched {
 			results[sha] = nil
 		}
 	}

--- a/internal/handler/git_test.go
+++ b/internal/handler/git_test.go
@@ -694,6 +694,81 @@ func TestServeGitWorkingTreeFiles_NoChanges(t *testing.T) {
 	assert.Equal(t, false, resp["hasUncommitted"])
 }
 
+// --- ServeGitVerifyCommits ---
+
+func TestServeGitVerifyCommits_SingleCommit(t *testing.T) {
+	env, teardown := setupTestEnv(t)
+	defer teardown()
+
+	initGitRepo(t, env.ProjectDir)
+	sha := getHeadSHA(t, env.ProjectDir)
+
+	req := newRequest(t, http.MethodPost, "/api/git/verify-commits", map[string]interface{}{
+		"shas": []string{sha},
+	})
+	withProjectCookie(req, env.ProjectDir)
+
+	w := callHandler(ServeGitVerifyCommits, req)
+	assertOK(t, w)
+
+	var resp map[string]interface{}
+	json.Unmarshal(w.Body.Bytes(), &resp)
+	results, ok := resp["results"].(map[string]interface{})
+	assert.True(t, ok)
+	info, ok := results[sha].(map[string]interface{})
+	assert.True(t, ok, "SHA should be a valid commit")
+	assert.Equal(t, sha, info["sha"])
+	assert.Equal(t, "initial commit", info["msg"])
+}
+
+func TestServeGitVerifyCommits_MultipleCommits(t *testing.T) {
+	env, teardown := setupTestEnv(t)
+	defer teardown()
+
+	initGitRepo(t, env.ProjectDir)
+	sha1 := getHeadSHA(t, env.ProjectDir)
+
+	createTestFile(t, env.ProjectDir, "newfile.txt", "hello")
+	gitCommitAll(t, env.ProjectDir, "add newfile")
+	sha2 := getHeadSHA(t, env.ProjectDir)
+
+	req := newRequest(t, http.MethodPost, "/api/git/verify-commits", map[string]interface{}{
+		"shas": []string{sha1, sha2},
+	})
+	withProjectCookie(req, env.ProjectDir)
+
+	w := callHandler(ServeGitVerifyCommits, req)
+	assertOK(t, w)
+
+	var resp map[string]interface{}
+	json.Unmarshal(w.Body.Bytes(), &resp)
+	results := resp["results"].(map[string]interface{})
+	assert.NotNil(t, results[sha1])
+	assert.NotNil(t, results[sha2])
+}
+
+func TestServeGitVerifyCommits_MixedValidInvalid(t *testing.T) {
+	env, teardown := setupTestEnv(t)
+	defer teardown()
+
+	initGitRepo(t, env.ProjectDir)
+	sha := getHeadSHA(t, env.ProjectDir)
+
+	req := newRequest(t, http.MethodPost, "/api/git/verify-commits", map[string]interface{}{
+		"shas": []string{sha, "0000000000000000000000000000000000000000"},
+	})
+	withProjectCookie(req, env.ProjectDir)
+
+	w := callHandler(ServeGitVerifyCommits, req)
+	assertOK(t, w)
+
+	var resp map[string]interface{}
+	json.Unmarshal(w.Body.Bytes(), &resp)
+	results := resp["results"].(map[string]interface{})
+	assert.NotNil(t, results[sha])
+	assert.Nil(t, results["0000000000000000000000000000000000000000"])
+}
+
 // --- validateFilePath ---
 
 func TestValidateFilePath_ValidRelative(t *testing.T) {

--- a/internal/handler/git_test.go
+++ b/internal/handler/git_test.go
@@ -769,6 +769,31 @@ func TestServeGitVerifyCommits_MixedValidInvalid(t *testing.T) {
 	assert.Nil(t, results["0000000000000000000000000000000000000000"])
 }
 
+func TestServeGitVerifyCommits_AbbreviatedSHA(t *testing.T) {
+	env, teardown := setupTestEnv(t)
+	defer teardown()
+
+	initGitRepo(t, env.ProjectDir)
+	sha := getHeadSHA(t, env.ProjectDir)
+	abbrevSHA := sha[:7] // Frontend may send abbreviated SHAs
+
+	req := newRequest(t, http.MethodPost, "/api/git/verify-commits", map[string]interface{}{
+		"shas": []string{abbrevSHA},
+	})
+	withProjectCookie(req, env.ProjectDir)
+
+	w := callHandler(ServeGitVerifyCommits, req)
+	assertOK(t, w)
+
+	var resp map[string]interface{}
+	json.Unmarshal(w.Body.Bytes(), &resp)
+	results := resp["results"].(map[string]interface{})
+	// Result should be keyed by the requested abbreviated SHA, not the full SHA
+	info, ok := results[abbrevSHA].(map[string]interface{})
+	assert.True(t, ok, "abbreviated SHA should resolve to a valid commit")
+	assert.Equal(t, sha, info["sha"])
+}
+
 // --- validateFilePath ---
 
 func TestValidateFilePath_ValidRelative(t *testing.T) {

--- a/internal/handler/scheduler.go
+++ b/internal/handler/scheduler.go
@@ -34,8 +34,14 @@ func ServeTasks(w http.ResponseWriter, r *http.Request) {
 		for i := range tasks {
 			tasks[i].RunningCount = runningCounts[tasks[i].ID]
 		}
-		// Check if any task has unread executions
-		hasUnread, _ := service.HasUnreadTasks(projectPath)
+		// Derive hasUnread from already-fetched tasks (avoid redundant DB query)
+		hasUnread := false
+		for _, t := range tasks {
+			if t.UnreadCount > 0 {
+				hasUnread = true
+				break
+			}
+		}
 		writeJSON(w, http.StatusOK, map[string]any{"tasks": tasks, "hasUnread": hasUnread})
 
 	case http.MethodPost:

--- a/internal/handler/scheduler_agent_test.go
+++ b/internal/handler/scheduler_agent_test.go
@@ -1247,3 +1247,88 @@ func createTestSession(t *testing.T, projectPath string) string {
 	})
 	return id
 }
+
+// ---------- hasUnread logic (derived from tasks.UnreadCount) ----------
+
+// TestServeTasks_Get_HasUnreadTrue verifies that hasUnread is true when at
+// least one task has UnreadCount > 0.
+func TestServeTasks_Get_HasUnreadTrue(t *testing.T) {
+	env, teardown := setupTestEnv(t)
+	defer teardown()
+
+	model.Agents = map[string]*model.Agent{
+		"coder": {ID: "coder", Name: "Coder", Backend: "claude"},
+	}
+	defer func() { model.Agents = nil }()
+
+	s := service.NewScheduler()
+	defer s.Stop()
+	service.GlobalScheduler = s
+	defer func() { service.GlobalScheduler = nil }()
+
+	// Create a task
+	task := &model.ScheduledTask{
+		ProjectPath: env.ProjectDir,
+		Name:        "Unread Task",
+		CronExpr:    "0 * * * *",
+		AgentID:     "coder",
+		Prompt:      "Test",
+		RepeatMode:  "unlimited",
+	}
+	err := s.AddTask(task)
+	assert.NoError(t, err)
+
+	// Create a completed execution (not read) → makes UnreadCount = 1
+	sessionID, err := service.CreateSession(env.ProjectDir, "claude", "Exec", "coder", "", "default", "scheduled")
+	assert.NoError(t, err)
+	_, err = service.AddTaskExecution(task.ID, sessionID, "auto")
+	assert.NoError(t, err)
+	service.UpdateExecutionStatus(sessionID, "completed")
+
+	req := newRequest(t, http.MethodGet, "/api/tasks", nil)
+	req = withProjectCookie(req, env.ProjectDir)
+	w := callHandler(ServeTasks, req)
+
+	assertOK(t, w)
+	var result map[string]any
+	json.Unmarshal(w.Body.Bytes(), &result)
+	assert.Equal(t, true, result["hasUnread"], "hasUnread should be true when a task has unread executions")
+}
+
+// TestServeTasks_Get_HasUnreadFalse verifies that hasUnread is false when
+// all tasks have UnreadCount == 0.
+func TestServeTasks_Get_HasUnreadFalse(t *testing.T) {
+	env, teardown := setupTestEnv(t)
+	defer teardown()
+
+	model.Agents = map[string]*model.Agent{
+		"coder": {ID: "coder", Name: "Coder", Backend: "claude"},
+	}
+	defer func() { model.Agents = nil }()
+
+	s := service.NewScheduler()
+	defer s.Stop()
+	service.GlobalScheduler = s
+	defer func() { service.GlobalScheduler = nil }()
+
+	// Create a task with no executions → UnreadCount = 0
+	task := &model.ScheduledTask{
+		ProjectPath: env.ProjectDir,
+		Name:        "Read Task",
+		CronExpr:    "0 * * * *",
+		AgentID:     "coder",
+		Prompt:      "Test",
+		RepeatMode:  "unlimited",
+	}
+	err := s.AddTask(task)
+	assert.NoError(t, err)
+
+	req := newRequest(t, http.MethodGet, "/api/tasks", nil)
+	req = withProjectCookie(req, env.ProjectDir)
+	w := callHandler(ServeTasks, req)
+
+	assertOK(t, w)
+	var result map[string]any
+	json.Unmarshal(w.Body.Bytes(), &result)
+	assert.Equal(t, false, result["hasUnread"], "hasUnread should be false when no tasks have unread executions")
+}

--- a/internal/handler/testutil_test.go
+++ b/internal/handler/testutil_test.go
@@ -87,6 +87,7 @@ func setupTestEnv(t *testing.T) (*testEnv, func()) {
 			model TEXT DEFAULT '',
 			session_type TEXT NOT NULL DEFAULT 'chat',
 			external_session_id TEXT DEFAULT '',
+			thinking_effort TEXT DEFAULT '',
 			deleted INTEGER NOT NULL DEFAULT 0,
 			created_at DATETIME DEFAULT CURRENT_TIMESTAMP,
 			updated_at DATETIME DEFAULT CURRENT_TIMESTAMP,

--- a/internal/handler/testutil_test.go
+++ b/internal/handler/testutil_test.go
@@ -45,6 +45,7 @@ func setupTestEnv(t *testing.T) (*testEnv, func()) {
 	origToken := model.SessionToken
 	origWatch := model.WatchDir
 	origDB := service.DB
+	origDBRead := service.DBRead
 	origAgents := model.Agents
 	origAgentList := model.AgentList
 
@@ -167,6 +168,7 @@ func setupTestEnv(t *testing.T) (*testEnv, func()) {
 	}
 
 	service.DB = db
+	service.DBRead = db // Same instance for :memory: SQLite — data is shared
 
 	// Register mock agents so GetDefaultAgentID() works
 	model.Agents = map[string]*model.Agent{
@@ -189,6 +191,7 @@ func setupTestEnv(t *testing.T) (*testEnv, func()) {
 		model.Agents = origAgents
 		model.AgentList = origAgentList
 		service.DB = origDB
+		service.DBRead = origDBRead
 		db.Close()
 	}
 

--- a/internal/rag/cleanup_test.go
+++ b/internal/rag/cleanup_test.go
@@ -64,9 +64,12 @@ func setupCleanupDB(t *testing.T) *sql.DB {
 	assert.NoError(t, err)
 
 	origDB := service.DB
+	origDBRead := service.DBRead
 	service.DB = db
+	service.DBRead = db // Same instance for :memory: SQLite — data is shared
 	t.Cleanup(func() {
 		service.DB = origDB
+		service.DBRead = origDBRead
 		db.Close()
 	})
 	return db

--- a/internal/rag/indexer_test.go
+++ b/internal/rag/indexer_test.go
@@ -64,9 +64,12 @@ func setupIndexerDB(t *testing.T) *sql.DB {
 	require.NoError(t, err)
 
 	origDB := service.DB
+	origDBRead := service.DBRead
 	service.DB = db
+	service.DBRead = db // Same instance for :memory: SQLite — data is shared
 	t.Cleanup(func() {
 		service.DB = origDB
+		service.DBRead = origDBRead
 		db.Close()
 	})
 	return db

--- a/internal/rag/search_test.go
+++ b/internal/rag/search_test.go
@@ -60,9 +60,12 @@ func setupSearchDB(t *testing.T) *sql.DB {
 	require.NoError(t, err)
 
 	origDB := service.DB
+	origDBRead := service.DBRead
 	service.DB = db
+	service.DBRead = db // Same instance for :memory: SQLite — data is shared
 	t.Cleanup(func() {
 		service.DB = origDB
+		service.DBRead = origDBRead
 		db.Close()
 	})
 	return db

--- a/internal/service/chat.go
+++ b/internal/service/chat.go
@@ -11,27 +11,25 @@ import (
 
 // GetChatHistory retrieves all chat messages for a given project path, backend, and session.
 func GetChatHistory(projectPath, backend, sessionID string) ([]model.ChatMessage, error) {
-	return GetChatHistoryPaged(projectPath, backend, sessionID, 0, "")
+	return GetChatHistoryPaged(projectPath, backend, sessionID, 0, 0)
 }
 
 // GetChatHistoryPaged retrieves chat messages with pagination.
 // limit=0 means no limit (all messages).
-// beforeTime: if non-empty, only return messages created before this timestamp (cursor-based for lazy load).
-// When beforeTime is empty and limit > 0, returns the most recent (limit) messages.
+// beforeID: if > 0, only return messages with id < beforeID (cursor-based for lazy load).
+// When beforeID == 0 and limit > 0, returns the most recent (limit) messages.
 // Returns messages in chronological (ASC) order.
-func GetChatHistoryPaged(projectPath, backend, sessionID string, limit int, beforeTime string) ([]model.ChatMessage, error) {
+func GetChatHistoryPaged(projectPath, backend, sessionID string, limit int, beforeID int) ([]model.ChatMessage, error) {
 	messages := []model.ChatMessage{}
 
-	if limit > 0 && beforeTime != "" {
-		// Cursor-based: load messages older than beforeTime
-		// id is AUTOINCREMENT so ORDER BY id gives deterministic chronological order
-		// (unlike created_at which has only second-precision and can tie).
+	if limit > 0 && beforeID > 0 {
+		// Cursor-based: load messages older than beforeID
 		query := `SELECT id, role, content, files, backend, streaming, created_at, indexed FROM (
 			SELECT id, role, content, files, backend, streaming, created_at, indexed FROM chat_history
-			WHERE project_path = ? AND session_id = ? AND created_at < ? AND deleted = 0
+			WHERE project_path = ? AND session_id = ? AND id < ? AND deleted = 0
 			ORDER BY id DESC LIMIT ?
 		) sub ORDER BY id ASC`
-		rows, err := DBRead.Query(query, projectPath, sessionID, beforeTime, limit)
+		rows, err := DBRead.Query(query, projectPath, sessionID, beforeID, limit)
 		if err != nil {
 			return messages, err
 		}

--- a/internal/service/chat.go
+++ b/internal/service/chat.go
@@ -397,6 +397,24 @@ func GetLatestSessionID(projectPath string) (sessionID, backend string, err erro
 	return
 }
 
+// GetMessageIDBeforeTime resolves a legacy "before" (created_at timestamp) cursor
+// to the corresponding message ID. This provides backward compatibility for older
+// clients that still send ?before=<timestamp> instead of ?before_id=<id>.
+// Returns the max ID of messages created before the given timestamp, or 0 if none found.
+func GetMessageIDBeforeTime(projectPath, backend, sessionID, beforeTime string) (int, error) {
+	var id sql.NullInt64
+	err := DBRead.QueryRow(
+		`SELECT MAX(id) FROM chat_history
+		 WHERE project_path = ? AND backend = ? AND session_id = ?
+		 AND created_at < ? AND deleted = 0`,
+		projectPath, backend, sessionID, beforeTime,
+	).Scan(&id)
+	if err != nil {
+		return 0, err
+	}
+	return int(id.Int64), nil
+}
+
 // GetSessionModel returns the model ID of a session, or empty string if not found or deleted.
 func GetSessionModel(sessionID string) string {
 	var modelID string

--- a/internal/service/chat.go
+++ b/internal/service/chat.go
@@ -385,6 +385,18 @@ func GetSessionProjectPath(sessionID string) string {
 	return projectPath
 }
 
+// GetLatestSessionID returns the ID and backend of the most recently updated chat session
+// for a project. Returns sql.ErrNoRows if no sessions exist.
+func GetLatestSessionID(projectPath string) (sessionID, backend string, err error) {
+	err = DBRead.QueryRow(
+		`SELECT id, backend FROM chat_sessions
+		 WHERE project_path = ? AND deleted = 0 AND session_type = 'chat'
+		 ORDER BY updated_at DESC, id DESC LIMIT 1`,
+		projectPath,
+	).Scan(&sessionID, &backend)
+	return
+}
+
 // GetSessionModel returns the model ID of a session, or empty string if not found or deleted.
 func GetSessionModel(sessionID string) string {
 	var modelID string

--- a/internal/service/chat.go
+++ b/internal/service/chat.go
@@ -29,7 +29,7 @@ func GetChatHistoryPaged(projectPath, backend, sessionID string, limit int, befo
 			WHERE project_path = ? AND session_id = ? AND created_at < ? AND deleted = 0
 			ORDER BY created_at DESC LIMIT ?
 		) sub ORDER BY created_at ASC`
-		rows, err := DB.Query(query, projectPath, sessionID, beforeTime, limit)
+		rows, err := DBRead.Query(query, projectPath, sessionID, beforeTime, limit)
 		if err != nil {
 			return messages, err
 		}
@@ -44,7 +44,7 @@ func GetChatHistoryPaged(projectPath, backend, sessionID string, limit int, befo
 			WHERE project_path = ? AND session_id = ? AND deleted = 0
 			ORDER BY created_at DESC LIMIT ?
 		) sub ORDER BY created_at ASC`
-		rows, err := DB.Query(query, projectPath, sessionID, limit)
+		rows, err := DBRead.Query(query, projectPath, sessionID, limit)
 		if err != nil {
 			return messages, err
 		}
@@ -54,7 +54,7 @@ func GetChatHistoryPaged(projectPath, backend, sessionID string, limit int, befo
 
 	// No limit: return all messages in chronological order
 	query := `SELECT id, role, content, files, backend, streaming, created_at, indexed FROM chat_history WHERE project_path = ? AND session_id = ? AND deleted = 0 ORDER BY created_at ASC`
-	rows, err := DB.Query(query, projectPath, sessionID)
+	rows, err := DBRead.Query(query, projectPath, sessionID)
 	if err != nil {
 		return messages, err
 	}
@@ -87,7 +87,7 @@ func scanMessages(rows *sql.Rows, sessionID string) ([]model.ChatMessage, error)
 // GetChatMessageCount returns the number of messages in a session.
 func GetChatMessageCount(sessionID string) int {
 	var count int
-	DB.QueryRow("SELECT COUNT(*) FROM chat_history WHERE session_id = ? AND deleted = 0", sessionID).Scan(&count)
+	DBRead.QueryRow("SELECT COUNT(*) FROM chat_history WHERE session_id = ? AND deleted = 0", sessionID).Scan(&count)
 	return count
 }
 
@@ -99,7 +99,7 @@ func GetMessageByID(id int64) (*model.ChatMessage, error) {
 	var streaming int
 	var indexed int
 
-	err := DB.QueryRow(
+	err := DBRead.QueryRow(
 		"SELECT id, role, content, files, backend, streaming, created_at, indexed, session_id, project_path FROM chat_history WHERE id = ?",
 		id,
 	).Scan(&msg.ID, &msg.Role, &msg.Content, &filesJSON, &msg.Backend, &streaming, &msg.CreatedAt, &indexed, &msg.SessionID, &msg.ProjectPath)
@@ -118,7 +118,7 @@ func GetMessageByID(id int64) (*model.ChatMessage, error) {
 // Unlike GetChatHistory, this does not require projectPath or backend — session_id is globally unique.
 // Returns messages in chronological order with all content blocks (text, thinking, tool_use).
 func GetMessagesBySessionID(sessionID string) ([]model.ChatMessage, error) {
-	rows, err := DB.Query(
+	rows, err := DBRead.Query(
 		"SELECT id, role, content, files, backend, streaming, created_at, indexed FROM chat_history WHERE session_id = ? AND streaming = 0 ORDER BY created_at ASC",
 		sessionID,
 	)
@@ -202,7 +202,7 @@ func AddChatMessage(projectPath, backend, sessionID, role, content string, files
 // GetRecentProjects returns the most recent 10 project paths.
 func GetRecentProjects() ([]string, error) {
 	var paths []string
-	rows, err := DB.Query("SELECT project_path FROM recent_projects ORDER BY accessed_at DESC LIMIT 10")
+	rows, err := DBRead.Query("SELECT project_path FROM recent_projects ORDER BY accessed_at DESC LIMIT 10")
 	if err != nil {
 		return nil, err
 	}
@@ -268,7 +268,7 @@ func GetSessions(projectPath, backend string) ([]model.ChatSession, error) {
 	}
 	query += " ORDER BY s.updated_at DESC, s.id DESC"
 
-	rows, err := DB.Query(query, args...)
+	rows, err := DBRead.Query(query, args...)
 	if err != nil {
 		return sessions, err
 	}
@@ -328,7 +328,7 @@ func GetSessionsPaged(projectPath, backend string, limit int, cursor string, cur
 	query += " ORDER BY s.updated_at DESC, s.id DESC LIMIT ?"
 	args = append(args, limit+1)
 
-	rows, err := DB.Query(query, args...)
+	rows, err := DBRead.Query(query, args...)
 	if err != nil {
 		return nil, false, err
 	}
@@ -366,7 +366,7 @@ func UpdateLastRead(sessionID string) {
 // GetSessionBackend returns the backend of a session, or empty string if not found or deleted.
 func GetSessionBackend(sessionID string) string {
 	var backend string
-	err := DB.QueryRow("SELECT backend FROM chat_sessions WHERE id = ? AND deleted = 0", sessionID).Scan(&backend)
+	err := DBRead.QueryRow("SELECT backend FROM chat_sessions WHERE id = ? AND deleted = 0", sessionID).Scan(&backend)
 	if err != nil {
 		return ""
 	}
@@ -376,7 +376,7 @@ func GetSessionBackend(sessionID string) string {
 // GetSessionProjectPath returns the project path of a session, or empty string if not found.
 func GetSessionProjectPath(sessionID string) string {
 	var projectPath string
-	err := DB.QueryRow("SELECT project_path FROM chat_sessions WHERE id = ?", sessionID).Scan(&projectPath)
+	err := DBRead.QueryRow("SELECT project_path FROM chat_sessions WHERE id = ?", sessionID).Scan(&projectPath)
 	if err != nil {
 		return ""
 	}
@@ -386,7 +386,7 @@ func GetSessionProjectPath(sessionID string) string {
 // GetSessionModel returns the model ID of a session, or empty string if not found or deleted.
 func GetSessionModel(sessionID string) string {
 	var modelID string
-	err := DB.QueryRow("SELECT model FROM chat_sessions WHERE id = ? AND deleted = 0", sessionID).Scan(&modelID)
+	err := DBRead.QueryRow("SELECT model FROM chat_sessions WHERE id = ? AND deleted = 0", sessionID).Scan(&modelID)
 	if err != nil {
 		return ""
 	}
@@ -404,7 +404,7 @@ func UpdateSessionModel(sessionID, modelID string) error {
 // GetSessionThinkingEffort returns the thinking effort level for a session, or empty string if not set.
 func GetSessionThinkingEffort(sessionID string) string {
 	var effort string
-	err := DB.QueryRow("SELECT thinking_effort FROM chat_sessions WHERE id = ? AND deleted = 0", sessionID).Scan(&effort)
+	err := DBRead.QueryRow("SELECT thinking_effort FROM chat_sessions WHERE id = ? AND deleted = 0", sessionID).Scan(&effort)
 	if err != nil {
 		return ""
 	}
@@ -422,7 +422,7 @@ func UpdateSessionThinkingEffort(sessionID, effort string) error {
 // preference exists (caller should fall back to agent defaults).
 // Used by scheduled tasks to respect the user's global model preference.
 func GetLatestUserModel(agentID, projectPath string) (modelID, thinkingEffort string) {
-	err := DB.QueryRow(
+	err := DBRead.QueryRow(
 		"SELECT model, thinking_effort FROM chat_sessions WHERE agent_id = ? AND project_path = ? AND deleted = 0 AND model != '' ORDER BY updated_at DESC LIMIT 1",
 		agentID, projectPath,
 	).Scan(&modelID, &thinkingEffort)
@@ -471,14 +471,14 @@ func DeleteSession(projectPath, backend, sessionID string) error {
 // Only counts sessions with session_type='chat' (excludes scheduled sessions).
 func GetSessionCount(projectPath string) (int, error) {
 	var count int
-	err := DB.QueryRow("SELECT COUNT(*) FROM chat_sessions WHERE project_path = ? AND deleted = 0 AND session_type = 'chat'", projectPath).Scan(&count)
+	err := DBRead.QueryRow("SELECT COUNT(*) FROM chat_sessions WHERE project_path = ? AND deleted = 0 AND session_type = 'chat'", projectPath).Scan(&count)
 	return count, err
 }
 
 // GetSessionTitle returns the title of an active (non-deleted) session.
 func GetSessionTitle(sessionID string) (string, error) {
 	var title string
-	err := DB.QueryRow("SELECT title FROM chat_sessions WHERE id = ? AND deleted = 0", sessionID).Scan(&title)
+	err := DBRead.QueryRow("SELECT title FROM chat_sessions WHERE id = ? AND deleted = 0", sessionID).Scan(&title)
 	if err != nil {
 		return "", err
 	}
@@ -501,7 +501,7 @@ func GetSessionTitlesBatch(sessionIDs []string) (map[string]string, error) {
 		args[i] = id
 	}
 
-	rows, err := DB.Query("SELECT id, title FROM chat_sessions WHERE id IN ("+placeholders+") AND deleted = 0", args...)
+	rows, err := DBRead.Query("SELECT id, title FROM chat_sessions WHERE id IN ("+placeholders+") AND deleted = 0", args...)
 	if err != nil {
 		return nil, err
 	}
@@ -523,7 +523,7 @@ func GetSessionTitlesBatch(sessionIDs []string) (map[string]string, error) {
 // GetSessionAgentID returns the agent_id of an active (non-deleted) session.
 func GetSessionAgentID(sessionID string) string {
 	var agentID string
-	DB.QueryRow("SELECT agent_id FROM chat_sessions WHERE id = ? AND deleted = 0", sessionID).Scan(&agentID)
+	DBRead.QueryRow("SELECT agent_id FROM chat_sessions WHERE id = ? AND deleted = 0", sessionID).Scan(&agentID)
 	return agentID
 }
 
@@ -536,7 +536,7 @@ func SessionHasAssistant(sessionID string) bool {
 // Used to determine when to re-inject the system prompt for CLI backends without --system-prompt.
 func GetAssistantMessageCount(sessionID string) int {
 	var count int
-	DB.QueryRow("SELECT COUNT(*) FROM chat_history WHERE session_id = ? AND role = 'assistant' AND streaming = 0 AND deleted = 0", sessionID).Scan(&count)
+	DBRead.QueryRow("SELECT COUNT(*) FROM chat_history WHERE session_id = ? AND role = 'assistant' AND streaming = 0 AND deleted = 0", sessionID).Scan(&count)
 	return count
 }
 
@@ -563,7 +563,7 @@ func FinalizeStreamingMessage(projectPath, backend, sessionID, content string) e
 // Returns 0 if not found.
 func GetStreamingMessageID(sessionID string) int64 {
 	var id int64
-	err := DB.QueryRow(
+	err := DBRead.QueryRow(
 		"SELECT id FROM chat_history WHERE session_id = ? AND role = 'assistant' AND streaming = 0 ORDER BY id DESC LIMIT 1",
 		sessionID,
 	).Scan(&id)
@@ -598,7 +598,7 @@ func UpdateExternalSessionID(sessionID, externalID string) error {
 // GetExternalSessionID returns the external session ID for a ClawBench session.
 func GetExternalSessionID(sessionID string) string {
 	var externalID string
-	err := DB.QueryRow("SELECT external_session_id FROM chat_sessions WHERE id = ?", sessionID).Scan(&externalID)
+	err := DBRead.QueryRow("SELECT external_session_id FROM chat_sessions WHERE id = ?", sessionID).Scan(&externalID)
 	if err != nil {
 		return ""
 	}
@@ -619,7 +619,7 @@ type UnindexedMessage struct {
 // GetUnindexedMessages fetches chat messages that have not been indexed by RAG.
 // Returns up to limit messages ordered by creation time DESC (newest first).
 func GetUnindexedMessages(limit int) ([]UnindexedMessage, error) {
-	rows, err := DB.Query(
+	rows, err := DBRead.Query(
 		"SELECT id, content, role, session_id, project_path, backend, created_at FROM chat_history WHERE indexed = 0 AND streaming = 0 ORDER BY created_at DESC LIMIT ?",
 		limit,
 	)
@@ -648,14 +648,14 @@ func MarkMessageIndexed(messageID int64) error {
 // UnindexedCount returns the number of messages waiting to be indexed by RAG.
 func UnindexedCount() (int, error) {
 	var count int
-	err := DB.QueryRow("SELECT COUNT(*) FROM chat_history WHERE indexed = 0 AND streaming = 0").Scan(&count)
+	err := DBRead.QueryRow("SELECT COUNT(*) FROM chat_history WHERE indexed = 0 AND streaming = 0").Scan(&count)
 	return count, err
 }
 
 // GetExpiredDeletedSessions returns session IDs of soft-deleted sessions
 // whose updated_at (set to deletion time) is older than the cutoff.
 func GetExpiredDeletedSessions(cutoff time.Time) ([]string, error) {
-	rows, err := DB.Query("SELECT id FROM chat_sessions WHERE deleted = 1 AND updated_at < ?", cutoff)
+	rows, err := DBRead.Query("SELECT id FROM chat_sessions WHERE deleted = 1 AND updated_at < ?", cutoff)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/service/chat.go
+++ b/internal/service/chat.go
@@ -27,8 +27,8 @@ func GetChatHistoryPaged(projectPath, backend, sessionID string, limit int, befo
 		query := `SELECT id, role, content, files, backend, streaming, created_at, indexed FROM (
 			SELECT id, role, content, files, backend, streaming, created_at, indexed FROM chat_history
 			WHERE project_path = ? AND session_id = ? AND created_at < ? AND deleted = 0
-			ORDER BY created_at DESC LIMIT ?
-		) sub ORDER BY created_at ASC`
+			ORDER BY created_at DESC, id DESC LIMIT ?
+		) sub ORDER BY created_at ASC, id ASC`
 		rows, err := DBRead.Query(query, projectPath, sessionID, beforeTime, limit)
 		if err != nil {
 			return messages, err
@@ -42,8 +42,8 @@ func GetChatHistoryPaged(projectPath, backend, sessionID string, limit int, befo
 		query := `SELECT id, role, content, files, backend, streaming, created_at, indexed FROM (
 			SELECT id, role, content, files, backend, streaming, created_at, indexed FROM chat_history
 			WHERE project_path = ? AND session_id = ? AND deleted = 0
-			ORDER BY created_at DESC LIMIT ?
-		) sub ORDER BY created_at ASC`
+			ORDER BY created_at DESC, id DESC LIMIT ?
+		) sub ORDER BY created_at ASC, id ASC`
 		rows, err := DBRead.Query(query, projectPath, sessionID, limit)
 		if err != nil {
 			return messages, err
@@ -53,7 +53,7 @@ func GetChatHistoryPaged(projectPath, backend, sessionID string, limit int, befo
 	}
 
 	// No limit: return all messages in chronological order
-	query := `SELECT id, role, content, files, backend, streaming, created_at, indexed FROM chat_history WHERE project_path = ? AND session_id = ? AND deleted = 0 ORDER BY created_at ASC`
+	query := `SELECT id, role, content, files, backend, streaming, created_at, indexed FROM chat_history WHERE project_path = ? AND session_id = ? AND deleted = 0 ORDER BY created_at ASC, id ASC`
 	rows, err := DBRead.Query(query, projectPath, sessionID)
 	if err != nil {
 		return messages, err
@@ -119,7 +119,7 @@ func GetMessageByID(id int64) (*model.ChatMessage, error) {
 // Returns messages in chronological order with all content blocks (text, thinking, tool_use).
 func GetMessagesBySessionID(sessionID string) ([]model.ChatMessage, error) {
 	rows, err := DBRead.Query(
-		"SELECT id, role, content, files, backend, streaming, created_at, indexed FROM chat_history WHERE session_id = ? AND streaming = 0 ORDER BY created_at ASC",
+		"SELECT id, role, content, files, backend, streaming, created_at, indexed FROM chat_history WHERE session_id = ? AND streaming = 0 ORDER BY created_at ASC, id ASC",
 		sessionID,
 	)
 	if err != nil {

--- a/internal/service/chat.go
+++ b/internal/service/chat.go
@@ -24,11 +24,13 @@ func GetChatHistoryPaged(projectPath, backend, sessionID string, limit int, befo
 
 	if limit > 0 && beforeTime != "" {
 		// Cursor-based: load messages older than beforeTime
+		// id is AUTOINCREMENT so ORDER BY id gives deterministic chronological order
+		// (unlike created_at which has only second-precision and can tie).
 		query := `SELECT id, role, content, files, backend, streaming, created_at, indexed FROM (
 			SELECT id, role, content, files, backend, streaming, created_at, indexed FROM chat_history
 			WHERE project_path = ? AND session_id = ? AND created_at < ? AND deleted = 0
-			ORDER BY created_at DESC, id DESC LIMIT ?
-		) sub ORDER BY created_at ASC, id ASC`
+			ORDER BY id DESC LIMIT ?
+		) sub ORDER BY id ASC`
 		rows, err := DBRead.Query(query, projectPath, sessionID, beforeTime, limit)
 		if err != nil {
 			return messages, err
@@ -42,8 +44,8 @@ func GetChatHistoryPaged(projectPath, backend, sessionID string, limit int, befo
 		query := `SELECT id, role, content, files, backend, streaming, created_at, indexed FROM (
 			SELECT id, role, content, files, backend, streaming, created_at, indexed FROM chat_history
 			WHERE project_path = ? AND session_id = ? AND deleted = 0
-			ORDER BY created_at DESC, id DESC LIMIT ?
-		) sub ORDER BY created_at ASC, id ASC`
+			ORDER BY id DESC LIMIT ?
+		) sub ORDER BY id ASC`
 		rows, err := DBRead.Query(query, projectPath, sessionID, limit)
 		if err != nil {
 			return messages, err
@@ -53,7 +55,7 @@ func GetChatHistoryPaged(projectPath, backend, sessionID string, limit int, befo
 	}
 
 	// No limit: return all messages in chronological order
-	query := `SELECT id, role, content, files, backend, streaming, created_at, indexed FROM chat_history WHERE project_path = ? AND session_id = ? AND deleted = 0 ORDER BY created_at ASC, id ASC`
+	query := `SELECT id, role, content, files, backend, streaming, created_at, indexed FROM chat_history WHERE project_path = ? AND session_id = ? AND deleted = 0 ORDER BY id ASC`
 	rows, err := DBRead.Query(query, projectPath, sessionID)
 	if err != nil {
 		return messages, err
@@ -119,7 +121,7 @@ func GetMessageByID(id int64) (*model.ChatMessage, error) {
 // Returns messages in chronological order with all content blocks (text, thinking, tool_use).
 func GetMessagesBySessionID(sessionID string) ([]model.ChatMessage, error) {
 	rows, err := DBRead.Query(
-		"SELECT id, role, content, files, backend, streaming, created_at, indexed FROM chat_history WHERE session_id = ? AND streaming = 0 ORDER BY created_at ASC, id ASC",
+		"SELECT id, role, content, files, backend, streaming, created_at, indexed FROM chat_history WHERE session_id = ? AND streaming = 0 ORDER BY id ASC",
 		sessionID,
 	)
 	if err != nil {

--- a/internal/service/chat.go
+++ b/internal/service/chat.go
@@ -534,6 +534,30 @@ func GetSessionTitlesBatch(sessionIDs []string) (map[string]string, error) {
 	return titles, rows.Err()
 }
 
+// SessionInfo contains session metadata for the chat view.
+type SessionInfo struct {
+	Title          string
+	Backend        string
+	AgentID        string
+	Model          string
+	ThinkingEffort string
+}
+
+// GetSessionInfo fetches session metadata (title, backend, agent_id, model, thinking_effort)
+// in a single query instead of 5 separate queries.
+func GetSessionInfo(sessionID string) (*SessionInfo, error) {
+	info := &SessionInfo{}
+	err := DBRead.QueryRow(
+		`SELECT title, backend, agent_id, model, thinking_effort
+		 FROM chat_sessions WHERE id = ? AND deleted = 0`,
+		sessionID,
+	).Scan(&info.Title, &info.Backend, &info.AgentID, &info.Model, &info.ThinkingEffort)
+	if err != nil {
+		return nil, err
+	}
+	return info, nil
+}
+
 // GetSessionAgentID returns the agent_id of an active (non-deleted) session.
 func GetSessionAgentID(sessionID string) string {
 	var agentID string

--- a/internal/service/chat.go
+++ b/internal/service/chat.go
@@ -256,12 +256,13 @@ func GetSessions(projectPath, backend string) ([]model.ChatSession, error) {
 			SELECT h.session_id, COUNT(*) AS cnt
 			FROM chat_history h
 			JOIN chat_sessions s2 ON s2.id = h.session_id
-			WHERE h.role = 'assistant' AND h.streaming = 0 AND h.deleted = 0
+			WHERE h.project_path = ?
+			  AND h.role = 'assistant' AND h.streaming = 0 AND h.deleted = 0
 			  AND (s2.last_read_at IS NULL OR h.created_at > s2.last_read_at)
 			GROUP BY h.session_id
 		) unread ON unread.session_id = s.id
 		WHERE s.project_path = ? AND s.deleted = 0 AND s.session_type = 'chat'`
-	args := []interface{}{projectPath}
+	args := []interface{}{projectPath, projectPath}
 	if backend != "" {
 		query += " AND s.backend = ?"
 		args = append(args, backend)
@@ -311,12 +312,13 @@ func GetSessionsPaged(projectPath, backend string, limit int, cursor string, cur
 			SELECT h.session_id, COUNT(*) AS cnt
 			FROM chat_history h
 			JOIN chat_sessions s2 ON s2.id = h.session_id
-			WHERE h.role = 'assistant' AND h.streaming = 0 AND h.deleted = 0
+			WHERE h.project_path = ?
+			  AND h.role = 'assistant' AND h.streaming = 0 AND h.deleted = 0
 			  AND (s2.last_read_at IS NULL OR h.created_at > s2.last_read_at)
 			GROUP BY h.session_id
 		) unread ON unread.session_id = s.id
 		WHERE s.project_path = ? AND s.deleted = 0 AND s.session_type = 'chat'`
-	args := []interface{}{projectPath}
+	args := []interface{}{projectPath, projectPath}
 	if backend != "" {
 		query += " AND s.backend = ?"
 		args = append(args, backend)

--- a/internal/service/chat_test.go
+++ b/internal/service/chat_test.go
@@ -105,7 +105,9 @@ func setupDB(t *testing.T) *sql.DB {
 	assert.NoError(t, err)
 
 	service.DB = db
+	service.DBRead = db // Same instance for :memory: SQLite — data is shared
 	t.Cleanup(func() {
+		service.DBRead = nil
 		db.Close()
 	})
 	return db
@@ -1993,6 +1995,13 @@ func TestGetSessionsPaged_UnreadCount(t *testing.T) {
 	assert.Len(t, sessions, 1)
 	assert.Equal(t, 1, sessions[0].UnreadCount)
 	assert.False(t, hasMore)
+}
+
+// ---------- DBRead initialization ----------
+
+func TestDBRead_Initialized_ChatDB(t *testing.T) {
+	_ = setupDB(t)
+	assert.NotNil(t, service.DBRead, "DBRead should be initialized in test setup")
 }
 
 // ---------- GetRunningSessionIDs ----------

--- a/internal/service/chat_test.go
+++ b/internal/service/chat_test.go
@@ -2096,6 +2096,54 @@ func TestGetRunningSessionIDs_SomeRunning(t *testing.T) {
 	service.SetSessionRunning("sess-2", false)
 }
 
+// ---------- GetLatestSessionID ----------
+
+func TestGetLatestSessionID(t *testing.T) {
+	_ = setupDB(t)
+
+	// No sessions yet
+	_, _, err := service.GetLatestSessionID("/project")
+	assert.Error(t, err)
+
+	// Create a session
+	s1, _ := service.CreateSession("/project", "claude", "First", "claude", "", "default", "chat")
+
+	// Should return it
+	id, backend, err := service.GetLatestSessionID("/project")
+	assert.NoError(t, err)
+	assert.Equal(t, s1, id)
+	assert.Equal(t, "claude", backend)
+
+	// Create another with more recent timestamp
+	s2, _ := service.CreateSession("/project", "codebuddy", "Second", "codebuddy", "", "default", "chat")
+
+	// Should return the newer one
+	id, backend, err = service.GetLatestSessionID("/project")
+	assert.NoError(t, err)
+	assert.Equal(t, s2, id)
+	assert.Equal(t, "codebuddy", backend)
+
+	// Different project should return error
+	_, _, err = service.GetLatestSessionID("/other-project")
+	assert.Error(t, err)
+}
+
+func TestGetLatestSessionID_ExcludesDeleted(t *testing.T) {
+	_ = setupDB(t)
+
+	s1, _ := service.CreateSession("/project", "claude", "First", "claude", "", "default", "chat")
+	s2, _ := service.CreateSession("/project", "codebuddy", "Second", "codebuddy", "", "default", "chat")
+
+	// Delete the most recent session
+	service.DeleteSession("/project", "codebuddy", s2)
+
+	// Should return the remaining session
+	id, backend, err := service.GetLatestSessionID("/project")
+	assert.NoError(t, err)
+	assert.Equal(t, s1, id)
+	assert.Equal(t, "claude", backend)
+}
+
 func TestGetRunningSessionIDs_AfterClearAll(t *testing.T) {
 	setupDB(t)
 

--- a/internal/service/chat_test.go
+++ b/internal/service/chat_test.go
@@ -2147,8 +2147,9 @@ func TestGetLatestSessionID(t *testing.T) {
 	assert.Equal(t, s1, id)
 	assert.Equal(t, "claude", backend)
 
-	// Create another with more recent timestamp
+	// Create another and force its updated_at ahead (SQLite timestamps have second precision)
 	s2, _ := service.CreateSession("/project", "codebuddy", "Second", "codebuddy", "", "default", "chat")
+	service.DB.Exec("UPDATE chat_sessions SET updated_at = datetime('now', '+1 second') WHERE id = ?", s2)
 
 	// Should return the newer one
 	id, backend, err = service.GetLatestSessionID("/project")

--- a/internal/service/chat_test.go
+++ b/internal/service/chat_test.go
@@ -924,6 +924,30 @@ func TestGetChatHistory_SameSecondOrdering(t *testing.T) {
 	assert.Equal(t, "assistant", msgs[1].Role, "assistant message must come second")
 }
 
+func TestGetMessageIDBeforeTime(t *testing.T) {
+	setupDB(t)
+
+	sid := helperCreateSession(t, "/project", "claude", "BeforeTime")
+
+	// Insert messages with known timestamps
+	service.DB.Exec("INSERT INTO chat_history (project_path, backend, session_id, role, content, created_at, deleted) VALUES (?, ?, ?, ?, ?, ?, ?)",
+		"/project", "claude", sid, "user", "msg1", "2025-01-01 10:00:00", 0)
+	service.DB.Exec("INSERT INTO chat_history (project_path, backend, session_id, role, content, created_at, deleted) VALUES (?, ?, ?, ?, ?, ?, ?)",
+		"/project", "claude", sid, "assistant", "msg2", "2025-01-01 10:00:01", 0)
+	service.DB.Exec("INSERT INTO chat_history (project_path, backend, session_id, role, content, created_at, deleted) VALUES (?, ?, ?, ?, ?, ?, ?)",
+		"/project", "claude", sid, "user", "msg3", "2025-01-01 10:00:02", 0)
+
+	// Query for messages before 10:00:02 — should return max ID of messages before that time
+	id, err := service.GetMessageIDBeforeTime("/project", "claude", sid, "2025-01-01 10:00:02")
+	assert.NoError(t, err)
+	assert.Greater(t, id, 0, "should find a message ID before the given time")
+
+	// Query with a time before all messages — should return 0
+	id, err = service.GetMessageIDBeforeTime("/project", "claude", sid, "2025-01-01 09:00:00")
+	assert.NoError(t, err)
+	assert.Equal(t, 0, id, "should return 0 when no messages before the given time")
+}
+
 // Ensure TestMain-like global DB save/restore works correctly
 func TestGlobalDBPreservedAcrossParallelTests(t *testing.T) {
 	originalDB := service.DB

--- a/internal/service/chat_test.go
+++ b/internal/service/chat_test.go
@@ -1844,6 +1844,39 @@ func TestGetSessionTitlesBatch_NonExistentID(t *testing.T) {
 	assert.False(t, ok, "non-existent ID should not appear in titles")
 }
 
+// ---------- GetSessionInfo ----------
+
+func TestGetSessionInfo(t *testing.T) {
+	_ = setupDB(t)
+
+	s1, _ := service.CreateSession("/project", "claude", "My Session", "claude", "claude-sonnet-4-6", "default", "chat")
+
+	info, err := service.GetSessionInfo(s1)
+	assert.NoError(t, err)
+	assert.Equal(t, "My Session", info.Title)
+	assert.Equal(t, "claude", info.Backend)
+	assert.Equal(t, "claude", info.AgentID)
+	assert.Equal(t, "claude-sonnet-4-6", info.Model)
+	assert.Equal(t, "", info.ThinkingEffort)
+}
+
+func TestGetSessionInfo_NotFound(t *testing.T) {
+	_ = setupDB(t)
+
+	_, err := service.GetSessionInfo("nonexistent")
+	assert.Error(t, err)
+}
+
+func TestGetSessionInfo_Deleted(t *testing.T) {
+	_ = setupDB(t)
+
+	s1, _ := service.CreateSession("/project", "claude", "Deleted", "claude", "", "default", "chat")
+	service.DeleteSession("/project", "claude", s1)
+
+	_, err := service.GetSessionInfo(s1)
+	assert.Error(t, err)
+}
+
 // ---------- GetSessions UnreadCount ----------
 
 func TestGetSessions_UnreadCount_NoMessages(t *testing.T) {

--- a/internal/service/chat_test.go
+++ b/internal/service/chat_test.go
@@ -1981,6 +1981,31 @@ func TestGetSessions_UnreadCount_DeletedMessagesExcluded(t *testing.T) {
 	assert.Equal(t, 1, sessions[0].UnreadCount, "deleted messages should not count as unread")
 }
 
+func TestGetSessions_UnreadCountScopedToProject(t *testing.T) {
+	db := setupDB(t)
+	_ = db
+
+	// Create sessions in two different projects
+	s1, _ := service.CreateSession("/project-a", "claude", "S1", "claude", "", "default", "chat")
+	s2, _ := service.CreateSession("/project-b", "claude", "S2", "claude", "", "default", "chat")
+
+	// Add assistant messages to both sessions
+	service.AddChatMessage("/project-a", "claude", s1, "assistant", `{"blocks":[{"type":"text","text":"hello"}]}`, nil, false, "")
+	service.AddChatMessage("/project-b", "claude", s2, "assistant", `{"blocks":[{"type":"text","text":"world"}]}`, nil, false, "")
+
+	// Query project-a only — should have 1 unread
+	sessions, err := service.GetSessions("/project-a", "")
+	assert.NoError(t, err)
+	assert.Len(t, sessions, 1)
+	assert.Equal(t, 1, sessions[0].UnreadCount, "unread count should only count messages in project-a")
+
+	// Verify project-b also has 1 unread independently
+	sessionsB, err := service.GetSessions("/project-b", "")
+	assert.NoError(t, err)
+	assert.Len(t, sessionsB, 1)
+	assert.Equal(t, 1, sessionsB[0].UnreadCount, "unread count should only count messages in project-b")
+}
+
 // ---------- GetSessionsPaged UnreadCount ----------
 
 func TestGetSessionsPaged_UnreadCount(t *testing.T) {

--- a/internal/service/chat_test.go
+++ b/internal/service/chat_test.go
@@ -897,6 +897,33 @@ func TestGetChatHistory_DifferentBackendsIsolated(t *testing.T) {
 	assert.Equal(t, "codebuddy msg", msgsCB[0].Content)
 }
 
+// TestGetChatHistory_SameSecondOrdering verifies that messages inserted in the
+// same second (identical created_at due to CURRENT_TIMESTAMP second precision)
+// are returned in insertion order (id ASC) rather than non-deterministic order.
+// This is the root cause of the bug where assistant output appeared above user input.
+func TestGetChatHistory_SameSecondOrdering(t *testing.T) {
+	setupDB(t)
+
+	sid := helperCreateSession(t, "/project", "claude", "Same Second")
+
+	// Insert user then assistant within the same second — no sleep
+	userID, err := service.AddChatMessage("/project", "claude", sid, "user", "我自己定 AI-Driven Engineering", nil, false, "")
+	assert.NoError(t, err)
+
+	assistantID, err := service.AddChatMessage("/project", "claude", sid, "assistant", "很好！AI-Driven Engineering — 精准", nil, false, "")
+	assert.NoError(t, err)
+
+	// assistantID > userID since AUTOINCREMENT guarantees this
+	assert.Greater(t, assistantID, userID, "assistant message should have higher ID than user message")
+
+	// Verify chronological order: user first, assistant second
+	msgs, err := service.GetChatHistory("/project", "claude", sid)
+	assert.NoError(t, err)
+	assert.Len(t, msgs, 2)
+	assert.Equal(t, "user", msgs[0].Role, "user message must come first")
+	assert.Equal(t, "assistant", msgs[1].Role, "assistant message must come second")
+}
+
 // Ensure TestMain-like global DB save/restore works correctly
 func TestGlobalDBPreservedAcrossParallelTests(t *testing.T) {
 	originalDB := service.DB

--- a/internal/service/chat_test.go
+++ b/internal/service/chat_test.go
@@ -104,10 +104,13 @@ func setupDB(t *testing.T) *sql.DB {
 	_, err = db.Exec(schema)
 	assert.NoError(t, err)
 
+	origDB := service.DB
+	origDBRead := service.DBRead
 	service.DB = db
 	service.DBRead = db // Same instance for :memory: SQLite — data is shared
 	t.Cleanup(func() {
-		service.DBRead = nil
+		service.DB = origDB
+		service.DBRead = origDBRead
 		db.Close()
 	})
 	return db

--- a/internal/service/database.go
+++ b/internal/service/database.go
@@ -7,6 +7,7 @@ import (
 	"log/slog"
 	"os"
 	"path/filepath"
+	"time"
 
 	"clawbench/internal/model"
 
@@ -211,12 +212,18 @@ func InitDB(runFromServer ...bool) error {
 	// may still be actively streaming, and these are NOT orphaned messages.
 	isServerStartup := len(runFromServer) > 0 && runFromServer[0]
 
-	// Initialize read connection pool for concurrent reads (WAL mode)
+	// Initialize read connection pool for concurrent reads (WAL mode).
+	// WAL contract: DB (MaxOpenConns=1) serializes writes; DBRead (MaxOpenConns=2)
+	// allows concurrent reads that never block writes and vice versa.
+	// Both pools must use WAL mode + busy_timeout for this to work correctly.
 	DBRead, err = sql.Open("sqlite", dbPath)
 	if err != nil {
 		return fmt.Errorf("failed to open read database: %w", err)
 	}
 	DBRead.SetMaxOpenConns(2)
+	DBRead.SetMaxIdleConns(2)           // match MaxOpenConns to avoid churn
+	DBRead.SetConnMaxLifetime(0)        // unlimited — SQLite file DB, no reconnection needed
+	DBRead.SetConnMaxIdleTime(30 * time.Minute) // close idle conns after 30min
 	if _, err := DBRead.Exec("PRAGMA journal_mode=WAL"); err != nil {
 		return fmt.Errorf("failed to set read DB WAL mode: %w", err)
 	}

--- a/internal/service/database.go
+++ b/internal/service/database.go
@@ -289,7 +289,7 @@ func CloseDB() {
 // Returns (summary, found).
 func GetTTSSummary(cacheKey string) (string, bool) {
 	var summary string
-	err := DB.QueryRow(
+	err := DBRead.QueryRow(
 		"SELECT summary FROM tts_summaries WHERE cache_key = ?",
 		cacheKey,
 	).Scan(&summary)
@@ -369,7 +369,7 @@ type crudHelpers[T any, E any] struct {
 
 // list returns all rows from the helper's table ordered by sort_order.
 func (h crudHelpers[T, E]) list() ([]T, error) {
-	rows, err := DB.Query("SELECT " + h.scanCols + " FROM " + h.table + " ORDER BY sort_order")
+	rows, err := DBRead.Query("SELECT " + h.scanCols + " FROM " + h.table + " ORDER BY sort_order")
 	if err != nil {
 		return nil, err
 	}

--- a/internal/service/database.go
+++ b/internal/service/database.go
@@ -126,6 +126,12 @@ func InitDB(runFromServer ...bool) error {
 		CREATE INDEX IF NOT EXISTS idx_executions_session ON task_executions(session_id);
 		CREATE INDEX IF NOT EXISTS idx_sessions_type ON chat_sessions(session_type, project_path, deleted);
 
+		-- Covering index for session-based queries (GetChatMessageCount, GetAssistantMessageCount,
+		-- unread subquery, GetChatHistoryPaged) — avoids full table scan through large content rows.
+		CREATE INDEX IF NOT EXISTS idx_history_session_id ON chat_history(session_id, deleted, role, streaming, created_at);
+		-- Index for task listing by project
+		CREATE INDEX IF NOT EXISTS idx_tasks_project ON scheduled_tasks(project_path, created_at DESC);
+
 		CREATE TABLE IF NOT EXISTS tts_summaries (
 			cache_key TEXT PRIMARY KEY,
 			summary TEXT NOT NULL,

--- a/internal/service/database.go
+++ b/internal/service/database.go
@@ -15,6 +15,10 @@ import (
 
 var DB *sql.DB
 
+// DBRead is the read-only connection pool (MaxOpenConns=2) for SELECT queries.
+// In WAL mode, reads never block writes and vice versa.
+var DBRead *sql.DB
+
 // InitDB initializes the SQLite database with latest schema.
 // When runFromServer is true (server startup), orphaned streaming messages
 // from previous crashes are cleaned up. When false (CLI subcommand), cleanup
@@ -206,6 +210,19 @@ func InitDB(runFromServer ...bool) error {
 	// SKIP when called from CLI subcommands (task/rag) — the server process
 	// may still be actively streaming, and these are NOT orphaned messages.
 	isServerStartup := len(runFromServer) > 0 && runFromServer[0]
+
+	// Initialize read connection pool for concurrent reads (WAL mode)
+	DBRead, err = sql.Open("sqlite", dbPath)
+	if err != nil {
+		return fmt.Errorf("failed to open read database: %w", err)
+	}
+	DBRead.SetMaxOpenConns(2)
+	if _, err := DBRead.Exec("PRAGMA journal_mode=WAL"); err != nil {
+		return fmt.Errorf("failed to set read DB WAL mode: %w", err)
+	}
+	if _, err := DBRead.Exec("PRAGMA busy_timeout=5000"); err != nil {
+		return fmt.Errorf("failed to set read DB busy_timeout: %w", err)
+	}
 	if isServerStartup {
 		rows, err := DB.Query("SELECT id, content FROM chat_history WHERE streaming = 1")
 		if err != nil {
@@ -256,6 +273,16 @@ func InitDB(runFromServer ...bool) error {
 	}
 
 	return nil
+}
+
+// CloseDB closes both write and read database connections.
+func CloseDB() {
+	if DB != nil {
+		DB.Close()
+	}
+	if DBRead != nil {
+		DBRead.Close()
+	}
 }
 
 // GetTTSSummary looks up a cached TTS summary by cache key.

--- a/internal/service/database_test.go
+++ b/internal/service/database_test.go
@@ -55,6 +55,7 @@ func setupTestDBForTTS(t *testing.T) (*sql.DB, func()) {
 			model TEXT DEFAULT '',
 			session_type TEXT NOT NULL DEFAULT 'chat',
 			external_session_id TEXT DEFAULT '',
+			thinking_effort TEXT DEFAULT '',
 			deleted INTEGER NOT NULL DEFAULT 0,
 			last_read_at DATETIME,
 			created_at DATETIME DEFAULT CURRENT_TIMESTAMP,
@@ -236,6 +237,34 @@ func TestInitDB_ReadWriteSeparation(t *testing.T) {
 	assert.NoError(t, err, "DBRead should be able to query")
 
 	// Verify CloseDB closes both
+	CloseDB()
+}
+
+// TestCloseDB_NilDB verifies that CloseDB does not panic when DB and DBRead are nil.
+func TestCloseDB_NilDB(t *testing.T) {
+	origDB := DB
+	origDBRead := DBRead
+	defer func() { DB = origDB; DBRead = origDBRead }()
+
+	DB = nil
+	DBRead = nil
+
+	// Should not panic
+	CloseDB()
+}
+
+// TestCloseDB_NilDBRead verifies that CloseDB does not panic when DBRead is nil but DB is not.
+func TestCloseDB_NilDBRead(t *testing.T) {
+	origDB := DB
+	origDBRead := DBRead
+	defer func() { DB = origDB; DBRead = origDBRead }()
+
+	db, err := sql.Open("sqlite", ":memory:")
+	assert.NoError(t, err)
+	DB = db
+	DBRead = nil
+
+	// Should not panic, should close DB
 	CloseDB()
 }
 

--- a/internal/service/database_test.go
+++ b/internal/service/database_test.go
@@ -192,6 +192,36 @@ func getIndexes(t *testing.T, db *sql.DB) map[string]bool {
 	return indexes
 }
 
+// ---------- Performance indexes ----------
+
+func TestSchema_HistorySessionIDIndex(t *testing.T) {
+	tmpDir := t.TempDir()
+	origBinDir := model.BinDir
+	model.BinDir = tmpDir
+	defer func() { model.BinDir = origBinDir }()
+
+	err := InitDB()
+	assert.NoError(t, err)
+	defer DB.Close()
+
+	indexes := getIndexes(t, DB)
+	assert.True(t, indexes["idx_history_session_id"], "expected idx_history_session_id index to exist")
+}
+
+func TestSchema_TasksProjectIndex(t *testing.T) {
+	tmpDir := t.TempDir()
+	origBinDir := model.BinDir
+	model.BinDir = tmpDir
+	defer func() { model.BinDir = origBinDir }()
+
+	err := InitDB()
+	assert.NoError(t, err)
+	defer DB.Close()
+
+	indexes := getIndexes(t, DB)
+	assert.True(t, indexes["idx_tasks_project"], "expected idx_tasks_project index to exist")
+}
+
 // ---------- Table creation ----------
 
 func TestInitDB_CreatesTables(t *testing.T) {

--- a/internal/service/database_test.go
+++ b/internal/service/database_test.go
@@ -16,6 +16,7 @@ import (
 func setupTestDBForTTS(t *testing.T) (*sql.DB, func()) {
 	t.Helper()
 	origDB := DB
+	origDBRead := DBRead
 
 	db, err := sql.Open("sqlite", ":memory:")
 	if err != nil {
@@ -66,8 +67,10 @@ func setupTestDBForTTS(t *testing.T) (*sql.DB, func()) {
 	}
 
 	DB = db
+	DBRead = db // Same instance for :memory: SQLite — data is shared
 	teardown := func() {
 		DB = origDB
+		DBRead = origDBRead
 		db.Close()
 	}
 	return db, teardown
@@ -78,6 +81,7 @@ func setupTestDBForTTS(t *testing.T) (*sql.DB, func()) {
 func setupTestDBForQuickSend(t *testing.T) (*sql.DB, func()) {
 	t.Helper()
 	origDB := DB
+	origDBRead := DBRead
 
 	db, err := sql.Open("sqlite", ":memory:")
 	if err != nil {
@@ -102,8 +106,10 @@ func setupTestDBForQuickSend(t *testing.T) (*sql.DB, func()) {
 	}
 
 	DB = db
+	DBRead = db // Same instance for :memory: SQLite — data is shared
 	teardown := func() {
 		DB = origDB
+		DBRead = origDBRead
 		db.Close()
 	}
 	return db, teardown

--- a/internal/service/database_test.go
+++ b/internal/service/database_test.go
@@ -124,9 +124,13 @@ func TestSchema_SessionTypeColumnExists(t *testing.T) {
 	model.BinDir = tmpDir
 	defer func() { model.BinDir = origBinDir }()
 
+	origDB := DB
+	origDBRead := DBRead
+	defer func() { DB = origDB; DBRead = origDBRead }()
+
 	err := InitDB()
 	assert.NoError(t, err)
-	defer DB.Close()
+	defer CloseDB()
 
 	columns := getTableColumns(t, DB, "chat_sessions")
 	assert.Contains(t, columns, "session_type", "chat_sessions should have session_type column")
@@ -138,9 +142,13 @@ func TestSchema_TaskExecutionsColumns(t *testing.T) {
 	model.BinDir = tmpDir
 	defer func() { model.BinDir = origBinDir }()
 
+	origDB := DB
+	origDBRead := DBRead
+	defer func() { DB = origDB; DBRead = origDBRead }()
+
 	err := InitDB()
 	assert.NoError(t, err)
-	defer DB.Close()
+	defer CloseDB()
 
 	columns := getTableColumns(t, DB, "task_executions")
 	assert.Contains(t, columns, "session_id", "task_executions should have session_id column")
@@ -154,9 +162,13 @@ func TestSchema_NewIndexes(t *testing.T) {
 	model.BinDir = tmpDir
 	defer func() { model.BinDir = origBinDir }()
 
+	origDB := DB
+	origDBRead := DBRead
+	defer func() { DB = origDB; DBRead = origDBRead }()
+
 	err := InitDB()
 	assert.NoError(t, err)
-	defer DB.Close()
+	defer CloseDB()
 
 	indexes := getIndexes(t, DB)
 	assert.Contains(t, indexes, "idx_executions_session", "idx_executions_session index should exist")
@@ -276,9 +288,13 @@ func TestSchema_HistorySessionIDIndex(t *testing.T) {
 	model.BinDir = tmpDir
 	defer func() { model.BinDir = origBinDir }()
 
+	origDB := DB
+	origDBRead := DBRead
+	defer func() { DB = origDB; DBRead = origDBRead }()
+
 	err := InitDB()
 	assert.NoError(t, err)
-	defer DB.Close()
+	defer CloseDB()
 
 	indexes := getIndexes(t, DB)
 	assert.True(t, indexes["idx_history_session_id"], "expected idx_history_session_id index to exist")
@@ -290,9 +306,13 @@ func TestSchema_TasksProjectIndex(t *testing.T) {
 	model.BinDir = tmpDir
 	defer func() { model.BinDir = origBinDir }()
 
+	origDB := DB
+	origDBRead := DBRead
+	defer func() { DB = origDB; DBRead = origDBRead }()
+
 	err := InitDB()
 	assert.NoError(t, err)
-	defer DB.Close()
+	defer CloseDB()
 
 	indexes := getIndexes(t, DB)
 	assert.True(t, indexes["idx_tasks_project"], "expected idx_tasks_project index to exist")

--- a/internal/service/database_test.go
+++ b/internal/service/database_test.go
@@ -192,6 +192,47 @@ func getIndexes(t *testing.T, db *sql.DB) map[string]bool {
 	return indexes
 }
 
+// ---------- Read-write connection separation ----------
+
+func TestInitDB_ReadWriteSeparation(t *testing.T) {
+	tmpDir := t.TempDir()
+	origBinDir := model.BinDir
+	model.BinDir = tmpDir
+	defer func() { model.BinDir = origBinDir }()
+
+	origDB := DB
+	origDBRead := DBRead
+	defer func() { DB = origDB; DBRead = origDBRead }()
+
+	err := InitDB()
+	assert.NoError(t, err)
+
+	// DB (write pool) should be initialized
+	assert.NotNil(t, DB, "DB (write pool) should be initialized")
+
+	// DBRead (read pool) should be initialized
+	assert.NotNil(t, DBRead, "DBRead (read pool) should be initialized")
+
+	// Both should be different instances
+	assert.NotEqual(t, DB, DBRead, "DB and DBRead should be separate connections")
+
+	// Verify write pool has MaxOpenConns=1
+	stats := DB.Stats()
+	assert.Equal(t, 1, stats.MaxOpenConnections, "DB write pool should have MaxOpenConns=1")
+
+	// Verify read pool has MaxOpenConns=2
+	statsRead := DBRead.Stats()
+	assert.Equal(t, 2, statsRead.MaxOpenConnections, "DBRead pool should have MaxOpenConns=2")
+
+	// Verify both can query
+	var count int
+	err = DBRead.QueryRow("SELECT COUNT(*) FROM chat_sessions").Scan(&count)
+	assert.NoError(t, err, "DBRead should be able to query")
+
+	// Verify CloseDB closes both
+	CloseDB()
+}
+
 // ---------- Performance indexes ----------
 
 func TestSchema_HistorySessionIDIndex(t *testing.T) {

--- a/internal/service/proxy_test.go
+++ b/internal/service/proxy_test.go
@@ -262,8 +262,10 @@ func setupTestDB(t *testing.T) *sql.DB {
 func TestProxyRegistry_PortPersistence_RegisterAndLoad(t *testing.T) {
 	// Set up in-memory DB and make it available globally
 	origDB := DB
+	origDBRead := DBRead
 	DB = setupTestDB(t)
-	defer func() { DB = origDB }()
+	DBRead = DB // Same instance for :memory: SQLite — data is shared
+	defer func() { DB = origDB; DBRead = origDBRead }()
 
 	// Create registry and register ports — should persist to DB
 	r := NewProxyRegistry("1024-65535", 0)
@@ -295,8 +297,10 @@ func TestProxyRegistry_PortPersistence_RegisterAndLoad(t *testing.T) {
 
 func TestProxyRegistry_PortPersistence_UnregisterDeletesFromDB(t *testing.T) {
 	origDB := DB
+	origDBRead := DBRead
 	DB = setupTestDB(t)
-	defer func() { DB = origDB }()
+	DBRead = DB
+	defer func() { DB = origDB; DBRead = origDBRead }()
 
 	r := NewProxyRegistry("1024-65535", 0)
 	defer r.Stop()
@@ -323,8 +327,10 @@ func TestProxyRegistry_PortPersistence_UnregisterDeletesFromDB(t *testing.T) {
 
 func TestProxyRegistry_PortPersistence_RestoreOnStartup(t *testing.T) {
 	origDB := DB
+	origDBRead := DBRead
 	DB = setupTestDB(t)
-	defer func() { DB = origDB }()
+	DBRead = DB
+	defer func() { DB = origDB; DBRead = origDBRead }()
 
 	// First registry: register ports (persists to DB)
 	r1 := NewProxyRegistry("1024-65535", 0)
@@ -351,8 +357,10 @@ func TestProxyRegistry_PortPersistence_RestoreOnStartup(t *testing.T) {
 
 func TestProxyRegistry_PortPersistence_FullLifecycle(t *testing.T) {
 	origDB := DB
+	origDBRead := DBRead
 	DB = setupTestDB(t)
-	defer func() { DB = origDB }()
+	DBRead = DB
+	defer func() { DB = origDB; DBRead = origDBRead }()
 
 	// Phase 1: Create, register, verify
 	r1 := NewProxyRegistry("1024-65535", 0)
@@ -394,8 +402,10 @@ func TestProxyRegistry_PortPersistence_FullLifecycle(t *testing.T) {
 
 func TestProxyRegistry_PortPersistence_SkipsOutOfAllowedRange(t *testing.T) {
 	origDB := DB
+	origDBRead := DBRead
 	DB = setupTestDB(t)
-	defer func() { DB = origDB }()
+	DBRead = DB
+	defer func() { DB = origDB; DBRead = origDBRead }()
 
 	// Insert a port directly into DB that is outside the new allowed range
 	_, err := DB.Exec("INSERT INTO forwarded_ports (port, name, protocol) VALUES (80, 'system', 'http')")
@@ -413,8 +423,10 @@ func TestProxyRegistry_PortPersistence_SkipsOutOfAllowedRange(t *testing.T) {
 func TestProxyRegistry_PortPersistence_NoDB(t *testing.T) {
 	// When DB is nil, persistence methods should be no-ops (not panic)
 	origDB := DB
+	origDBRead := DBRead
 	DB = nil
-	defer func() { DB = origDB }()
+	DBRead = nil
+	defer func() { DB = origDB; DBRead = origDBRead }()
 
 	r := NewProxyRegistry("1024-65535", 0)
 	defer r.Stop()

--- a/internal/service/recent_projects_test.go
+++ b/internal/service/recent_projects_test.go
@@ -30,7 +30,9 @@ func setupRecentProjectsDB(t *testing.T) *sql.DB {
 	assert.NoError(t, err)
 
 	service.DB = db
+	service.DBRead = db // Same instance for :memory: SQLite — data is shared
 	t.Cleanup(func() {
+		service.DBRead = nil
 		db.Close()
 	})
 	return db

--- a/internal/service/recent_projects_test.go
+++ b/internal/service/recent_projects_test.go
@@ -29,10 +29,13 @@ func setupRecentProjectsDB(t *testing.T) *sql.DB {
 	_, err = db.Exec(recentProjectsSchema)
 	assert.NoError(t, err)
 
+	origDB := service.DB
+	origDBRead := service.DBRead
 	service.DB = db
 	service.DBRead = db // Same instance for :memory: SQLite — data is shared
 	t.Cleanup(func() {
-		service.DBRead = nil
+		service.DB = origDB
+		service.DBRead = origDBRead
 		db.Close()
 	})
 	return db

--- a/internal/service/scheduler.go
+++ b/internal/service/scheduler.go
@@ -923,7 +923,19 @@ func DeleteTaskExecution(executionID int64) error {
 		return fmt.Errorf("cannot delete a running execution")
 	}
 
-	// Soft-delete the associated chat session
+	// Hard-delete the execution row first (conditional on status to prevent TOCTOU race).
+	// This must happen BEFORE soft-deleting the session: if the conditional DELETE fails
+	// (execution became running between the DBRead check and this DELETE), the session
+	// must remain intact to avoid inconsistent state.
+	result, err := DB.Exec("DELETE FROM task_executions WHERE id = ? AND status != 'running'", executionID)
+	if err != nil {
+		return fmt.Errorf("failed to delete execution: %w", err)
+	}
+	if rows, _ := result.RowsAffected(); rows == 0 {
+		return fmt.Errorf("cannot delete a running execution")
+	}
+
+	// Only soft-delete the associated chat session AFTER successful execution deletion.
 	var projectPath, backend string
 	err = DBRead.QueryRow(
 		"SELECT project_path, backend FROM chat_sessions WHERE id = ?",
@@ -936,15 +948,6 @@ func DeleteTaskExecution(executionID int64) error {
 				slog.String("err", err.Error()),
 			)
 		}
-	}
-
-	// Hard-delete the execution row (conditional on status to prevent TOCTOU race with DBRead)
-	result, err := DB.Exec("DELETE FROM task_executions WHERE id = ? AND status != 'running'", executionID)
-	if err != nil {
-		return fmt.Errorf("failed to delete execution: %w", err)
-	}
-	if rows, _ := result.RowsAffected(); rows == 0 {
-		return fmt.Errorf("cannot delete a running execution")
 	}
 
 	// Decrement run_count on the parent task (clamp to 0)

--- a/internal/service/scheduler.go
+++ b/internal/service/scheduler.go
@@ -239,7 +239,7 @@ func (s *Scheduler) RemoveTask(id int64) {
 	s.mu.Unlock()
 
 	// Cascade: soft-delete associated chat sessions
-	rows, err := DB.Query(`
+	rows, err := DBRead.Query(`
 		SELECT te.session_id, cs.project_path, cs.backend
 		FROM task_executions te
 		JOIN chat_sessions cs ON cs.id = te.session_id
@@ -647,7 +647,7 @@ func (s *Scheduler) executeTask(task *model.ScheduledTask, projectPath string, t
 	// Check repeat mode — for "limited", read current DB value to decide completion
 	if task.RepeatMode == "limited" {
 		var currentCount int
-		if err := DB.QueryRow("SELECT run_count FROM scheduled_tasks WHERE id = ?", task.ID).Scan(&currentCount); err == nil {
+		if err := DBRead.QueryRow("SELECT run_count FROM scheduled_tasks WHERE id = ?", task.ID).Scan(&currentCount); err == nil {
 			if currentCount+1 >= task.MaxRuns {
 				newStatus = "completed"
 			}
@@ -756,7 +756,7 @@ func GetTasks(projectPath string) ([]model.ScheduledTask, error) {
 		args = []interface{}{projectPath}
 	}
 
-	rows, err := DB.Query(query, args...)
+	rows, err := DBRead.Query(query, args...)
 	if err != nil {
 		return nil, err
 	}
@@ -786,7 +786,7 @@ func GetTasks(projectPath string) ([]model.ScheduledTask, error) {
 func GetTaskByID(id int64) (*model.ScheduledTask, error) {
 	var t model.ScheduledTask
 	var lastRun, nextRun, lastRead sql.NullTime
-	err := DB.QueryRow(
+	err := DBRead.QueryRow(
 		`SELECT s.id, s.project_path, s.name, s.cron_expr, s.agent_id, s.prompt, s.session_id,
 		s.status, s.repeat_mode, s.max_runs, s.last_run_at, s.next_run_at, s.run_count,
 		s.last_read_at, s.created_at, s.updated_at,
@@ -911,7 +911,7 @@ func DeleteTaskExecution(executionID int64) error {
 	var sessionID string
 	var taskID int64
 	var status string
-	err := DB.QueryRow(
+	err := DBRead.QueryRow(
 		"SELECT session_id, task_id, status FROM task_executions WHERE id = ?",
 		executionID,
 	).Scan(&sessionID, &taskID, &status)
@@ -925,7 +925,7 @@ func DeleteTaskExecution(executionID int64) error {
 
 	// Soft-delete the associated chat session
 	var projectPath, backend string
-	err = DB.QueryRow(
+	err = DBRead.QueryRow(
 		"SELECT project_path, backend FROM chat_sessions WHERE id = ?",
 		sessionID,
 	).Scan(&projectPath, &backend)
@@ -953,7 +953,7 @@ func DeleteTaskExecution(executionID int64) error {
 // and soft-deletes the associated chat sessions.
 func DeleteAllTaskExecutions(taskID int64) error {
 	// Collect all non-running executions with their session info
-	rows, err := DB.Query(`
+	rows, err := DBRead.Query(`
 		SELECT te.id, te.session_id, cs.project_path, cs.backend
 		FROM task_executions te
 		JOIN chat_sessions cs ON cs.id = te.session_id
@@ -992,7 +992,7 @@ func DeleteAllTaskExecutions(taskID int64) error {
 
 	// Reset run_count to match remaining (running) executions
 	var runningCount int
-	DB.QueryRow("SELECT COUNT(*) FROM task_executions WHERE task_id = ?", taskID).Scan(&runningCount)
+	DBRead.QueryRow("SELECT COUNT(*) FROM task_executions WHERE task_id = ?", taskID).Scan(&runningCount)
 	DB.Exec("UPDATE scheduled_tasks SET run_count = ?, updated_at = CURRENT_TIMESTAMP WHERE id = ?", runningCount, taskID)
 
 	return nil
@@ -1003,14 +1003,14 @@ func HasUnreadTasks(projectPath string) (bool, error) {
 	var count int
 	var err error
 	if projectPath == "" {
-		err = DB.QueryRow(
+		err = DBRead.QueryRow(
 			`SELECT COUNT(*) FROM scheduled_tasks s
 			 WHERE (SELECT COUNT(*) FROM task_executions e
 			      WHERE e.task_id = s.id AND e.read_at IS NULL AND e.status != 'running'
 			      AND (s.last_read_at IS NULL OR e.created_at > s.last_read_at)) > 0`,
 		).Scan(&count)
 	} else {
-		err = DB.QueryRow(
+		err = DBRead.QueryRow(
 			`SELECT COUNT(*) FROM scheduled_tasks s
 			 WHERE s.project_path = ?
 			 AND (SELECT COUNT(*) FROM task_executions e

--- a/internal/service/scheduler.go
+++ b/internal/service/scheduler.go
@@ -938,9 +938,13 @@ func DeleteTaskExecution(executionID int64) error {
 		}
 	}
 
-	// Hard-delete the execution row
-	if _, err := DB.Exec("DELETE FROM task_executions WHERE id = ?", executionID); err != nil {
+	// Hard-delete the execution row (conditional on status to prevent TOCTOU race with DBRead)
+	result, err := DB.Exec("DELETE FROM task_executions WHERE id = ? AND status != 'running'", executionID)
+	if err != nil {
 		return fmt.Errorf("failed to delete execution: %w", err)
+	}
+	if rows, _ := result.RowsAffected(); rows == 0 {
+		return fmt.Errorf("cannot delete a running execution")
 	}
 
 	// Decrement run_count on the parent task (clamp to 0)

--- a/internal/service/scheduler_test.go
+++ b/internal/service/scheduler_test.go
@@ -1008,6 +1008,18 @@ func TestDeleteTaskExecution_RunningExecution(t *testing.T) {
 	err = service.DB.QueryRow("SELECT COUNT(*) FROM task_executions WHERE id = ?", execID).Scan(&execCount)
 	assert.NoError(t, err)
 	assert.Equal(t, 1, execCount, "running execution should not be deleted")
+
+	// Verify session is NOT soft-deleted (operation order fix: DELETE runs first,
+	// so if DELETE fails, session must remain intact)
+	var sessionDeleted int
+	err = service.DB.QueryRow("SELECT deleted FROM chat_sessions WHERE id = ?", sessionID).Scan(&sessionDeleted)
+	assert.NoError(t, err)
+	assert.Equal(t, 0, sessionDeleted, "session should NOT be soft-deleted when execution deletion is rejected")
+
+	// Verify run_count is NOT decremented
+	task, err := service.GetTaskByID(taskID)
+	assert.NoError(t, err)
+	assert.Equal(t, 1, task.RunCount, "run_count should not be decremented when deletion is rejected")
 }
 
 func TestDeleteTaskExecution_RunCountClampToZero(t *testing.T) {

--- a/internal/service/scheduler_test.go
+++ b/internal/service/scheduler_test.go
@@ -94,7 +94,11 @@ func setupSchedulerDB(t *testing.T) *sql.DB {
 	_, err = db.Exec(schedulerSchema)
 	assert.NoError(t, err)
 	service.DB = db
-	t.Cleanup(func() { db.Close() })
+	service.DBRead = db // Same instance for :memory: SQLite — data is shared
+	t.Cleanup(func() {
+		service.DBRead = nil
+		db.Close()
+	})
 	return db
 }
 
@@ -1297,4 +1301,11 @@ func TestHasUnreadTasks_RunningExecutionNotUnread(t *testing.T) {
 	hasUnread, err = service.HasUnreadTasks("/proj")
 	assert.NoError(t, err)
 	assert.True(t, hasUnread, "completed execution should count as unread")
+}
+
+// ---------- DBRead initialization ----------
+
+func TestDBRead_Initialized_SchedulerDB(t *testing.T) {
+	_ = setupSchedulerDB(t)
+	assert.NotNil(t, service.DBRead, "DBRead should be initialized in test setup")
 }

--- a/internal/service/scheduler_test.go
+++ b/internal/service/scheduler_test.go
@@ -93,10 +93,13 @@ func setupSchedulerDB(t *testing.T) *sql.DB {
 	db.SetMaxOpenConns(1) // Required for :memory: SQLite — all queries must use the same connection
 	_, err = db.Exec(schedulerSchema)
 	assert.NoError(t, err)
+	origDB := service.DB
+	origDBRead := service.DBRead
 	service.DB = db
 	service.DBRead = db // Same instance for :memory: SQLite — data is shared
 	t.Cleanup(func() {
-		service.DBRead = nil
+		service.DB = origDB
+		service.DBRead = origDBRead
 		db.Close()
 	})
 	return db

--- a/internal/service/session_runtime_test.go
+++ b/internal/service/session_runtime_test.go
@@ -446,9 +446,11 @@ func insertTestMessage(t *testing.T, db *sql.DB, sessionID, role, content string
 
 func TestGetSessionResponsePreview_WithTextBlock(t *testing.T) {
 	origDB := DB
+	origDBRead := DBRead
 	db := setupChatTestDB(t)
 	DB = db
-	defer func() { DB = origDB }()
+	DBRead = db // Same instance for :memory: SQLite — data is shared
+	defer func() { DB = origDB; DBRead = origDBRead }()
 
 	content := model.ContentBlock{Type: "text", Text: "你好，这是AI的回复内容"}
 	blocks := map[string]any{"blocks": []model.ContentBlock{content}}
@@ -462,9 +464,11 @@ func TestGetSessionResponsePreview_WithTextBlock(t *testing.T) {
 
 func TestGetSessionResponsePreview_Truncation(t *testing.T) {
 	origDB := DB
+	origDBRead := DBRead
 	db := setupChatTestDB(t)
 	DB = db
-	defer func() { DB = origDB }()
+	DBRead = db // Same instance for :memory: SQLite — data is shared
+	defer func() { DB = origDB; DBRead = origDBRead }()
 
 	// responsePreviewMaxRunes+1 runes — should be truncated
 	longText := strings.Repeat("测", responsePreviewMaxRunes+1)
@@ -482,9 +486,11 @@ func TestGetSessionResponsePreview_Truncation(t *testing.T) {
 
 func TestGetSessionResponsePreview_NoAssistantMessage(t *testing.T) {
 	origDB := DB
+	origDBRead := DBRead
 	db := setupChatTestDB(t)
 	DB = db
-	defer func() { DB = origDB }()
+	DBRead = db // Same instance for :memory: SQLite — data is shared
+	defer func() { DB = origDB; DBRead = origDBRead }()
 
 	insertTestMessage(t, db, "session-preview-3", "user", "只有用户消息")
 
@@ -494,9 +500,11 @@ func TestGetSessionResponsePreview_NoAssistantMessage(t *testing.T) {
 
 func TestGetSessionResponsePreview_NoMessages(t *testing.T) {
 	origDB := DB
+	origDBRead := DBRead
 	db := setupChatTestDB(t)
 	DB = db
-	defer func() { DB = origDB }()
+	DBRead = db // Same instance for :memory: SQLite — data is shared
+	defer func() { DB = origDB; DBRead = origDBRead }()
 
 	result := getSessionResponsePreview("session-nonexistent")
 	assert.Equal(t, "", result)
@@ -504,9 +512,11 @@ func TestGetSessionResponsePreview_NoMessages(t *testing.T) {
 
 func TestGetSessionResponsePreview_SkipsToolUseBlocks(t *testing.T) {
 	origDB := DB
+	origDBRead := DBRead
 	db := setupChatTestDB(t)
 	DB = db
-	defer func() { DB = origDB }()
+	DBRead = db // Same instance for :memory: SQLite — data is shared
+	defer func() { DB = origDB; DBRead = origDBRead }()
 
 	toolBlock := model.ContentBlock{Type: "tool_use", Name: "Read", ID: "tool-1"}
 	textBlock := model.ContentBlock{Type: "text", Text: "工具执行后的文本"}
@@ -521,9 +531,11 @@ func TestGetSessionResponsePreview_SkipsToolUseBlocks(t *testing.T) {
 
 func TestGetSessionResponsePreview_UsesLastAssistantMessage(t *testing.T) {
 	origDB := DB
+	origDBRead := DBRead
 	db := setupChatTestDB(t)
 	DB = db
-	defer func() { DB = origDB }()
+	DBRead = db // Same instance for :memory: SQLite — data is shared
+	defer func() { DB = origDB; DBRead = origDBRead }()
 
 	firstContent := model.ContentBlock{Type: "text", Text: "第一次回复"}
 	firstBlocks := map[string]any{"blocks": []model.ContentBlock{firstContent}}
@@ -543,9 +555,11 @@ func TestGetSessionResponsePreview_UsesLastAssistantMessage(t *testing.T) {
 
 func TestGetSessionResponsePreview_InvalidJSON(t *testing.T) {
 	origDB := DB
+	origDBRead := DBRead
 	db := setupChatTestDB(t)
 	DB = db
-	defer func() { DB = origDB }()
+	DBRead = db // Same instance for :memory: SQLite — data is shared
+	defer func() { DB = origDB; DBRead = origDBRead }()
 
 	insertTestMessage(t, db, "session-preview-6", "user", "问题")
 	insertTestMessage(t, db, "session-preview-6", "assistant", "not valid json {{{")
@@ -556,9 +570,11 @@ func TestGetSessionResponsePreview_InvalidJSON(t *testing.T) {
 
 func TestGetSessionResponsePreview_NoTextBlocks(t *testing.T) {
 	origDB := DB
+	origDBRead := DBRead
 	db := setupChatTestDB(t)
 	DB = db
-	defer func() { DB = origDB }()
+	DBRead = db // Same instance for :memory: SQLite — data is shared
+	defer func() { DB = origDB; DBRead = origDBRead }()
 
 	toolBlock := model.ContentBlock{Type: "tool_use", Name: "Read", ID: "tool-1"}
 	blocks := map[string]any{"blocks": []model.ContentBlock{toolBlock}}
@@ -572,9 +588,11 @@ func TestGetSessionResponsePreview_NoTextBlocks(t *testing.T) {
 
 func TestGetSessionResponsePreview_ExactMaxRunes(t *testing.T) {
 	origDB := DB
+	origDBRead := DBRead
 	db := setupChatTestDB(t)
 	DB = db
-	defer func() { DB = origDB }()
+	DBRead = db // Same instance for :memory: SQLite — data is shared
+	defer func() { DB = origDB; DBRead = origDBRead }()
 
 	// Exactly responsePreviewMaxRunes runes — should NOT be truncated
 	exactText := strings.Repeat("一二三四", responsePreviewMaxRunes/4)
@@ -591,9 +609,11 @@ func TestGetSessionResponsePreview_ExactMaxRunes(t *testing.T) {
 
 func TestGetSessionResponsePreview_OneOverMaxRunes(t *testing.T) {
 	origDB := DB
+	origDBRead := DBRead
 	db := setupChatTestDB(t)
 	DB = db
-	defer func() { DB = origDB }()
+	DBRead = db // Same instance for :memory: SQLite — data is shared
+	defer func() { DB = origDB; DBRead = origDBRead }()
 
 	// responsePreviewMaxRunes+1 runes — should be truncated to maxRunes + …
 	longText := strings.Repeat("一二三四", responsePreviewMaxRunes/4) + "五"
@@ -611,9 +631,11 @@ func TestGetSessionResponsePreview_OneOverMaxRunes(t *testing.T) {
 
 func TestEmitSessionEvent_CompletedWithPreview(t *testing.T) {
 	origDB := DB
+	origDBRead := DBRead
 	db := setupChatTestDB(t)
 	DB = db
-	defer func() { DB = origDB }()
+	DBRead = db // Same instance for :memory: SQLite — data is shared
+	defer func() { DB = origDB; DBRead = origDBRead }()
 
 	// Insert assistant message for preview
 	content := model.ContentBlock{Type: "text", Text: "AI完成了任务"}
@@ -657,9 +679,11 @@ func TestEmitSessionEvent_CompletedWithPreview(t *testing.T) {
 
 func TestEmitSessionEvent_RunningNoPreview(t *testing.T) {
 	origDB := DB
+	origDBRead := DBRead
 	db := setupChatTestDB(t)
 	DB = db
-	defer func() { DB = origDB }()
+	DBRead = db // Same instance for :memory: SQLite — data is shared
+	defer func() { DB = origDB; DBRead = origDBRead }()
 
 	mgr := ws.NewManagerForTest(nil)
 	ws.SetManagerForTest(mgr)
@@ -915,9 +939,11 @@ func setupExecTaskDB(t *testing.T) *sql.DB {
 func TestExecuteTask_BackendCreationFailed(t *testing.T) {
 	// Set up DB with scheduler schema
 	origDB := DB
+	origDBRead := DBRead
 	db := setupExecTaskDB(t)
 	DB = db
-	defer func() { DB = origDB }()
+	DBRead = db // Same instance for :memory: SQLite — data is shared
+	defer func() { DB = origDB; DBRead = origDBRead }()
 
 	// Set up ws manager to capture events
 	mgr := ws.NewManagerForTest(nil)

--- a/internal/service/uuid_test.go
+++ b/internal/service/uuid_test.go
@@ -37,9 +37,12 @@ func setupUUIDTestDB(t *testing.T) *sql.DB {
 		t.Fatalf("failed to create tables: %v", err)
 	}
 	origDB := DB
+	origDBRead := DBRead
 	DB = db
+	DBRead = db // Same instance for :memory: SQLite — data is shared
 	t.Cleanup(func() {
 		DB = origDB
+		DBRead = origDBRead
 		db.Close()
 	})
 	return db

--- a/web/src/composables/__tests__/useChatSession.test.ts
+++ b/web/src/composables/__tests__/useChatSession.test.ts
@@ -2154,3 +2154,144 @@ describe('syncModelFromData', () => {
     expect(mockIdentity.currentModelName).toBe('Default Model')
   })
 })
+
+describe('loadMoreMessages', () => {
+  let originalFetch: typeof globalThis.fetch
+
+  beforeEach(() => {
+    resetMockState()
+    resetAdditionalMocks()
+    originalFetch = globalThis.fetch
+  })
+
+  afterEach(() => {
+    globalThis.fetch = originalFetch
+  })
+
+  it('fetches older messages using before_id cursor from oldest message id', async () => {
+    // First: loadHistory to populate messages and totalMessages
+    const initialMsgs = [
+      { id: 50, role: 'user', content: 'hello' },
+      { id: 51, role: 'assistant', content: 'hi' },
+    ]
+    const olderMsgs = [
+      { id: 42, role: 'user', content: 'older' },
+      { id: 43, role: 'assistant', content: 'older reply' },
+    ]
+
+    // First fetch: loadHistory
+    // Second fetch: loadMoreMessages
+    mockUtilsFns.parseMessages
+      .mockReturnValueOnce(initialMsgs)
+      .mockReturnValueOnce(olderMsgs)
+
+    globalThis.fetch = vi.fn()
+      .mockResolvedValueOnce({
+        ok: true,
+        json: () => Promise.resolve({
+          sessionId: 'current-s1',
+          messages: [{ id: 50 }, { id: 51 }],
+          total: 100, // more than 2 → hasMore=true
+          running: false,
+        }),
+      })
+      .mockResolvedValueOnce({
+        ok: true,
+        json: () => Promise.resolve({
+          messages: [{ id: 42 }, { id: 43 }],
+          total: 100,
+        }),
+      })
+
+    const options = {
+      currentSessionId: ref('current-s1'),
+      messages: ref([]),
+      loading: ref(false),
+      inputDisabled: ref(false),
+      blockTasks: {},
+      blockAskQuestions: {},
+      expandedTools: ref({}),
+      onParseAssistantContent: vi.fn(),
+      onExtractScheduledTasks: vi.fn(),
+      onRenderUpdate: vi.fn(),
+      onScrollBottom: vi.fn(),
+      onConnectStream: vi.fn(),
+      onStopPolling: vi.fn(),
+      onDisconnectStream: vi.fn(),
+      onOpen: vi.fn(),
+    }
+    const session = useChatSession(options)
+
+    // Load initial messages
+    await session.loadHistory(true, false, false)
+    expect(options.messages.value.length).toBe(2)
+
+    // Load more (older) messages
+    await session.loadMoreMessages()
+
+    // Should use before_id=50 (oldest message id) in the fetch URL
+    const secondCallUrl = (globalThis.fetch as ReturnType<typeof vi.fn>).mock.calls[1]?.[0] as string
+    expect(secondCallUrl).toContain('before_id=50')
+    expect(secondCallUrl).toContain('limit=20')
+
+    // Older messages should be prepended
+    expect(options.messages.value.length).toBe(4)
+    expect(options.messages.value[0].id).toBe(42)
+  })
+
+  it('skips when loadingMore is already true', async () => {
+    globalThis.fetch = vi.fn()
+
+    const options = {
+      currentSessionId: ref('current-s1'),
+      messages: ref([{ id: 1, role: 'user' }]),
+      loading: ref(false),
+      inputDisabled: ref(false),
+      blockTasks: {},
+      blockAskQuestions: {},
+      expandedTools: ref({}),
+      onParseAssistantContent: vi.fn(),
+      onExtractScheduledTasks: vi.fn(),
+      onRenderUpdate: vi.fn(),
+      onScrollBottom: vi.fn(),
+      onConnectStream: vi.fn(),
+      onStopPolling: vi.fn(),
+      onDisconnectStream: vi.fn(),
+      onOpen: vi.fn(),
+    }
+    const session = useChatSession(options)
+    session.loadingMore.value = true
+
+    await session.loadMoreMessages()
+
+    expect(globalThis.fetch).not.toHaveBeenCalled()
+  })
+
+  it('skips when hasMore is false', async () => {
+    globalThis.fetch = vi.fn()
+
+    const options = {
+      currentSessionId: ref('current-s1'),
+      messages: ref([{ id: 1, role: 'user' }]),
+      loading: ref(false),
+      inputDisabled: ref(false),
+      blockTasks: {},
+      blockAskQuestions: {},
+      expandedTools: ref({}),
+      onParseAssistantContent: vi.fn(),
+      onExtractScheduledTasks: vi.fn(),
+      onRenderUpdate: vi.fn(),
+      onScrollBottom: vi.fn(),
+      onConnectStream: vi.fn(),
+      onStopPolling: vi.fn(),
+      onDisconnectStream: vi.fn(),
+      onOpen: vi.fn(),
+    }
+    const session = useChatSession(options)
+    session.hasMore.value = false
+
+    await session.loadMoreMessages()
+
+    expect(globalThis.fetch).not.toHaveBeenCalled()
+  })
+})

--- a/web/src/composables/useChatSession.ts
+++ b/web/src/composables/useChatSession.ts
@@ -229,10 +229,10 @@ export function useChatSession(options: UseChatSessionOptions) {
     loadingMore.value = true
     try {
       const pageSize = store.state.chatPageSize
-      // Use cursor-based pagination: pass the created_at of the oldest loaded message
+      // Use cursor-based pagination: pass the id of the oldest loaded message
       const oldestMsg = messages.value[0]
-      const before = oldestMsg?.createdAt || ''
-      const resp = await fetch(`/api/ai/chat?session_id=${encodeURIComponent(currentSessionId.value)}&limit=${pageSize}&before=${encodeURIComponent(before)}`)
+      const beforeId = oldestMsg?.id || ''
+      const resp = await fetch(`/api/ai/chat?session_id=${encodeURIComponent(currentSessionId.value)}&limit=${pageSize}&before_id=${encodeURIComponent(beforeId)}`)
       if (!resp.ok) return
       const data = await resp.json()
       const olderMsgs = parseMessages(data.messages || [], onParseAssistantContent)


### PR DESCRIPTION
## 性能优化 P0+P1+P2

### 问题分析
314MB SQLite 数据库，`MaxOpenConns(1)` 串行化所有查询，缺少覆盖索引，导致 P95/P99 飙升到 30-60s。

### P0 — 读写分离 (核心修复)
- `DB` (MaxOpenConns=1, 写) + `DBRead` (MaxOpenConns=2, 读) 双连接池
- 所有 service 层读查询迁移到 `DBRead`，写操作仍用 `DB`
- WAL 模式 + `busy_timeout=5000` 确保并发安全

### P1 — 查询优化
- 新增覆盖索引 `idx_history_session_id ON chat_history(session_id, deleted, role, streaming, created_at)`
- 新增索引 `idx_tasks_project ON scheduled_tasks(project_path, created_at DESC)`
- `GetLatestSessionID()` 替代 `GetSessions()` 做 lightweight 查找
- `GetSessionInfo()` 合并 5 次 metadata 查询为 1 次
- `GetSessions` unread 子查询增加 `project_path` 过滤
- `hasUnread` 从已获取的 tasks 列表内存推导，去掉冗余 `HasUnreadTasks` 查询
- `git verify-commits` 从 2N+1 个串行 git 进程改为单次 `git log --no-walk=sorted --ignore-missing`

### P2 — 鲁棒性
- `GetLatestSessionID` 区分 `sql.ErrNoRows` vs 真实错误
- `DeleteTaskExecution` 用条件 `DELETE WHERE status != 'running'` 消除 TOCTOU
- `ServeVerifyCommits` 缩写 SHA → 完整 SHA 的 key 映射
- `CloseDB()` 双连接池关闭 + nil 安全
- `defer service.CloseDB()` 加到 main

### 测试
- 16 packages 全部通过
- Diff coverage: 96.0% (≥80% gate)
- 覆盖索引存在性、读写分离、handler 错误路径等均有专门测试

### 文件变更 (19 files, +857 -111)
| 文件 | 变更说明 |
|------|---------|
| `internal/service/database.go` | DBRead 初始化 + 两个覆盖索引 |
| `internal/service/chat.go` | 读查询迁移 + GetLatestSessionID/GetSessionInfo |
| `internal/service/scheduler.go` | 读查询迁移 + TOCTOU 修复 |
| `internal/handler/chat.go` | GetLatestSessionID + GetSessionInfo 集成 |
| `internal/handler/git.go` | 批量 git verify-commits |
| `internal/handler/scheduler.go` | 内存 hasUnread 推导 |
| `cmd/server/main.go` | defer CloseDB() |
