### PR TITLE
fix: SSE 重连逻辑与 Cookie Secure 标志修复

### DIFF
--- a/internal/handler/auth.go
+++ b/internal/handler/auth.go
@@ -194,6 +194,7 @@ func ServeLogin(w http.ResponseWriter, r *http.Request) {
 				Value:    sessionToken,
 				Path:     "/",
 				HttpOnly: true,
+				Secure:   r.TLS != nil,
 				MaxAge:   int(7 * 24 * 3600),
 				SameSite: http.SameSiteLaxMode,
 			})

--- a/internal/handler/project.go
+++ b/internal/handler/project.go
@@ -87,6 +87,7 @@ func ServeProjectSet(w http.ResponseWriter, r *http.Request) {
 				Path:     "/",
 				MaxAge:   7 * 24 * 3600,
 				HttpOnly: true,
+				Secure:   r.TLS != nil,
 				SameSite: http.SameSiteLaxMode,
 			})
 		}
@@ -148,6 +149,7 @@ func ServeProjectSet(w http.ResponseWriter, r *http.Request) {
 			Path:     "/",
 			MaxAge:   7 * 24 * 3600,
 			HttpOnly: true,
+			Secure:   r.TLS != nil,
 			SameSite: http.SameSiteLaxMode,
 		})
 		w.Header().Set("Content-Type", "application/json")

--- a/web/src/composables/useChatStream.ts
+++ b/web/src/composables/useChatStream.ts
@@ -58,9 +58,9 @@ export function useChatStream(options: UseChatStreamOptions) {
   const TOOL_USE_TIMEOUT_MS = 30000 // 30 seconds without 'done' event = mark as done
 
   const reconnect = useReconnect({
-    maxAttempts: 1,
+    maxAttempts: 3,
     baseDelay: 2000,
-    onReconnect: () => connectStream(currentSessionId.value),
+    onReconnect: () => connectStream(currentSessionId.value, true),
   })
 
   function debouncedRender() {
@@ -135,7 +135,7 @@ export function useChatStream(options: UseChatStreamOptions) {
     const MAX_JSON_PARSE_FAILURES = 5
     pollingInterval = setInterval(async () => {
       try {
-        const resp = await fetch(`/api/ai/chat?session_id=${encodeURIComponent(currentSessionId.value)}`)
+        const resp = await fetch(`/api/ai/chat?session_id=${encodeURIComponent(currentSessionId.value)}`, { credentials: 'same-origin' })
         if (!resp.ok) {
           throw new Error(`HTTP ${resp.status}`)
         }
@@ -216,10 +216,15 @@ export function useChatStream(options: UseChatStreamOptions) {
     }, 2000)
   }
 
-  function connectStream(sessionId: string) {
+  function connectStream(sessionId: string, isRetry = false) {
     disconnectStream()
     stopPolling()
-    reconnect.reset()
+    // Only reset reconnect state for fresh/intentional connections (user action,
+    // foreground return, network recovery). Do NOT reset for automatic reconnection
+    // attempts — that would clear reconnectAttempts, making maxAttempts useless.
+    if (!isRetry) {
+      reconnect.reset()
+    }
 
     // Find existing streaming message or create a new one
     let streamingMsg = messages.value.find(m => m.role === 'assistant' && m.streaming)
@@ -250,7 +255,7 @@ export function useChatStream(options: UseChatStreamOptions) {
       return true
     }
 
-    eventSource = new EventSource(`/api/ai/chat/stream?session_id=${encodeURIComponent(sessionId)}`)
+    eventSource = new EventSource(`/api/ai/chat/stream?session_id=${encodeURIComponent(sessionId)}`, { withCredentials: true })
 
     // Start stream timeout
     resetStreamTimeout()
@@ -377,6 +382,7 @@ export function useChatStream(options: UseChatStreamOptions) {
       if (streamTimeout) { clearTimeout(streamTimeout); streamTimeout = null }
       clearToolUseTimeouts()
       disconnectStream()
+      reconnect.reset() // Stream completed — reset reconnect state for future sessions
       // Reload from DB to ensure complete content — SSE events may have been
       // dropped during transmission, so the local state may be incomplete.
       onLoadHistory().finally(() => {
@@ -523,6 +529,7 @@ export function useChatStream(options: UseChatStreamOptions) {
         reconnect.scheduleReconnect()
       } else {
         // Too many attempts or session inactive — fall back to polling
+        reconnect.reset() // Clear reconnect state before falling back to polling
         forceCleanupStreamingState()
         pollUntilDone()
       }
@@ -554,7 +561,7 @@ export function useChatStream(options: UseChatStreamOptions) {
     if (eventSource) {
       console.info('Network recovered, reconnecting SSE stream')
       disconnectStream()
-      reconnect.reset()
+      // connectStream with isRetry=false will reset reconnect state
       connectStream(currentSessionId.value)
     }
   }


### PR DESCRIPTION
## 问题描述

在 HTTPS 环境下（尤其是移动端 Safari），聊天流频繁出现「服务重启/AI 响应中断」错误，导致用户无法正常接收 AI 回复。

## 修改内容

### 1. Cookie Secure 标志（后端）

- `internal/handler/auth.go`：为 `clawbench_session` Cookie 添加 `Secure: r.TLS != nil`
- `internal/handler/project.go`：为两处 `clawbench_project` Cookie 添加 `Secure: r.TLS != nil`

在 HTTPS 下，浏览器不会发送没有 `Secure` 标志的 Cookie（或根据 SameSite 策略严格限制），导致 SSE/WebSocket 请求鉴权失败。

### 2. SSE 重连逻辑修复（前端）

**根本原因**：`connectStream()` 每次被调用时都会执行 `reconnect.reset()`，清除 `reconnectAttempts` 计数器。这导致 `maxAttempts` 配置形同虚设——每次重连都从 0 重新计数，永远无法达到上限。

- `web/src/composables/useChatStream.ts`：
  - 添加 `isRetry` 参数区分主动连接与自动重连，仅在非重连时执行 `reset()`
  - 将 `maxAttempts` 从 `1` 增加到 `3`，允许更多重连尝试
  - `onReconnect` 回调传入 `isRetry: true`
  - `done` 事件后 `reset()` 重连状态，为未来会话做准备
  - 回退到 polling 前 `reset()` 清理状态
  - 网络恢复时由 `connectStream(isRetry=false)` 负责重置

### 3. EventSource 凭据传递

- 为 EventSource 添加 `withCredentials: true`，确保 Cookie 随 SSE 请求发送
- 为 polling 回退的 `fetch` 调用添加 `credentials: 'same-origin'`

## 测试

- 在 HTTPS 环境下通过 iPhone（WiFi + 5G）测试聊天流
- 验证 Cookie 在 SSE 连接中正确传递
- 验证网络短暂中断后 SSE 自动重连成功
- 验证多次重连失败后正确回退到 polling 模式

Closes #61