### PR TITLE
fix(android): complete JPush error degradation — reset jpushEnabledOnServer + restart native WS

### DIFF
--- a/android/app/src/main/java/com/clawbench/app/JPushReceiver.java
+++ b/android/app/src/main/java/com/clawbench/app/JPushReceiver.java
@@ -115,16 +115,28 @@ public class JPushReceiver extends JPushMessageReceiver {
             if (errorCode == 1005 || errorCode == 1008 || errorCode == 6001) {
                 AppLog.w(TAG, "JPush: init/registration failed (code=" + errorCode
                         + "), push unavailable — falling back to WebSocket");
-                // Reset pushAvailable on the main thread so BackgroundService
-                // can restore native WS for real-time event delivery.
+                // Reset both pushAvailable and jpushEnabledOnServer on the main thread
+                // so BackgroundService can restore native WS for real-time event delivery.
+                // jpushEnabledOnServer must also be reset because BackgroundService.onMessage
+                // checks (pushAvailable || jpushEnabledOnServer) — if jpushEnabledOnServer
+                // stays true, native WS won't be reconnected even though push is broken.
                 if (MainActivity.instance != null) {
                     MainActivity.instance.runOnUiThread(() -> {
                         if (MainActivity.instance.pushAvailable) {
                             MainActivity.instance.pushAvailable = false;
-                            AppLog.i(TAG, "JPush: pushAvailable reset to false, native WS will resume");
                         }
+                        if (MainActivity.instance.jpushEnabledOnServer) {
+                            MainActivity.instance.jpushEnabledOnServer = false;
+                        }
+                        AppLog.i(TAG, "JPush: pushAvailable and jpushEnabledOnServer reset to false, native WS will resume");
                     });
                 }
+                // Proactively restart native WS to ensure background event delivery.
+                // When the app is in the background, onPause() already ran and skipped
+                // starting native WS because jpushEnabledOnServer was true. Now that
+                // push has failed, we must start native WS immediately, otherwise the
+                // user gets no notifications until they bring the app to the foreground.
+                BackgroundService.startNativeEventWs(context);
             }
         } else {
             AppLog.d(TAG, "JPush: command success, cmd=" + cmdMessage.cmd);

--- a/android/app/src/test/java/com/clawbench/app/JPushReceiverCommandResultTest.java
+++ b/android/app/src/test/java/com/clawbench/app/JPushReceiverCommandResultTest.java
@@ -146,9 +146,9 @@ public class JPushReceiverCommandResultTest {
 
     @Test
     public void lambda_onCommandResult_resetsPushAvailable() throws Exception {
-        setupMainActivity(true);
+        setupMainActivity(true, true);
 
-        // Directly invoke the lambda that resets pushAvailable
+        // Directly invoke the lambda that resets pushAvailable and jpushEnabledOnServer
         Method lambda = JPushReceiver.class.getDeclaredMethod("lambda$onCommandResult$0");
         lambda.setAccessible(true);
         lambda.invoke(null);
@@ -158,15 +158,21 @@ public class JPushReceiverCommandResultTest {
         paField.setAccessible(true);
         assertFalse("pushAvailable should be false after lambda resets it",
                 paField.getBoolean(MainActivity.instance));
+
+        // Verify jpushEnabledOnServer was also reset to false
+        Field jesField = MainActivity.class.getDeclaredField("jpushEnabledOnServer");
+        jesField.setAccessible(true);
+        assertFalse("jpushEnabledOnServer should be false after lambda resets it",
+                jesField.getBoolean(MainActivity.instance));
     }
 
     // =====================================================
-    // Test 10: Lambda does nothing when pushAvailable is already false
+    // Test 10: Lambda does nothing when already false
     // =====================================================
 
     @Test
     public void lambda_onCommandResult_alreadyFalse_noException() throws Exception {
-        setupMainActivity(false);
+        setupMainActivity(false, false);
 
         Method lambda = JPushReceiver.class.getDeclaredMethod("lambda$onCommandResult$0");
         lambda.setAccessible(true);
@@ -175,11 +181,19 @@ public class JPushReceiverCommandResultTest {
         Field paField = MainActivity.class.getDeclaredField("pushAvailable");
         paField.setAccessible(true);
         assertFalse("pushAvailable should still be false", paField.getBoolean(MainActivity.instance));
+
+        Field jesField = MainActivity.class.getDeclaredField("jpushEnabledOnServer");
+        jesField.setAccessible(true);
+        assertFalse("jpushEnabledOnServer should still be false", jesField.getBoolean(MainActivity.instance));
     }
 
     // --- Helper methods ---
 
     private void setupMainActivity(boolean pushAvailableValue) throws Exception {
+        setupMainActivity(pushAvailableValue, pushAvailableValue);
+    }
+
+    private void setupMainActivity(boolean pushAvailableValue, boolean jpushEnabledOnServerValue) throws Exception {
         // Create a minimal MainActivity instance via Unsafe allocation
         var unsafeField = Class.forName("sun.misc.Unsafe").getDeclaredField("theUnsafe");
         unsafeField.setAccessible(true);
@@ -195,6 +209,10 @@ public class JPushReceiverCommandResultTest {
         Field paField = MainActivity.class.getDeclaredField("pushAvailable");
         paField.setAccessible(true);
         paField.setBoolean(activity, pushAvailableValue);
+
+        Field jesField = MainActivity.class.getDeclaredField("jpushEnabledOnServer");
+        jesField.setAccessible(true);
+        jesField.setBoolean(activity, jpushEnabledOnServerValue);
     }
 
     private static void callOnCommandResult(JPushReceiver receiver, cn.jpush.android.api.CmdMessage cmdMessage) throws Exception {


### PR DESCRIPTION
## Problem

PR #69 的修复不完整：`onCommandResult` 错误回调只重置了 `pushAvailable`，没有重置 `jpushEnabledOnServer`。

`BackgroundService.onMessage` 的判断条件是 `pushAvailable || jpushEnabledOnServer`——只要 `jpushEnabledOnServer` 仍为 true，native WS 就不会被恢复。结果：
1. JPush 初始化失败（1005）→ `pushAvailable = false` ✅
2. 但 `jpushEnabledOnServer` 仍为 `true` ❌
3. BackgroundService 断开 native WS 后不会重连 ❌
4. 用户在后台收不到任何通知 ❌

此外，如果 App 已在后台，`onPause()` 已经因为 `jpushEnabledOnServer=true` 跳过了启动 native WS。即使后续重置了两个标志，native WS 也不会被自动启动。

## Changes

1. **`onCommandResult` 同时重置 `jpushEnabledOnServer = false`**
   - BackgroundService 的 `pushAvailable || jpushEnabledOnServer` 条件现在两个都为 false
   - native WS 可以被正确恢复

2. **主动调用 `BackgroundService.startNativeEventWs(context)`**
   - 即使 App 在后台，也能立即恢复 native WS 事件通道
   - 不需要等用户下次 `onPause` 触发

## Testing

- Tier 1 (Project) ✅
- Tier 2 (Diff) ✅ — 90.9%
- Go 后端测试全部通过

Ref: #57