### PR TITLE
feat: improve push notification title/alert and unify preview length limit

### DIFF
--- a/internal/model/chat.go
+++ b/internal/model/chat.go
@@ -2,6 +2,10 @@ package model
 
 import "time"
 
+// ResponsePreviewMaxRunes is the maximum number of runes included in the
+// response preview sent via WS session_update events and JPush notifications.
+const ResponsePreviewMaxRunes = 512
+
 // ChatMessage represents a single message in the chat history
 type ChatMessage struct {
 	ID          int64     `json:"id,omitempty"`

--- a/internal/service/session_runtime.go
+++ b/internal/service/session_runtime.go
@@ -25,11 +25,8 @@ var sessionStreams sync.Map // map[string]chan ai.StreamEvent
 var sessionCancels sync.Map         // map[string]context.CancelFunc
 var sessionCancelReasons sync.Map   // map[string]string — "user", "disconnect"
 
-// responsePreviewMaxRunes is the maximum number of runes included in the
-// response preview sent via WS session_update events. This is intentionally
-// generous (for WS consumers); the JPush alert path applies its own shorter
-// limit (see ws.Manager.broadcastToSubscription).
-const responsePreviewMaxRunes = 64
+// responsePreviewMaxRunes is an alias for model.ResponsePreviewMaxRunes for local use.
+const responsePreviewMaxRunes = model.ResponsePreviewMaxRunes
 
 // EmitSessionEvent broadcasts a session_update event to connected clients.
 func EmitSessionEvent(sessionID, status string, hasNewMessages bool) {

--- a/internal/service/session_runtime_test.go
+++ b/internal/service/session_runtime_test.go
@@ -678,9 +678,8 @@ func TestGetSessionResponsePreview_RealData_ToolThenWorktreeReport(t *testing.T)
 	result := getSessionResponsePreview("session-real-tool-worktree")
 	// Should start with the final answer, not with thinking or tool output
 	assert.Contains(t, result, "Worktree 已创建")
-	// Verify truncation kicks in (finalText is 110 runes, exceeds responsePreviewMaxRunes=64)
-	assert.True(t, utf8.RuneCountInString(result) <= responsePreviewMaxRunes+1, "result should be truncated")
-	assert.True(t, strings.HasSuffix(result, "…"), "truncated result should end with ellipsis")
+	// With responsePreviewMaxRunes=512, this text (110 runes) fits without truncation
+	assert.Equal(t, finalText, result)
 }
 
 func TestGetSessionResponsePreview_RealData_MultiToolInterleavedWithText(t *testing.T) {
@@ -766,7 +765,8 @@ func TestGetSessionResponsePreview_RealData_ThreeToolsThenWorktreeReport(t *test
 
 	result := getSessionResponsePreview("session-real-three-tools")
 	assert.Contains(t, result, "Worktree 已创建")
-	assert.True(t, utf8.RuneCountInString(result) <= responsePreviewMaxRunes+1, "result should be truncated")
+	// With responsePreviewMaxRunes=512, this text fits without truncation
+	assert.Equal(t, finalText, result)
 }
 
 func TestGetSessionResponsePreview_RealData_PureTextSummary(t *testing.T) {
@@ -790,7 +790,8 @@ func TestGetSessionResponsePreview_RealData_PureTextSummary(t *testing.T) {
 
 	result := getSessionResponsePreview("session-real-pure-text")
 	assert.Contains(t, result, "后台耗电优化到此为止")
-	assert.True(t, utf8.RuneCountInString(result) <= responsePreviewMaxRunes+1, "result should be truncated")
+	// With responsePreviewMaxRunes=512, this text fits without truncation
+	assert.Equal(t, finalText, result)
 }
 
 func TestGetSessionResponsePreview_UsesLastAssistantMessage(t *testing.T) {

--- a/internal/ws/manager.go
+++ b/internal/ws/manager.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/coder/websocket"
 
+	"clawbench/internal/model"
 	"clawbench/internal/push"
 	"unicode/utf8"
 )
@@ -31,10 +32,8 @@ type ClientSubscription struct {
 // resource exhaustion. Matches the original SSE limit of 20.
 const maxSubscriptions = 20
 
-// pushAlertMaxRunes is the maximum number of runes used for the JPush alert text.
-// OPPO (the most restrictive vendor channel) limits alert to 50 characters;
-// we use 40 to leave room for the "…" ellipsis and a safety margin.
-const pushAlertMaxRunes = 40
+// pushAlertMaxRunes is an alias for model.ResponsePreviewMaxRunes for local use.
+const pushAlertMaxRunes = model.ResponsePreviewMaxRunes
 
 // wsWriteTimeout is the maximum time to wait for a WebSocket write to complete.
 const wsWriteTimeout = 5 * time.Second
@@ -305,12 +304,13 @@ func (m *Manager) broadcastToSubscription(key string, msg ServerMessage, deliver
 		if msg.Event == "task_update" {
 			alert = "计划任务已完成"
 		}
-		// Use session title as alert text when available (more informative than response preview),
-		// then fall back to response preview. Both are truncated for push channel limits.
+		// For session events: put session title in the notification title (more visible),
+		// and use response preview as the alert body (the actual AI answer content).
 		if d, ok := msg.Data.(*SessionUpdateData); ok {
 			if d.SessionTitle != "" {
-				alert = truncateForPush(d.SessionTitle)
-			} else if d.ResponsePreview != "" {
+				title = "Done:" + d.SessionTitle
+			}
+			if d.ResponsePreview != "" {
 				alert = truncateForPush(d.ResponsePreview)
 			}
 		}

--- a/internal/ws/manager_test.go
+++ b/internal/ws/manager_test.go
@@ -464,13 +464,14 @@ func TestBroadcastEvent_BufferWindow(t *testing.T) {
 }
 
 func TestManager_BroadcastEvent_JPushAlert_WithSessionTitle(t *testing.T) {
-	var receivedAlert string
+	var receivedTitle, receivedAlert string
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		var payload map[string]any
 		if err := json.NewDecoder(r.Body).Decode(&payload); err == nil {
 			if n, ok := payload["notification"].(map[string]any); ok {
 				if a, ok := n["android"].(map[string]any); ok {
 					receivedAlert, _ = a["alert"].(string)
+					receivedTitle, _ = a["title"].(string)
 				}
 			}
 		}
@@ -506,20 +507,24 @@ func TestManager_BroadcastEvent_JPushAlert_WithSessionTitle(t *testing.T) {
 	}
 	mgr.BroadcastEvent(msg)
 
-	// SessionTitle takes priority over ResponsePreview
-	if receivedAlert != "帮我写一个Go HTTP服务器" {
-		t.Errorf("expected alert to be session title, got %q", receivedAlert)
+	// SessionTitle goes into the notification title; ResponsePreview goes into the alert
+	if receivedTitle != "Done:帮我写一个Go HTTP服务器" {
+		t.Errorf("expected title to include session title, got %q", receivedTitle)
+	}
+	if receivedAlert != "AI回复的预览内容" {
+		t.Errorf("expected alert to be response preview, got %q", receivedAlert)
 	}
 }
 
 func TestManager_BroadcastEvent_JPushAlert_WithResponsePreview(t *testing.T) {
-	var receivedAlert string
+	var receivedTitle, receivedAlert string
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		var payload map[string]any
 		if err := json.NewDecoder(r.Body).Decode(&payload); err == nil {
 			if n, ok := payload["notification"].(map[string]any); ok {
 				if a, ok := n["android"].(map[string]any); ok {
 					receivedAlert, _ = a["alert"].(string)
+					receivedTitle, _ = a["title"].(string)
 				}
 			}
 		}
@@ -554,20 +559,25 @@ func TestManager_BroadcastEvent_JPushAlert_WithResponsePreview(t *testing.T) {
 	}
 	mgr.BroadcastEvent(msg)
 
+	// Without session title, notification title stays as default
+	if receivedTitle != "AI任务完成" {
+		t.Errorf("expected default title, got %q", receivedTitle)
+	}
 	// Short preview should pass through unchanged (under pushAlertMaxRunes)
 	if receivedAlert != "AI回复的预览内容" {
 		t.Errorf("expected alert to be response preview, got %q", receivedAlert)
 	}
 }
 
-func TestManager_BroadcastEvent_JPushAlert_TruncatesLongTitle(t *testing.T) {
-	var receivedAlert string
+func TestManager_BroadcastEvent_JPushAlert_TruncatesLongPreview(t *testing.T) {
+	var receivedTitle, receivedAlert string
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		var payload map[string]any
 		if err := json.NewDecoder(r.Body).Decode(&payload); err == nil {
 			if n, ok := payload["notification"].(map[string]any); ok {
 				if a, ok := n["android"].(map[string]any); ok {
 					receivedAlert, _ = a["alert"].(string)
+					receivedTitle, _ = a["title"].(string)
 				}
 			}
 		}
@@ -589,8 +599,8 @@ func TestManager_BroadcastEvent_JPushAlert_TruncatesLongTitle(t *testing.T) {
 	mgr.RegisterPushID("reg-123", "client-1")
 	mgr.DisconnectClient("client-1")
 
-	// pushAlertMaxRunes+1 rune title — should be truncated
-	longTitle := strings.Repeat("测", pushAlertMaxRunes+1)
+	// Long response preview — should be truncated in alert
+	longPreview := strings.Repeat("测", pushAlertMaxRunes+1)
 	msg := ServerMessage{
 		Type:  "event",
 		ID:    "evt_1",
@@ -599,12 +609,18 @@ func TestManager_BroadcastEvent_JPushAlert_TruncatesLongTitle(t *testing.T) {
 			SessionID:      "s1",
 			Status:         "completed",
 			HasNewMessages: true,
-			SessionTitle:   longTitle,
+			SessionTitle:   "测试标题",
+			ResponsePreview: longPreview,
 		},
 	}
 	mgr.BroadcastEvent(msg)
 
-	expected := string([]rune(longTitle)[:pushAlertMaxRunes]) + "…"
+	// Title includes session title without truncation
+	if receivedTitle != "Done:测试标题" {
+		t.Errorf("expected title with session title, got %q", receivedTitle)
+	}
+	// Alert is the truncated response preview
+	expected := string([]rune(longPreview)[:pushAlertMaxRunes]) + "…"
 	if receivedAlert != expected {
 		t.Errorf("expected truncated alert, got %q (want %q)", receivedAlert, expected)
 	}
@@ -614,13 +630,14 @@ func TestManager_BroadcastEvent_JPushAlert_TruncatesLongTitle(t *testing.T) {
 }
 
 func TestManager_BroadcastEvent_JPushAlert_WithoutTitleOrPreview(t *testing.T) {
-	var receivedAlert string
+	var receivedTitle, receivedAlert string
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		var payload map[string]any
 		if err := json.NewDecoder(r.Body).Decode(&payload); err == nil {
 			if n, ok := payload["notification"].(map[string]any); ok {
 				if a, ok := n["android"].(map[string]any); ok {
 					receivedAlert, _ = a["alert"].(string)
+					receivedTitle, _ = a["title"].(string)
 				}
 			}
 		}
@@ -654,6 +671,9 @@ func TestManager_BroadcastEvent_JPushAlert_WithoutTitleOrPreview(t *testing.T) {
 	}
 	mgr.BroadcastEvent(msg)
 
+	if receivedTitle != "AI任务完成" {
+		t.Errorf("expected default title, got %q", receivedTitle)
+	}
 	if receivedAlert != "AI会话已结束" {
 		t.Errorf("expected default alert, got %q", receivedAlert)
 	}


### PR DESCRIPTION
## Summary

Follow-up to #59 (issue #55). Improves push notification content and unifies the preview length limit.

### Changes

**Push notification format:**
- **Title**: `Done:` + SessionTitle (was: fixed "AI任务完成")
- **Alert**: ResponsePreview — the actual AI answer (was: SessionTitle priority → ResponsePreview fallback)

Before: title="AI任务完成", alert="帮我写一个Go HTTP服务器"
After: title="Done:帮我写一个Go HTTP服务器", alert="已创建main.go，包含HTTP服务器代码…"

**Preview length limit:**
- Unified `model.ResponsePreviewMaxRunes = 512` (single source of truth)
- `service.responsePreviewMaxRunes` and `ws.pushAlertMaxRunes` both reference it
- Was 64 (service) + 40 (JPush OPPO limit), now 512 for both WS and JPush
- Removed OPPO vendor channel truncation concern

### Files Changed
- `internal/model/chat.go` — add `ResponsePreviewMaxRunes` constant
- `internal/service/session_runtime.go` — reference `model.ResponsePreviewMaxRunes`
- `internal/ws/manager.go` — new title/alert format, reference `model.ResponsePreviewMaxRunes`
- `internal/ws/manager_test.go` — updated assertions for new format
- `internal/service/session_runtime_test.go` — updated truncation assertions