### PR TITLE
fix: 修复 ISS-123, ISS-126, ISS-130 — HttpOnly cookie、安全类型断言、embedding 非有限值校验

### DIFF
--- a/internal/handler/chat_session.go
+++ b/internal/handler/chat_session.go
@@ -176,13 +176,14 @@ func getSessionID(r *http.Request) string {
 }
 
 // setSessionID sets session ID in cookie.
+// HttpOnly: true prevents JavaScript access, mitigating XSS-based session hijack (ISS-123).
 func setSessionID(w http.ResponseWriter, sessionID string) {
 	http.SetCookie(w, &http.Cookie{
 		Name:     "chat_session_id",
 		Value:    sessionID,
 		Path:     "/",
 		MaxAge:   86400 * 30, // 30 days
-		HttpOnly: false,
+		HttpOnly: true,
 		SameSite: http.SameSiteLaxMode,
 	})
 }

--- a/internal/rag/store.go
+++ b/internal/rag/store.go
@@ -4,6 +4,7 @@ import (
 	"database/sql"
 	"fmt"
 	"log/slog"
+	"math"
 	"os"
 	"path/filepath"
 	"sort"
@@ -233,7 +234,11 @@ func (s *Store) InsertChunks(chunks []Chunk) error {
 	for _, c := range chunks {
 		var embeddingSQL string
 		if c.Embedding != nil {
-			embeddingSQL = embeddingToSQLArray(c.Embedding, s.embeddingDim)
+			esql, err := embeddingToSQLArray(c.Embedding, s.embeddingDim)
+			if err != nil {
+				return fmt.Errorf("embedding validation for chunk %d: %w", c.ID, err)
+			}
+			embeddingSQL = esql
 		} else {
 			embeddingSQL = "NULL"
 		}
@@ -265,7 +270,10 @@ func (s *Store) InsertChunks(chunks []Chunk) error {
 func (s *Store) SearchSimple(queryEmbedding []float64, limit int, projectPath, backend, role, sessionID, excludeSessionID, fromTime, toTime string) ([]SearchHit, error) {
 	// Build embedding as SQL array literal since go-duckdb cannot bind []float64
 	// as a parameter for FLOAT[dim] columns.
-	embeddingLiteral := embeddingToSQLArray(queryEmbedding, s.embeddingDim)
+	embeddingLiteral, err := embeddingToSQLArray(queryEmbedding, s.embeddingDim)
+	if err != nil {
+		return nil, fmt.Errorf("query embedding validation: %w", err)
+	}
 
 	query := fmt.Sprintf(`
 		SELECT id,
@@ -538,7 +546,10 @@ func (s *Store) UpdateEmbedding(chunkID int64, embedding []float64) error {
 	}
 
 	// Re-insert with the SAME id and embedding
-	embeddingLiteral := embeddingToSQLArray(embedding, s.embeddingDim)
+	embeddingLiteral, err := embeddingToSQLArray(embedding, s.embeddingDim)
+	if err != nil {
+		return fmt.Errorf("embedding validation for update: %w", err)
+	}
 	_, err = s.db.Exec(fmt.Sprintf(`
 		INSERT INTO chat_chunks (id, session_id, message_id, chunk_text, chunk_text_segmented,
 			chunk_index, token_count, embedding, has_embedding, project_path, backend, role, created_at)
@@ -704,17 +715,22 @@ func (s *Store) RecoverFromCorruption() error {
 
 // embeddingToSQLArray converts a float64 slice to a DuckDB array literal string.
 // e.g., [0.1, 0.2, 0.3] -> "array[0.1, 0.2, 0.3]::FLOAT[dim]"
-func embeddingToSQLArray(vec []float64, dim int) string {
+// Returns error if any value is non-finite (NaN/Inf) to prevent SQL injection. (ISS-130)
+func embeddingToSQLArray(vec []float64, dim int) (string, error) {
 	var buf strings.Builder
 	buf.WriteString("array[")
 	for i, v := range vec {
 		if i > 0 {
 			buf.WriteString(", ")
 		}
+		// Guard against NaN/Inf which produce invalid SQL float literals (ISS-130)
+		if math.IsInf(v, 0) || math.IsNaN(v) {
+			return "", fmt.Errorf("embedding contains non-finite value at index %d: %v", i, v)
+		}
 		buf.WriteString(strconv.FormatFloat(v, 'f', -1, 64))
 	}
 	buf.WriteString("]::FLOAT[")
 	buf.WriteString(strconv.Itoa(dim))
 	buf.WriteString("]")
-	return buf.String()
+	return buf.String(), nil
 }

--- a/internal/rag/store_test.go
+++ b/internal/rag/store_test.go
@@ -422,6 +422,52 @@ func TestEmbeddingToSQLArray_NonFinite(t *testing.T) {
 	assert.Contains(t, err.Error(), "non-finite")
 }
 
+// ---------- Non-finite embedding rejection in public methods (ISS-130) ----------
+
+func TestStore_InsertChunks_RejectsNaNEmbedding(t *testing.T) {
+	store := setupTestStore(t)
+
+	chunk := makeTestChunk("sess-nan", 1, 0, "test chunk with NaN embedding")
+	chunk.Embedding = makeTestEmbedding(1024)
+	chunk.Embedding[5] = math.NaN()
+
+	err := store.InsertChunks([]Chunk{chunk})
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "embedding validation")
+}
+
+func TestStore_SearchSimple_RejectsInfEmbedding(t *testing.T) {
+	store := setupTestStore(t)
+
+	queryEmbedding := makeTestEmbedding(1024)
+	queryEmbedding[0] = math.Inf(1)
+
+	_, err := store.SearchSimple(queryEmbedding, 10, "", "", "", "", "", "", "")
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "query embedding validation")
+}
+
+func TestStore_UpdateEmbedding_RejectsNaNEmbedding(t *testing.T) {
+	store := setupTestStore(t)
+
+	// First insert a valid chunk so UpdateEmbedding has a target
+	chunk := makeTestChunk("sess-update-nan", 1, 0, "test chunk for update")
+	err := store.InsertChunks([]Chunk{chunk})
+	require.NoError(t, err)
+
+	// Search to find the inserted chunk's ID
+	hits, err := store.SearchSimple(makeTestEmbedding(1024), 1, "", "", "", "", "", "", "")
+	require.NoError(t, err)
+	require.NotEmpty(t, hits)
+
+	// Try updating with NaN embedding
+	nanEmb := makeTestEmbedding(1024)
+	nanEmb[0] = math.NaN()
+	err = store.UpdateEmbedding(hits[0].ChunkID, nanEmb)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "embedding validation for update")
+}
+
 // ---------- Schema migration (new columns) ----------
 
 func TestStore_SchemaHasSegmentedTextColumn(t *testing.T) {

--- a/internal/rag/store_test.go
+++ b/internal/rag/store_test.go
@@ -2,6 +2,7 @@ package rag
 
 import (
 	"fmt"
+	"math"
 	"path/filepath"
 	"strings"
 	"testing"
@@ -396,7 +397,8 @@ func TestStore_Close_NilDB(t *testing.T) {
 
 func TestEmbeddingToSQLArray(t *testing.T) {
 	vec := []float64{0.1, 0.2, 0.3}
-	result := embeddingToSQLArray(vec, 1024)
+	result, err := embeddingToSQLArray(vec, 1024)
+	assert.NoError(t, err)
 	assert.True(t, strings.HasPrefix(result, "array["))
 	assert.True(t, strings.HasSuffix(result, "]::FLOAT[1024]"))
 	assert.Contains(t, result, "0.1")
@@ -405,8 +407,19 @@ func TestEmbeddingToSQLArray(t *testing.T) {
 }
 
 func TestEmbeddingToSQLArray_Empty(t *testing.T) {
-	result := embeddingToSQLArray([]float64{}, 1024)
+	result, err := embeddingToSQLArray([]float64{}, 1024)
+	assert.NoError(t, err)
 	assert.Equal(t, "array[]::FLOAT[1024]", result)
+}
+
+func TestEmbeddingToSQLArray_NonFinite(t *testing.T) {
+	_, err := embeddingToSQLArray([]float64{0.1, math.NaN(), 0.3}, 1024)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "non-finite")
+
+	_, err = embeddingToSQLArray([]float64{0.1, math.Inf(1)}, 1024)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "non-finite")
 }
 
 // ---------- Schema migration (new columns) ----------

--- a/internal/service/session_runtime.go
+++ b/internal/service/session_runtime.go
@@ -186,7 +186,12 @@ func GetAndClearCancelReason(sessionID string) string {
 	if !ok {
 		return ""
 	}
-	return val.(string)
+	// Safe type assertion to prevent panic if value is not a string (ISS-126)
+	reason, ok := val.(string)
+	if !ok {
+		return ""
+	}
+	return reason
 }
 
 // CancelSession cancels an ongoing AI stream for a session.

--- a/internal/service/session_runtime_test.go
+++ b/internal/service/session_runtime_test.go
@@ -96,6 +96,17 @@ func TestGetAndClearCancelReason_NoReason(t *testing.T) {
 	assert.Equal(t, "", reason)
 }
 
+func TestGetAndClearCancelReason_NonStringValue(t *testing.T) {
+	cleanupCancelReasons()
+	defer cleanupCancelReasons()
+
+	// Store a non-string value to trigger the safe type assertion path (ISS-126)
+	sessionCancelReasons.Store("session-nonstring", 12345)
+
+	reason := GetAndClearCancelReason("session-nonstring")
+	assert.Equal(t, "", reason)
+}
+
 // --- CancelSession ---
 
 func TestCancelSession_WithCancelFunc(t *testing.T) {


### PR DESCRIPTION
## 修复内容

### ISS-123 (P0 - Security)
- **问题**: `chat_session_id` cookie 设置 `HttpOnly: false`，JavaScript 可读取，存在 XSS 劫持风险
- **修复**: 将 `HttpOnly` 改为 `true`，前端从未通过 JS 读取此 cookie（使用 JSON 响应体）

### ISS-126 (P0 - Flow Correctness)
- **问题**: `GetAndClearCancelReason` 使用裸类型断言 `val.(string)`，若值非 string 会 panic 崩溃服务器
- **修复**: 改为 comma-ok 安全断言 `reason, ok := val.(string)`，非 string 时返回空字符串

### ISS-130 (P0 - Security)
- **问题**: `embeddingToSQLArray` 将 float64 直接格式化为 SQL 字面量，NaN/Inf 会产生无效 SQL
- **修复**: 添加 `math.IsInf`/`math.IsNaN` 校验，非有限值返回 error；更新所有 3 处调用点和测试

## 验证
- go build ✅
- go test ./... ✅ (含新增 TestEmbeddingToSQLArray_NonFinite)
- npx vitest run ✅ (2691 tests passed)