### PR TITLE
fix: push notification alert uses text after last tool_use block

### DIFF
--- a/internal/service/session_runtime.go
+++ b/internal/service/session_runtime.go
@@ -65,7 +65,10 @@ func EmitSessionEvent(sessionID, status string, hasNewMessages bool) {
 	})
 }
 
-// getSessionResponsePreview returns the first responsePreviewMaxRunes runes of the AI's final reply text.
+// getSessionResponsePreview returns a preview of the AI's final reply text.
+// It extracts text from after the last tool_use block in the last assistant
+// message, since the final text block(s) contain the AI's actual answer
+// rather than intermediate reasoning or tool-call commentary.
 func getSessionResponsePreview(sessionID string) string {
 	messages, err := GetMessagesBySessionID(sessionID)
 	if err != nil {
@@ -83,8 +86,16 @@ func getSessionResponsePreview(sessionID string) string {
 		if err := json.Unmarshal([]byte(messages[i].Content), &content); err != nil {
 			continue
 		}
-		// Extract text from text-type blocks
-		for _, b := range content.Blocks {
+		// Find the last tool_use block index to skip intermediate text
+		lastToolIdx := -1
+		for j, b := range content.Blocks {
+			if b.Type == "tool_use" {
+				lastToolIdx = j
+			}
+		}
+		// Extract text from blocks after the last tool_use
+		for j := lastToolIdx + 1; j < len(content.Blocks); j++ {
+			b := content.Blocks[j]
 			if b.Type == "text" && b.Text != "" {
 				if utf8.RuneCountInString(b.Text) > responsePreviewMaxRunes {
 					return string([]rune(b.Text)[:responsePreviewMaxRunes]) + "…"

--- a/internal/service/session_runtime_test.go
+++ b/internal/service/session_runtime_test.go
@@ -531,9 +531,11 @@ func TestGetSessionResponsePreview_SkipsToolUseBlocks(t *testing.T) {
 
 func TestGetSessionResponsePreview_PrefersTextAfterLastToolUse(t *testing.T) {
 	origDB := DB
+	origDBRead := DBRead
 	db := setupChatTestDB(t)
 	DB = db
-	defer func() { DB = origDB }()
+	DBRead = db // Same instance for :memory: SQLite — data is shared
+	defer func() { DB = origDB; DBRead = origDBRead }()
 
 	// Scenario: [text("Reading file..."), tool_use, text("Here is the analysis")]
 	// The preview should return "Here is the analysis", not "Reading file..."
@@ -551,9 +553,11 @@ func TestGetSessionResponsePreview_PrefersTextAfterLastToolUse(t *testing.T) {
 
 func TestGetSessionResponsePreview_MultipleToolUses(t *testing.T) {
 	origDB := DB
+	origDBRead := DBRead
 	db := setupChatTestDB(t)
 	DB = db
-	defer func() { DB = origDB }()
+	DBRead = db // Same instance for :memory: SQLite — data is shared
+	defer func() { DB = origDB; DBRead = origDBRead }()
 
 	// Scenario: [tool_use, text("intermediate"), tool_use, text("final answer")]
 	// Should return "final answer" — text after the LAST tool_use
@@ -572,9 +576,11 @@ func TestGetSessionResponsePreview_MultipleToolUses(t *testing.T) {
 
 func TestGetSessionResponsePreview_OnlyToolUses(t *testing.T) {
 	origDB := DB
+	origDBRead := DBRead
 	db := setupChatTestDB(t)
 	DB = db
-	defer func() { DB = origDB }()
+	DBRead = db // Same instance for :memory: SQLite — data is shared
+	defer func() { DB = origDB; DBRead = origDBRead }()
 
 	// Only tool_use blocks, no text after — should return empty
 	tool1 := model.ContentBlock{Type: "tool_use", Name: "Read", ID: "tool-1"}
@@ -590,9 +596,11 @@ func TestGetSessionResponsePreview_OnlyToolUses(t *testing.T) {
 
 func TestGetSessionResponsePreview_TextBeforeToolOnly(t *testing.T) {
 	origDB := DB
+	origDBRead := DBRead
 	db := setupChatTestDB(t)
 	DB = db
-	defer func() { DB = origDB }()
+	DBRead = db // Same instance for :memory: SQLite — data is shared
+	defer func() { DB = origDB; DBRead = origDBRead }()
 
 	// [text("thinking..."), tool_use] — no text AFTER tool_use, should return empty
 	textBlock := model.ContentBlock{Type: "text", Text: "让我思考一下"}
@@ -610,9 +618,11 @@ func TestGetSessionResponsePreview_TextBeforeToolOnly(t *testing.T) {
 
 func TestGetSessionResponsePreview_RealData_TextThenToolThenSummary(t *testing.T) {
 	origDB := DB
+	origDBRead := DBRead
 	db := setupChatTestDB(t)
 	DB = db
-	defer func() { DB = origDB }()
+	DBRead = db // Same instance for :memory: SQLite — data is shared
+	defer func() { DB = origDB; DBRead = origDBRead }()
 
 	// Real pattern from session 93c986e1, message id=1063:
 	//   [thinking, text("方案一已经在上一轮实现了。验证一下当前状态："), tool_use(Bash), tool_use(Bash), text("方案一已在 commit b4d7b73 中实现完毕...")]
@@ -635,9 +645,11 @@ func TestGetSessionResponsePreview_RealData_TextThenToolThenSummary(t *testing.T
 
 func TestGetSessionResponsePreview_RealData_ToolThenWorktreeReport(t *testing.T) {
 	origDB := DB
+	origDBRead := DBRead
 	db := setupChatTestDB(t)
 	DB = db
-	defer func() { DB = origDB }()
+	DBRead = db // Same instance for :memory: SQLite — data is shared
+	defer func() { DB = origDB; DBRead = origDBRead }()
 
 	// Real pattern from session dd1968cf, message id=1059:
 	//   [thinking, tool_use(Bash), text("Worktree 已创建：\n\n- **路径**: `/root/code/clawbench/.worktrees/fix-push-summary-55`...")]
@@ -662,9 +674,11 @@ func TestGetSessionResponsePreview_RealData_ToolThenWorktreeReport(t *testing.T)
 
 func TestGetSessionResponsePreview_RealData_MultiToolInterleavedWithText(t *testing.T) {
 	origDB := DB
+	origDBRead := DBRead
 	db := setupChatTestDB(t)
 	DB = db
-	defer func() { DB = origDB }()
+	DBRead = db // Same instance for :memory: SQLite — data is shared
+	defer func() { DB = origDB; DBRead = origDBRead }()
 
 	// Real pattern from session da4003a0, message id=1047:
 	//   [thinking, tool_use(Bash), text("有问题！..."), tool_use(Bash), tool_use(Bash),
@@ -694,9 +708,11 @@ func TestGetSessionResponsePreview_RealData_MultiToolInterleavedWithText(t *test
 
 func TestGetSessionResponsePreview_RealData_ThinkingThenToolThenIssueLink(t *testing.T) {
 	origDB := DB
+	origDBRead := DBRead
 	db := setupChatTestDB(t)
 	DB = db
-	defer func() { DB = origDB }()
+	DBRead = db // Same instance for :memory: SQLite — data is shared
+	defer func() { DB = origDB; DBRead = origDBRead }()
 
 	// Real pattern from session bb92e480, message id=1039:
 	//   [thinking, tool_use(Bash), text("已创建 Issue: https://github.com/xulongzhe/clawbench/issues/55")]
@@ -716,9 +732,11 @@ func TestGetSessionResponsePreview_RealData_ThinkingThenToolThenIssueLink(t *tes
 
 func TestGetSessionResponsePreview_RealData_ThreeToolsThenWorktreeReport(t *testing.T) {
 	origDB := DB
+	origDBRead := DBRead
 	db := setupChatTestDB(t)
 	DB = db
-	defer func() { DB = origDB }()
+	DBRead = db // Same instance for :memory: SQLite — data is shared
+	defer func() { DB = origDB; DBRead = origDBRead }()
 
 	// Real pattern from session bb92e480, message id=1055:
 	//   [thinking, tool_use(Bash), tool_use(Bash), tool_use(Bash), text("Worktree 已创建：...")]
@@ -742,9 +760,11 @@ func TestGetSessionResponsePreview_RealData_ThreeToolsThenWorktreeReport(t *test
 
 func TestGetSessionResponsePreview_RealData_PureTextSummary(t *testing.T) {
 	origDB := DB
+	origDBRead := DBRead
 	db := setupChatTestDB(t)
 	DB = db
-	defer func() { DB = origDB }()
+	DBRead = db // Same instance for :memory: SQLite — data is shared
+	defer func() { DB = origDB; DBRead = origDBRead }()
 
 	// Real pattern from session id=726 (no tool_use at all):
 	//   [text("好的。后台耗电优化到此为止，总结已完成的改动：\n\n1. **webView.onPause()**...")]

--- a/internal/service/session_runtime_test.go
+++ b/internal/service/session_runtime_test.go
@@ -529,6 +529,83 @@ func TestGetSessionResponsePreview_SkipsToolUseBlocks(t *testing.T) {
 	assert.Equal(t, "工具执行后的文本", result)
 }
 
+func TestGetSessionResponsePreview_PrefersTextAfterLastToolUse(t *testing.T) {
+	origDB := DB
+	db := setupChatTestDB(t)
+	DB = db
+	defer func() { DB = origDB }()
+
+	// Scenario: [text("Reading file..."), tool_use, text("Here is the analysis")]
+	// The preview should return "Here is the analysis", not "Reading file..."
+	textBeforeTool := model.ContentBlock{Type: "text", Text: "正在读取文件…"}
+	toolBlock := model.ContentBlock{Type: "tool_use", Name: "Read", ID: "tool-1"}
+	textAfterTool := model.ContentBlock{Type: "text", Text: "这是最终的分析结果"}
+	blocks := map[string]any{"blocks": []model.ContentBlock{textBeforeTool, toolBlock, textAfterTool}}
+	contentJSON, _ := json.Marshal(blocks)
+	insertTestMessage(t, db, "session-preview-after-tool", "user", "分析代码")
+	insertTestMessage(t, db, "session-preview-after-tool", "assistant", string(contentJSON))
+
+	result := getSessionResponsePreview("session-preview-after-tool")
+	assert.Equal(t, "这是最终的分析结果", result)
+}
+
+func TestGetSessionResponsePreview_MultipleToolUses(t *testing.T) {
+	origDB := DB
+	db := setupChatTestDB(t)
+	DB = db
+	defer func() { DB = origDB }()
+
+	// Scenario: [tool_use, text("intermediate"), tool_use, text("final answer")]
+	// Should return "final answer" — text after the LAST tool_use
+	tool1 := model.ContentBlock{Type: "tool_use", Name: "Read", ID: "tool-1"}
+	textMiddle := model.ContentBlock{Type: "text", Text: "中间结果"}
+	tool2 := model.ContentBlock{Type: "tool_use", Name: "Grep", ID: "tool-2"}
+	textFinal := model.ContentBlock{Type: "text", Text: "最终结论"}
+	blocks := map[string]any{"blocks": []model.ContentBlock{tool1, textMiddle, tool2, textFinal}}
+	contentJSON, _ := json.Marshal(blocks)
+	insertTestMessage(t, db, "session-preview-multi-tool", "user", "搜索代码")
+	insertTestMessage(t, db, "session-preview-multi-tool", "assistant", string(contentJSON))
+
+	result := getSessionResponsePreview("session-preview-multi-tool")
+	assert.Equal(t, "最终结论", result)
+}
+
+func TestGetSessionResponsePreview_OnlyToolUses(t *testing.T) {
+	origDB := DB
+	db := setupChatTestDB(t)
+	DB = db
+	defer func() { DB = origDB }()
+
+	// Only tool_use blocks, no text after — should return empty
+	tool1 := model.ContentBlock{Type: "tool_use", Name: "Read", ID: "tool-1"}
+	tool2 := model.ContentBlock{Type: "tool_use", Name: "Grep", ID: "tool-2"}
+	blocks := map[string]any{"blocks": []model.ContentBlock{tool1, tool2}}
+	contentJSON, _ := json.Marshal(blocks)
+	insertTestMessage(t, db, "session-preview-only-tools", "user", "搜索代码")
+	insertTestMessage(t, db, "session-preview-only-tools", "assistant", string(contentJSON))
+
+	result := getSessionResponsePreview("session-preview-only-tools")
+	assert.Equal(t, "", result)
+}
+
+func TestGetSessionResponsePreview_TextBeforeToolOnly(t *testing.T) {
+	origDB := DB
+	db := setupChatTestDB(t)
+	DB = db
+	defer func() { DB = origDB }()
+
+	// [text("thinking..."), tool_use] — no text AFTER tool_use, should return empty
+	textBlock := model.ContentBlock{Type: "text", Text: "让我思考一下"}
+	toolBlock := model.ContentBlock{Type: "tool_use", Name: "Read", ID: "tool-1"}
+	blocks := map[string]any{"blocks": []model.ContentBlock{textBlock, toolBlock}}
+	contentJSON, _ := json.Marshal(blocks)
+	insertTestMessage(t, db, "session-preview-text-before-tool", "user", "分析代码")
+	insertTestMessage(t, db, "session-preview-text-before-tool", "assistant", string(contentJSON))
+
+	result := getSessionResponsePreview("session-preview-text-before-tool")
+	assert.Equal(t, "", result)
+}
+
 func TestGetSessionResponsePreview_UsesLastAssistantMessage(t *testing.T) {
 	origDB := DB
 	origDBRead := DBRead

--- a/internal/service/session_runtime_test.go
+++ b/internal/service/session_runtime_test.go
@@ -606,6 +606,162 @@ func TestGetSessionResponsePreview_TextBeforeToolOnly(t *testing.T) {
 	assert.Equal(t, "", result)
 }
 
+// --- Real-data based tests (extracted from ClawBench production database) ---
+
+func TestGetSessionResponsePreview_RealData_TextThenToolThenSummary(t *testing.T) {
+	origDB := DB
+	db := setupChatTestDB(t)
+	DB = db
+	defer func() { DB = origDB }()
+
+	// Real pattern from session 93c986e1, message id=1063:
+	//   [thinking, text("方案一已经在上一轮实现了。验证一下当前状态："), tool_use(Bash), tool_use(Bash), text("方案一已在 commit b4d7b73 中实现完毕...")]
+	// Before fix: would return "方案一已经在上一轮实现了..." (intermediate commentary)
+	// After fix: should return "方案一已在 commit b4d7b73 中实现完毕..." (final answer)
+	blocks := []model.ContentBlock{
+		{Type: "thinking", Text: "Let me verify the current state of the implementation."},
+		{Type: "text", Text: "方案一已经在上一轮实现了。验证一下当前状态："},
+		{Type: "tool_use", Name: "Bash", ID: "tool-verify-1"},
+		{Type: "tool_use", Name: "Bash", ID: "tool-verify-2"},
+		{Type: "text", Text: "方案一已在 commit `b4d7b73` 中实现完毕，全部 14 个测试通过。"},
+	}
+	contentJSON, _ := json.Marshal(map[string]any{"blocks": blocks})
+	insertTestMessage(t, db, "session-real-text-tool-summary", "user", "实现方案一")
+	insertTestMessage(t, db, "session-real-text-tool-summary", "assistant", string(contentJSON))
+
+	result := getSessionResponsePreview("session-real-text-tool-summary")
+	assert.Equal(t, "方案一已在 commit `b4d7b73` 中实现完毕，全部 14 个测试通过。", result)
+}
+
+func TestGetSessionResponsePreview_RealData_ToolThenWorktreeReport(t *testing.T) {
+	origDB := DB
+	db := setupChatTestDB(t)
+	DB = db
+	defer func() { DB = origDB }()
+
+	// Real pattern from session dd1968cf, message id=1059:
+	//   [thinking, tool_use(Bash), text("Worktree 已创建：\n\n- **路径**: `/root/code/clawbench/.worktrees/fix-push-summary-55`...")]
+	// Simple case: tool then final answer text — should return the text
+	finalText := "Worktree 已创建：\n\n- **路径**: `/root/code/clawbench/.worktrees/fix-push-summary-55`\n- **分支**: `fix/push-summary-55`"
+	blocks := []model.ContentBlock{
+		{Type: "thinking", Text: "I'll create a worktree for this fix."},
+		{Type: "tool_use", Name: "Bash", ID: "tool-worktree"},
+		{Type: "text", Text: finalText},
+	}
+	contentJSON, _ := json.Marshal(map[string]any{"blocks": blocks})
+	insertTestMessage(t, db, "session-real-tool-worktree", "user", "创建worktree")
+	insertTestMessage(t, db, "session-real-tool-worktree", "assistant", string(contentJSON))
+
+	result := getSessionResponsePreview("session-real-tool-worktree")
+	// Should start with the final answer, not with thinking or tool output
+	assert.Contains(t, result, "Worktree 已创建")
+	// Verify truncation kicks in (finalText is 110 runes, exceeds responsePreviewMaxRunes=64)
+	assert.True(t, utf8.RuneCountInString(result) <= responsePreviewMaxRunes+1, "result should be truncated")
+	assert.True(t, strings.HasSuffix(result, "…"), "truncated result should end with ellipsis")
+}
+
+func TestGetSessionResponsePreview_RealData_MultiToolInterleavedWithText(t *testing.T) {
+	origDB := DB
+	db := setupChatTestDB(t)
+	DB = db
+	defer func() { DB = origDB }()
+
+	// Real pattern from session da4003a0, message id=1047:
+	//   [thinking, tool_use(Bash), text("有问题！..."), tool_use(Bash), tool_use(Bash),
+	//    text("确认问题：..."), tool_use(Bash), text("两个文件..."), tool_use(Bash),
+	//    tool_use(Bash), text("等等..."), tool_use(Bash), text("现在删除..."),
+	//    tool_use(Bash), tool_use(Bash), text("最后验证..."), tool_use(Bash),
+	//    tool_use(Bash), text("清理完成！总结一下做了什么：...")]
+	// 18 blocks total — should return the LAST text after the LAST tool_use
+	blocks := []model.ContentBlock{
+		{Type: "thinking", Text: "Let me investigate the root directory."},
+		{Type: "tool_use", Name: "Bash", ID: "tool-ls"},
+		{Type: "text", Text: "有问题！`/root/code/` 根目录下出现了不该有的文件。"},
+		{Type: "tool_use", Name: "Bash", ID: "tool-check-1"},
+		{Type: "tool_use", Name: "Bash", ID: "tool-check-2"},
+		{Type: "text", Text: "确认问题：这是某个子 Agent 误执行了 pnpm 命令。"},
+		{Type: "tool_use", Name: "Bash", ID: "tool-rm"},
+		{Type: "text", Text: "清理完成！总结一下做了什么：\n\n### 清理操作\n\n1. **删除了根目录误创建的文件**"},
+	}
+	contentJSON, _ := json.Marshal(map[string]any{"blocks": blocks})
+	insertTestMessage(t, db, "session-real-multi-interleaved", "user", "检查根目录")
+	insertTestMessage(t, db, "session-real-multi-interleaved", "assistant", string(contentJSON))
+
+	result := getSessionResponsePreview("session-real-multi-interleaved")
+	// Should return text after last tool_use (tool-rm), not the earlier texts
+	assert.Equal(t, "清理完成！总结一下做了什么：\n\n### 清理操作\n\n1. **删除了根目录误创建的文件**", result)
+}
+
+func TestGetSessionResponsePreview_RealData_ThinkingThenToolThenIssueLink(t *testing.T) {
+	origDB := DB
+	db := setupChatTestDB(t)
+	DB = db
+	defer func() { DB = origDB }()
+
+	// Real pattern from session bb92e480, message id=1039:
+	//   [thinking, tool_use(Bash), text("已创建 Issue: https://github.com/xulongzhe/clawbench/issues/55")]
+	// Short final text — perfect for push notification
+	blocks := []model.ContentBlock{
+		{Type: "thinking", Text: "I should create a GitHub issue for this bug."},
+		{Type: "tool_use", Name: "Bash", ID: "tool-gh-issue"},
+		{Type: "text", Text: "已创建 Issue: https://github.com/xulongzhe/clawbench/issues/55"},
+	}
+	contentJSON, _ := json.Marshal(map[string]any{"blocks": blocks})
+	insertTestMessage(t, db, "session-real-issue-link", "user", "创建Issue")
+	insertTestMessage(t, db, "session-real-issue-link", "assistant", string(contentJSON))
+
+	result := getSessionResponsePreview("session-real-issue-link")
+	assert.Equal(t, "已创建 Issue: https://github.com/xulongzhe/clawbench/issues/55", result)
+}
+
+func TestGetSessionResponsePreview_RealData_ThreeToolsThenWorktreeReport(t *testing.T) {
+	origDB := DB
+	db := setupChatTestDB(t)
+	DB = db
+	defer func() { DB = origDB }()
+
+	// Real pattern from session bb92e480, message id=1055:
+	//   [thinking, tool_use(Bash), tool_use(Bash), tool_use(Bash), text("Worktree 已创建：...")]
+	// Multiple consecutive tool_use blocks, then final text
+	finalText := "Worktree 已创建：\n\n- **路径**: `/root/code/clawbench/.worktrees/fix-jpush-init-timing`"
+	blocks := []model.ContentBlock{
+		{Type: "thinking", Text: "I need to create a worktree for the JPush fix."},
+		{Type: "tool_use", Name: "Bash", ID: "tool-fetch"},
+		{Type: "tool_use", Name: "Bash", ID: "tool-branch"},
+		{Type: "tool_use", Name: "Bash", ID: "tool-worktree"},
+		{Type: "text", Text: finalText},
+	}
+	contentJSON, _ := json.Marshal(map[string]any{"blocks": blocks})
+	insertTestMessage(t, db, "session-real-three-tools", "user", "创建worktree")
+	insertTestMessage(t, db, "session-real-three-tools", "assistant", string(contentJSON))
+
+	result := getSessionResponsePreview("session-real-three-tools")
+	assert.Contains(t, result, "Worktree 已创建")
+	assert.True(t, utf8.RuneCountInString(result) <= responsePreviewMaxRunes+1, "result should be truncated")
+}
+
+func TestGetSessionResponsePreview_RealData_PureTextSummary(t *testing.T) {
+	origDB := DB
+	db := setupChatTestDB(t)
+	DB = db
+	defer func() { DB = origDB }()
+
+	// Real pattern from session id=726 (no tool_use at all):
+	//   [text("好的。后台耗电优化到此为止，总结已完成的改动：\n\n1. **webView.onPause()**...")]
+	// Pure text response — should return as-is (lastToolIdx=-1, scan from start)
+	finalText := "好的。后台耗电优化到此为止，总结已完成的改动：\n\n1. **`webView.onPause()`** — 后台停止渲染管线，释放 CPU/GPU\n2. **`webView.pauseTimers()`** — 强制停止所有 JS 定时器"
+	blocks := []model.ContentBlock{
+		{Type: "text", Text: finalText},
+	}
+	contentJSON, _ := json.Marshal(map[string]any{"blocks": blocks})
+	insertTestMessage(t, db, "session-real-pure-text", "user", "还有其他优化吗")
+	insertTestMessage(t, db, "session-real-pure-text", "assistant", string(contentJSON))
+
+	result := getSessionResponsePreview("session-real-pure-text")
+	assert.Contains(t, result, "后台耗电优化到此为止")
+	assert.True(t, utf8.RuneCountInString(result) <= responsePreviewMaxRunes+1, "result should be truncated")
+}
+
 func TestGetSessionResponsePreview_UsesLastAssistantMessage(t *testing.T) {
 	origDB := DB
 	origDBRead := DBRead

--- a/scripts/check-go-coverage.sh
+++ b/scripts/check-go-coverage.sh
@@ -286,6 +286,19 @@ else:
             for ln in range(start_line, end_line + 1):
                 line_coverage[file_path][ln] = covered
 
+    # Files exempt from Tier 2 because they contain code that is fundamentally
+    # untestable without integration setup (CLI subprocess spawning, system-level
+    # port detection, etc.). This is more precise than exempting entire packages —
+    # testable files within previously-exempt packages are now checked normally.
+    exempt_files = {
+        "cmd/server/main.go",                    # package main: -coverprofile empty in certain modes
+        "internal/ai/cli_backend.go",            # ExecuteStream spawns CLI subprocesses
+        "internal/ai/codex_stream.go",           # ExecuteStream spawns CLI subprocesses
+        "internal/ai/vecli.go",                  # ExecuteStream spawns CLI subprocesses
+        "internal/ai/vecli_stream.go",           # parseVeCLISessionSummary: integration-only
+        "internal/service/scheduler.go",         # executeTask spawns CLI subprocesses
+    }
+
     # Cross-reference: match git diff files with coverage profile files
     diff_stats = {}
     pkg_diff_stats = defaultdict(lambda: {"total": 0, "covered": 0})
@@ -293,6 +306,9 @@ else:
     for file_path, lines in sorted(changed_lines.items()):
         if not file_path.endswith(".go") or file_path.endswith("_test.go"):
             continue
+
+        # Check per-file exemption
+        is_exempt = file_path in exempt_files
 
         # Try direct match then suffix match
         cov_data = line_coverage.get(file_path)
@@ -314,7 +330,11 @@ else:
                     covered_changed += 1
 
         if total_changed > 0:
-            diff_stats[file_path] = {"total": total_changed, "covered": covered_changed}
+            diff_stats[file_path] = {
+                "total": total_changed,
+                "covered": covered_changed,
+                "exempt": is_exempt,
+            }
             # Derive package from file path
             pkg = "/".join(file_path.split("/")[:-1])
             if not pkg.startswith("clawbench/"):
@@ -322,8 +342,10 @@ else:
                     if cov_path.endswith("/" + file_path):
                         pkg = "/".join(cov_path.split("/")[:-1])
                         break
-            pkg_diff_stats[pkg]["total"] += total_changed
-            pkg_diff_stats[pkg]["covered"] += covered_changed
+            # Exempt files do NOT count toward package or overall stats
+            if not is_exempt:
+                pkg_diff_stats[pkg]["total"] += total_changed
+                pkg_diff_stats[pkg]["covered"] += covered_changed
 
     if not diff_stats:
         tier2_skipped = True
@@ -345,23 +367,22 @@ else:
             covered = stats["covered"]
             pct = (covered / total * 100) if total > 0 else 100.0
 
-            # Packages exempt from per-package Tier 2 because they cannot produce
-            # coverage data (e.g., package main cannot be coverage-profiled when
-            # run as a single test binary — Go's -coverprofile produces empty
-            # profiles for package main in certain execution modes).
-            if pkg in {"clawbench/cmd/server", "clawbench/internal/ai", "clawbench/internal/service"}:
-                print(f"{pkg:<40} {covered:>8} {total:>8} {pct:>7.1f}%  {YELLOW}EXEMPT{RESET}")
-                continue
-
             passed = pct >= DIFF_THRESHOLD
             if not passed:
                 tier2_pass = False
             print(f"{pkg:<40} {covered:>8} {total:>8} {pct:>7.1f}%  {pass_fail(passed)}")
 
-        # Overall diff coverage (exclude EXEMPT packages from total)
-        exempt_pkgs = {"clawbench/cmd/server", "clawbench/internal/ai", "clawbench/internal/service"}
-        total_all = sum(s["total"] for pkg, s in pkg_diff_stats.items() if pkg not in exempt_pkgs)
-        covered_all = sum(s["covered"] for pkg, s in pkg_diff_stats.items() if pkg not in exempt_pkgs)
+        # Show exempt file details (informational, not gate-blocking)
+        exempt_changed = {fp: s for fp, s in diff_stats.items() if s.get("exempt")}
+        if exempt_changed:
+            print(f"\n{YELLOW}{BOLD}Exempt files (not counted toward gate):{RESET}")
+            for fp, stats in sorted(exempt_changed.items()):
+                pct = (stats["covered"] / stats["total"] * 100) if stats["total"] > 0 else 100.0
+                print(f"  {YELLOW}{fp:<50} {stats['covered']}/{stats['total']} ({pct:.1f}%){RESET}")
+
+        # Overall diff coverage (exempt files already excluded from pkg_diff_stats)
+        total_all = sum(s["total"] for s in pkg_diff_stats.values())
+        covered_all = sum(s["covered"] for s in pkg_diff_stats.values())
         overall_pct = (covered_all / total_all * 100) if total_all > 0 else 100.0
         overall_pass = overall_pct >= DIFF_THRESHOLD
         if not overall_pass:
@@ -370,9 +391,11 @@ else:
         print(f"{'─'*40} {'─'*8} {'─'*8} {'─'*8}  {'─'*8}")
         print(f"{BOLD}{'TOTAL':<40} {covered_all:>8} {total_all:>8} {overall_pct:>7.1f}%  {pass_fail(overall_pass)}{RESET}")
 
-        # Show uncovered files
+        # Show uncovered files (excluding exempt)
         uncovered_files = []
         for file_path, stats in sorted(diff_stats.items()):
+            if stats.get("exempt"):
+                continue
             if stats["covered"] < stats["total"]:
                 pct = (stats["covered"] / stats["total"] * 100) if stats["total"] > 0 else 0
                 uncovered_files.append((file_path, stats["covered"], stats["total"], pct))


### PR DESCRIPTION
## Fixes #55

### 问题
AI 会话完成后的推送通知 alert 取的是响应的**第一个**文本块，当 AI 回复包含工具调用时，第一个文本块往往是中间推理（如"正在读取文件…"），而非最终答案。

### 根因
`getSessionResponsePreview()` 遍历 content blocks 时从前往后取第一个 `text` 类型 block。在 `[text, tool_use, text]` 结构中，返回的是 tool_use 前面的中间文本。

### 修复 (3 commits)

**Commit 1: 核心修复** — `internal/service/session_runtime.go`
- 先扫描找到最后一个 `tool_use` block 的索引 (`lastToolIdx`)
- 只从 `lastToolIdx + 1` 之后的 blocks 中提取 text 作为 preview
- 无 `tool_use` 时 `lastToolIdx = -1`，从 block[0] 开始，完全向后兼容

**Commit 2: 覆盖率脚本改进** — `scripts/check-go-coverage.sh`
- Tier 2 EXEMPT 从 per-package 粒度收窄为 per-file 粒度
- 之前整个 `internal/service` 被 EXEMPT → 现在只有 `scheduler.go`（CLI subprocess）EXEMPT
- `session_runtime.go` 等可测文件正常参与 Tier 2 检查

**Commit 3: 真实数据测试** — `internal/service/session_runtime_test.go`
- 4 个合成测试覆盖边界场景
- 6 个从生产数据库 (ClawBench.db) 抽取的真实数据测试

### 测试覆盖

| 场景 | Block 结构 | 预期 |
|------|------------|------|
| TextThenToolThenSummary | `[thinking, text, tool, tool, text]` | 取最终 text |
| ToolThenWorktreeReport | `[thinking, tool, text]` | 取 tool 后 text |
| MultiToolInterleaved | `[thinking, tool, text, tool, tool, text, tool, text]` | 取最后 tool 后 text |
| OnlyToolUses | `[tool, tool]` | 返回空 |
| TextBeforeToolOnly | `[text, tool]` | 返回空 |
| PureTextSummary | `[text]` | 无 tool_use 时退化正常 |

### Tier 2 结果
```
clawbench/internal/service    7/7   100.0%  PASS
```