### PR TITLE
fix: 修复 iOS 聊天输入框自动放大及键盘弹出内容溢出

### DIFF
--- a/web/css/base.css
+++ b/web/css/base.css
@@ -9,9 +9,11 @@
     padding: 0;
 }
 
-/* HTML & Body */
+/* HTML & Body — use 100vh instead of 100dvh to avoid iOS WKWebView mismatch.
+   On iOS, dvh shrinks when the soft keyboard opens but position:fixed elements
+   still reference the full screen, causing overflow. 100vh stays stable. */
 html, body {
-    height: 100dvh;
+    height: 100vh;
     font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, 'Helvetica Neue', sans-serif;
     font-size: 15px;
     line-height: 1.6;

--- a/web/index.html
+++ b/web/index.html
@@ -2,7 +2,7 @@
 <html lang="en" data-theme="light">
 <head>
     <meta charset="UTF-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no, viewport-fit=cover">
     <meta name="theme-color" content="#0d1117">
     <meta name="description" content="一款专为移动端设计的轻量级代码和文档工作台">
 

--- a/web/src/App.vue
+++ b/web/src/App.vue
@@ -7,7 +7,7 @@
     <LoginView v-else-if="!isAuthenticated" @login-success="handleLoginSuccess" />
 
     <!-- Main app -->
-    <div v-else class="app-container" :class="{ 'chrome-hidden': terminalKeyboardActive }">
+    <div v-else class="app-container" :class="{ 'chrome-hidden': terminalKeyboardActive, 'chat-keyboard-open': chatKeyboardActive }">
       <AppHeader
         :hidden="terminalActive"
         :project-root="projectRoot"
@@ -175,7 +175,7 @@
       />
 
       <!-- Bottom dock (tab bar) -->
-      <div v-if="isAuthenticated" v-show="!terminalKeyboardActive" class="bottom-dock-wrapper">
+      <div v-if="isAuthenticated" v-show="!anyKeyboardActive" class="bottom-dock-wrapper">
         <div class="bottom-dock">
           <div class="dock-center">
             <div class="dock-btn-wrap">
@@ -279,6 +279,7 @@ import { loadSessionsOnce } from './composables/useChatSession.ts'
 import { useToast } from './composables/useToast.ts'
 import { useAppMode } from './composables/useAppMode.ts'
 import { useTerminalKeyboard } from './composables/useTerminalKeyboard.ts'
+import { useChatKeyboard } from './composables/useChatKeyboard.ts'
 import { usePortForward } from './composables/usePortForward.ts'
 import { useTerminalStatus } from './composables/useTerminalStatus.ts'
 import { useFileWatch } from './composables/useFileWatch.ts'
@@ -423,6 +424,14 @@ const terminalRequestedCwd = ref(null)
 const terminalActive = computed(() => activeTab.value === 'terminal')
 const { keyboardHeight: terminalKeyboardHeight } = useTerminalKeyboard()
 const terminalKeyboardActive = computed(() => terminalActive.value && terminalKeyboardHeight.value > 0)
+
+// Chat keyboard — on iOS WKWebView there's no adjustResize, so we detect
+// keyboard via visualViewport and compensate in the web layer.
+const { chatKeyboardHeight } = useChatKeyboard()
+const chatKeyboardActive = computed(() => activeTab.value === 'chat' && chatKeyboardHeight.value > 0)
+
+// Unified: any soft keyboard is open (terminal or chat)
+const anyKeyboardActive = computed(() => terminalKeyboardActive.value || chatKeyboardActive.value)
 
 const quoteQuestion = useQuoteQuestion()
 const sessionDrawerRef = ref(null)
@@ -915,6 +924,12 @@ onUnmounted(() => {
 /* When terminal keyboard is open, remove header padding so content expands to top */
 .chrome-hidden {
     padding-top: 0 !important;
+}
+
+/* When chat keyboard is open on iOS (no adjustResize), shrink the app container
+   from the bottom so content stays above the keyboard. */
+.chat-keyboard-open {
+    bottom: v-bind(chatKeyboardHeight + 'px') !important;
 }
 
 .bottom-dock-wrapper {

--- a/web/src/components/chat/ChatInputBar.vue
+++ b/web/src/components/chat/ChatInputBar.vue
@@ -97,7 +97,9 @@
           :placeholder="pendingFiles.length > 0 ? t('chat.input.placeholderOptional') : loading ? t('chat.input.placeholderQueue') : t('chat.input.placeholder')"
           rows="1"
           @keydown.enter.exact.prevent="$emit('send', inputText.trim())"
-          @blur="autoResizeTextarea"></textarea>
+          @focus="onTextareaFocus"
+          @blur="onTextareaBlur"
+          ></textarea>
         <button v-if="!stopPrimed" class="chat-send-btn" ref="sendBtnRef" :class="{ queued: loading }" @click.stop="handleSendClick" :title="loading ? t('chat.input.enqueue') : t('chat.input.send')">
           <!-- Queue mode: inbox with down arrow (enqueue) -->
           <Inbox v-if="loading" :size="16" />
@@ -192,6 +194,7 @@ import QuickSendDialog from '@/components/chat/QuickSendDialog.vue'
 import { createStopButtonMachine } from '@/utils/stopButtonMachine.ts'
 import { useDialog } from '@/composables/useDialog.ts'
 import { useQuickSend } from '@/composables/useQuickSend'
+import { useChatKeyboard } from '@/composables/useChatKeyboard'
 
 const { t } = useI18n()
 const dialog = useDialog()
@@ -251,6 +254,10 @@ const showModelMenu = ref(false)
 const modelChipRef = ref(null)
 const showThinkingEffortMenu = ref(false)
 const thinkingEffortChipRef = ref(null)
+
+// Keyboard detection for iOS (no adjustResize) — activates visualViewport monitoring
+// when textarea is focused so App.vue can compensate the layout.
+const chatKeyboard = useChatKeyboard()
 
 // Stop button two-click confirmation state
 const stopPrimed = ref(false)
@@ -334,6 +341,16 @@ function autoResizeTextarea() {
   const maxContentHeight = lineHeight * 3
   const maxHeight = maxContentHeight + paddingTop + paddingBottom
   el.style.height = Math.min(el.scrollHeight, maxHeight) + 'px'
+}
+
+function onTextareaFocus() {
+  chatKeyboard.activate()
+  autoResizeTextarea()
+}
+
+function onTextareaBlur() {
+  chatKeyboard.debounceDeactivate()
+  autoResizeTextarea()
 }
 
 // Watch inputText changes (both user input and programmatic changes like draft restore)
@@ -667,7 +684,7 @@ defineExpose({
   display: flex;
   flex-direction: column;
   background: var(--bg-tertiary, #f0f0f0);
-  flex: 1;
+  flex: none;
   min-width: 0;
   border: none;
   border-radius: 20px;
@@ -905,7 +922,7 @@ defineExpose({
   border: none;
   background: transparent;
   color: var(--text-primary);
-  font-size: 14px;
+  font-size: 16px;
   line-height: 20px;
   outline: none;
   resize: none;

--- a/web/src/composables/useChatKeyboard.ts
+++ b/web/src/composables/useChatKeyboard.ts
@@ -1,0 +1,87 @@
+import { ref } from 'vue'
+
+// Module-level singleton — shared between ChatInputBar (activator) and App.vue (reader)
+const chatKeyboardHeight = ref(0)
+
+/**
+ * Reactive soft-keyboard height for the chat input.
+ *
+ * On iOS WKWebView there is no adjustResize — window.innerHeight stays the same
+ * when the keyboard opens, so fixed-position elements extend behind the keyboard.
+ * This composable uses the visualViewport API to detect the keyboard height and
+ * expose it reactively so App.vue can compensate.
+ *
+ * On Android (adjustResize) and desktop, this always returns 0 — those platforms
+ * handle keyboard avoidance natively.
+ */
+export function useChatKeyboard() {
+  function activate() {
+    clearDeactivateTimer()
+    startWatching()
+  }
+
+  /**
+   * Debounced deactivate — wait a short period after blur before clearing
+   * the keyboard height. This prevents a flash where the keyboard is still
+   * animating closed (visualViewport still reports a reduced height) but
+   * we've already set height=0, causing a brief layout jump.
+   */
+  function debounceDeactivate() {
+    clearDeactivateTimer()
+    deactivateTimer = setTimeout(() => {
+      deactivateTimer = null
+      deactivate()
+    }, DEACTIVATE_DELAY_MS)
+  }
+
+  function deactivate() {
+    clearDeactivateTimer()
+    stopWatching()
+    chatKeyboardHeight.value = 0
+  }
+
+  return { chatKeyboardHeight, activate, deactivate, debounceDeactivate }
+}
+
+// ── Internal ──
+
+let watching = false
+let deactivateTimer: ReturnType<typeof setTimeout> | null = null
+const DEACTIVATE_DELAY_MS = 150
+
+function clearDeactivateTimer() {
+  if (deactivateTimer) {
+    clearTimeout(deactivateTimer)
+    deactivateTimer = null
+  }
+}
+
+function updateKeyboardHeight() {
+  const vv = window.visualViewport
+  if (!vv) return
+
+  // keyboardHeight = space taken by the keyboard relative to the layout viewport
+  const height = window.innerHeight - vv.height - vv.offsetTop
+  chatKeyboardHeight.value = Math.max(height, 0)
+}
+
+function onVisualViewportResize() {
+  updateKeyboardHeight()
+}
+
+function startWatching() {
+  if (watching) return
+  watching = true
+  updateKeyboardHeight()
+  if (window.visualViewport) {
+    window.visualViewport.addEventListener('resize', onVisualViewportResize)
+  }
+}
+
+function stopWatching() {
+  if (!watching) return
+  watching = false
+  if (window.visualViewport) {
+    window.visualViewport.removeEventListener('resize', onVisualViewportResize)
+  }
+}


### PR DESCRIPTION
## 关联 Issue

Fixes #66

## 修改内容

iOS 端点击聊天输入框会触发自动缩放和键盘遮挡两个问题，本 PR 修复这些 Web 层问题。

### 具体变更

| 文件 | 变更说明 |
|------|----------|
| `web/index.html` | viewport 添加 `maximum-scale=1.0, user-scalable=no`，禁止 iOS 自动缩放 |
| `web/css/base.css` | `100dvh` → `100vh`，避免 iOS 键盘弹出时高度与 fixed 元素不一致 |
| `web/src/composables/useChatKeyboard.ts` | 新增 composable，通过 `visualViewport` API 检测键盘高度 |
| `web/src/App.vue` | 聊天键盘弹出时通过 `v-bind` 动态设置底部偏移，隐藏底部 dock |
| `web/src/components/chat/ChatInputBar.vue` | textarea font-size 14px→16px 防止自动缩放；focus/blur 激活键盘检测；flex:1→flex:none 防止异常拉伸 |

### 与 PR #65 的关系

本 PR **不包含** PWA 顶部安全区域（`safe-area-inset-top`）的修改，该修复在 #65 中单独提交。

### 兼容性

- 桌面/Android：`visualViewport` 检测到的键盘高度为 0，行为不变
- iOS：输入框不再自动放大，键盘弹出时内容保持在键盘上方

### 测试

- 前端 2097 个测试全部通过
- iPhone 实机测试通过（PWA 模式）