### PR TITLE
fix: 适配 iOS PWA 顶部安全区域，修复 Header 被刘海遮挡

### DIFF
--- a/web/css/layout.css
+++ b/web/css/layout.css
@@ -9,7 +9,7 @@
     display: flex;
     flex-direction: column;
     overflow: hidden;
-    padding-top: var(--header-height);
+    padding-top: calc(var(--header-height) + var(--header-safe-area-top));
 }
 
 /* Header */
@@ -19,12 +19,14 @@
     left: 0;
     right: 0;
     flex-shrink: 0;
-    height: var(--header-height);
+    height: calc(var(--header-height) + var(--header-safe-area-top));
+    padding-top: var(--header-safe-area-top);
     background: var(--bg-secondary);
     border-bottom: 1px solid var(--border-color);
     display: flex;
     align-items: center;
-    padding: 0 6px;
+    padding-left: 6px;
+    padding-right: 6px;
     gap: 4px;
     flex-shrink: 0;
     overflow: hidden;

--- a/web/css/variables.css
+++ b/web/css/variables.css
@@ -15,6 +15,7 @@
     --accent-hover: #3a7bc8;
     --user-msg-color: #5b8fbf;
     --header-height: 40px;
+    --header-safe-area-top: env(safe-area-inset-top, 0px);
     --shadow-sm: 0 1px 3px rgba(0,0,0,0.08);
     --shadow-md: 0 4px 12px rgba(0,0,0,0.1);
     --radius-sm: 6px;

--- a/web/src/components/common/BottomSheet.vue
+++ b/web/src/components/common/BottomSheet.vue
@@ -84,7 +84,7 @@ defineExpose({
 
 .bs-overlay {
   position: fixed;
-  top: var(--header-height, 44px);
+  top: calc(var(--header-height, 44px) + var(--header-safe-area-top, 0px));
   left: 0;
   right: 0;
   bottom: var(--dock-height, 0);

--- a/web/src/components/common/QuoteQuestionBar.vue
+++ b/web/src/components/common/QuoteQuestionBar.vue
@@ -165,7 +165,7 @@ function handleSend() {
 <style scoped>
 .quote-question-bar {
   position: fixed;
-  top: calc(var(--header-height, 40px) + 8px + env(safe-area-inset-top, 0px));
+  top: calc(var(--header-height, 40px) + 8px + var(--header-safe-area-top, 0px));
   left: 8px;
   right: 8px;
   background: var(--bg-secondary);


### PR DESCRIPTION
## 关联 Issue

Fixes #64

## 修改内容

iOS PWA 模式下，Header 区域被刘海/灵动岛遮挡。本 PR 通过 `env(safe-area-inset-top)` 适配顶部安全区域。

### 具体变更

| 文件 | 变更说明 |
|------|----------|
| `web/css/variables.css` | 新增 `--header-safe-area-top` CSS 变量 |
| `web/css/layout.css` | Header 高度加入安全区域偏移，`padding-top` 推开刘海区域；`app-container` 的 `padding-top` 同步调整 |
| `web/src/components/common/BottomSheet.vue` | 遮罩层 `top` 偏移加入安全区域 |
| `web/src/components/common/QuoteQuestionBar.vue` | 使用集中的 CSS 变量替代直接 `env()` 调用 |

### 兼容性

- 普通浏览器：`env(safe-area-inset-top)` 为 `0px`，无任何视觉变化
- iOS PWA：Header 内容下移至刘海下方，可正常点击操作

### 测试

- 前端 2097 个测试全部通过