### PR TITLE
feat: apply Done: + preview format to task_update push notifications

### DIFF
--- a/internal/service/scheduler.go
+++ b/internal/service/scheduler.go
@@ -423,22 +423,32 @@ func UpdateTaskStats(task *model.ScheduledTask, newStatus string) {
 }
 
 // emitTaskEvent broadcasts a task_update event to connected clients.
-func emitTaskEvent(taskID, status, executionID, sessionID, projectPath string) {
+func emitTaskEvent(taskID, status, executionID, sessionID, projectPath, taskName string) {
 	mgr := ws.GetManager()
 	if mgr == nil {
 		return
+	}
+	data := &ws.TaskUpdateData{
+		TaskID:      taskID,
+		Status:      status,
+		ExecutionID: executionID,
+		SessionID:   sessionID,
+		ProjectPath: projectPath,
+	}
+	// For completed tasks, include session title (task name) and response preview
+	if status == "completed" || status == "cancelled" {
+		if taskName != "" {
+			data.SessionTitle = taskName
+		}
+		if status == "completed" && sessionID != "" {
+			data.ResponsePreview = getSessionResponsePreview(sessionID)
+		}
 	}
 	mgr.BroadcastEvent(ws.ServerMessage{
 		Type:  "event",
 		ID:    ws.GenerateEventID(),
 		Event: "task_update",
-		Data: &ws.TaskUpdateData{
-			TaskID:      taskID,
-			Status:      status,
-			ExecutionID: executionID,
-			SessionID:   sessionID,
-			ProjectPath: projectPath,
-		},
+		Data:  data,
 	})
 }
 
@@ -483,7 +493,7 @@ func (s *Scheduler) executeTask(task *model.ScheduledTask, projectPath string, t
 		slog.Error("failed to record task execution", slog.String("err", err.Error()))
 	}
 
-	emitTaskEvent(fmt.Sprintf("%d", task.ID), "running", fmt.Sprintf("%d", executionID), sessionID, projectPath)
+	emitTaskEvent(fmt.Sprintf("%d", task.ID), "running", fmt.Sprintf("%d", executionID), sessionID, projectPath, task.Name)
 
 	// Write user message (the prompt)
 	if _, err := AddChatMessage(projectPath, backendName, sessionID, "user", task.Prompt, nil, false, task.Name); err != nil {
@@ -561,7 +571,7 @@ func (s *Scheduler) executeTask(task *model.ScheduledTask, projectPath string, t
 	if err != nil {
 		slog.Error("failed to create backend for task", slog.String("err", err.Error()))
 		UpdateExecutionStatus(sessionID, "failed")
-		emitTaskEvent(fmt.Sprintf("%d", task.ID), "failed", fmt.Sprintf("%d", executionID), sessionID, projectPath)
+		emitTaskEvent(fmt.Sprintf("%d", task.ID), "failed", fmt.Sprintf("%d", executionID), sessionID, projectPath, task.Name)
 		return
 	}
 
@@ -569,7 +579,7 @@ func (s *Scheduler) executeTask(task *model.ScheduledTask, projectPath string, t
 	if err != nil {
 		slog.Error("failed to execute stream for task", slog.String("err", err.Error()))
 		UpdateExecutionStatus(sessionID, "failed")
-		emitTaskEvent(fmt.Sprintf("%d", task.ID), "failed", fmt.Sprintf("%d", executionID), sessionID, projectPath)
+		emitTaskEvent(fmt.Sprintf("%d", task.ID), "failed", fmt.Sprintf("%d", executionID), sessionID, projectPath, task.Name)
 		return
 	}
 
@@ -599,7 +609,7 @@ func (s *Scheduler) executeTask(task *model.ScheduledTask, projectPath string, t
 			slog.String("session_id", sessionID),
 		)
 		UpdateExecutionStatus(sessionID, "cancelled")
-		emitTaskEvent(fmt.Sprintf("%d", task.ID), "cancelled", fmt.Sprintf("%d", executionID), sessionID, projectPath)
+		emitTaskEvent(fmt.Sprintf("%d", task.ID), "cancelled", fmt.Sprintf("%d", executionID), sessionID, projectPath, task.Name)
 		newStatus := task.Status
 		UpdateTaskStats(task, newStatus)
 		return
@@ -614,7 +624,7 @@ func (s *Scheduler) executeTask(task *model.ScheduledTask, projectPath string, t
 			slog.String("session_id", sessionID),
 		)
 		UpdateExecutionStatus(sessionID, "failed")
-		emitTaskEvent(fmt.Sprintf("%d", task.ID), "failed", fmt.Sprintf("%d", executionID), sessionID, projectPath)
+		emitTaskEvent(fmt.Sprintf("%d", task.ID), "failed", fmt.Sprintf("%d", executionID), sessionID, projectPath, task.Name)
 		newStatus := task.Status
 		UpdateTaskStats(task, newStatus)
 		return
@@ -639,7 +649,7 @@ func (s *Scheduler) executeTask(task *model.ScheduledTask, projectPath string, t
 
 	// Mark execution as completed
 	UpdateExecutionStatus(sessionID, "completed")
-	emitTaskEvent(fmt.Sprintf("%d", task.ID), "completed", fmt.Sprintf("%d", executionID), sessionID, projectPath)
+	emitTaskEvent(fmt.Sprintf("%d", task.ID), "completed", fmt.Sprintf("%d", executionID), sessionID, projectPath, task.Name)
 
 	// Update task execution stats
 	newStatus := task.Status

--- a/internal/service/session_runtime_test.go
+++ b/internal/service/session_runtime_test.go
@@ -1059,6 +1059,13 @@ func TestSetSessionRunning_SkipEventTrue(t *testing.T) {
 // --- emitTaskEvent tests ---
 
 func TestEmitTaskEvent_WithSessionIDAndProjectPath(t *testing.T) {
+	origDB := DB
+	origDBRead := DBRead
+	db := setupChatTestDB(t)
+	DB = db
+	DBRead = db // Same instance for :memory: SQLite — data is shared
+	defer func() { DB = origDB; DBRead = origDBRead }()
+
 	mgr := ws.NewManagerForTest(nil)
 	ws.SetManagerForTest(mgr)
 	defer ws.SetManagerForTest(nil)
@@ -1067,7 +1074,7 @@ func TestEmitTaskEvent_WithSessionIDAndProjectPath(t *testing.T) {
 	sub := mgr.Subscribe(nil, &writeMu, "test-client-task-emit")
 	_ = sub
 
-	emitTaskEvent("42", "completed", "100", "session-task-1", "/home/user/project")
+	emitTaskEvent("42", "completed", "100", "session-task-1", "/home/user/project", "test task")
 
 	buffered := sub.GetBufferedEvents()
 	if len(buffered) == 0 {
@@ -1082,6 +1089,7 @@ func TestEmitTaskEvent_WithSessionIDAndProjectPath(t *testing.T) {
 	assert.Equal(t, "100", data.ExecutionID)
 	assert.Equal(t, "session-task-1", data.SessionID)
 	assert.Equal(t, "/home/user/project", data.ProjectPath)
+	assert.Equal(t, "test task", data.SessionTitle)
 }
 
 func TestEmitTaskEvent_EmptyOptionalFields(t *testing.T) {
@@ -1093,7 +1101,7 @@ func TestEmitTaskEvent_EmptyOptionalFields(t *testing.T) {
 	sub := mgr.Subscribe(nil, &writeMu, "test-client-task-emit2")
 	_ = sub
 
-	emitTaskEvent("43", "failed", "101", "", "")
+	emitTaskEvent("43", "failed", "101", "", "", "")
 
 	buffered := sub.GetBufferedEvents()
 	if len(buffered) == 0 {
@@ -1114,7 +1122,7 @@ func TestEmitTaskEvent_NilManager(t *testing.T) {
 
 	// Should not panic when ws manager is nil
 	assert.NotPanics(t, func() {
-		emitTaskEvent("44", "running", "102", "session-nil", "/project")
+		emitTaskEvent("44", "running", "102", "session-nil", "/project", "")
 	})
 }
 

--- a/internal/ws/manager.go
+++ b/internal/ws/manager.go
@@ -304,15 +304,24 @@ func (m *Manager) broadcastToSubscription(key string, msg ServerMessage, deliver
 		if msg.Event == "task_update" {
 			alert = "计划任务已完成"
 		}
-		// For session events: put session title in the notification title (more visible),
-		// and use response preview as the alert body (the actual AI answer content).
-		if d, ok := msg.Data.(*SessionUpdateData); ok {
-			if d.SessionTitle != "" {
-				title = "Done:" + d.SessionTitle
-			}
-			if d.ResponsePreview != "" {
-				alert = truncateForPush(d.ResponsePreview)
-			}
+		// Extract session title and response preview from event data for both
+		// session_update and task_update events, then format the notification:
+		//   title = "Done:" + session title
+		//   alert = response preview (the actual AI answer content)
+		var sessionTitle, responsePreview string
+		switch d := msg.Data.(type) {
+		case *SessionUpdateData:
+			sessionTitle = d.SessionTitle
+			responsePreview = d.ResponsePreview
+		case *TaskUpdateData:
+			sessionTitle = d.SessionTitle
+			responsePreview = d.ResponsePreview
+		}
+		if sessionTitle != "" {
+			title = "Done:" + sessionTitle
+		}
+		if responsePreview != "" {
+			alert = truncateForPush(responsePreview)
 		}
 		slog.Debug("ws: sending jpush notification", "event", msg.Event, "client_id", key, "reg_id", pushRegID, "title", title, "extras", extras)
 		if err := m.jpush.SendNotification(pushRegID, title, alert, extras); err != nil {

--- a/internal/ws/manager_test.go
+++ b/internal/ws/manager_test.go
@@ -680,13 +680,14 @@ func TestManager_BroadcastEvent_JPushAlert_WithoutTitleOrPreview(t *testing.T) {
 }
 
 func TestManager_BroadcastEvent_JPushAlert_TaskUpdate(t *testing.T) {
-	var receivedAlert string
+	var receivedTitle, receivedAlert string
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		var payload map[string]any
 		if err := json.NewDecoder(r.Body).Decode(&payload); err == nil {
 			if n, ok := payload["notification"].(map[string]any); ok {
 				if a, ok := n["android"].(map[string]any); ok {
 					receivedAlert, _ = a["alert"].(string)
+					receivedTitle, _ = a["title"].(string)
 				}
 			}
 		}
@@ -713,14 +714,19 @@ func TestManager_BroadcastEvent_JPushAlert_TaskUpdate(t *testing.T) {
 		ID:    "evt_1",
 		Event: "task_update",
 		Data: &TaskUpdateData{
-			TaskID: "t1",
-			Status: "completed",
+			TaskID:         "t1",
+			Status:         "completed",
+			SessionTitle:   "自动修复Bug",
+			ResponsePreview: "已修复空指针异常，添加了nil检查",
 		},
 	}
 	mgr.BroadcastEvent(msg)
 
-	if receivedAlert != "计划任务已完成" {
-		t.Errorf("expected task alert, got %q", receivedAlert)
+	if receivedTitle != "Done:自动修复Bug" {
+		t.Errorf("expected title with task name, got %q", receivedTitle)
+	}
+	if receivedAlert != "已修复空指针异常，添加了nil检查" {
+		t.Errorf("expected response preview alert, got %q", receivedAlert)
 	}
 }
 

--- a/internal/ws/protocol.go
+++ b/internal/ws/protocol.go
@@ -27,11 +27,13 @@ type SessionUpdateData struct {
 
 // TaskUpdateData is the data payload for "task_update" events.
 type TaskUpdateData struct {
-	TaskID      string `json:"task_id"`
-	Status      string `json:"status"`          // "running", "completed", "failed"
-	ExecutionID string `json:"execution_id,omitempty"`
-	SessionID   string `json:"session_id,omitempty"`
-	ProjectPath string `json:"project_path,omitempty"`
+	TaskID         string `json:"task_id"`
+	Status         string `json:"status"`                    // "running", "completed", "failed"
+	ExecutionID    string `json:"execution_id,omitempty"`
+	SessionID      string `json:"session_id,omitempty"`
+	ProjectPath    string `json:"project_path,omitempty"`
+	SessionTitle   string `json:"session_title,omitempty"`    // task name for push notification
+	ResponsePreview string `json:"response_preview,omitempty"` // preview of AI's final reply (completed only)
 }
 
 // QueueUpdateData is the data payload for "queue_update" events.


### PR DESCRIPTION
## Summary

Follow-up to #68. Extends the `Done:` + ResponsePreview push notification format to scheduled task (task_update) events, and unifies the preview length limit.

### Changes

**Task push notifications now match session format:**
- **Title**: `Done:` + task name (was: fixed "AI任务完成")
- **Alert**: ResponsePreview — the AI's actual answer (was: fixed "计划任务已完成")

**Protocol changes:**
- `TaskUpdateData` gains `SessionTitle` and `ResponsePreview` fields
- `emitTaskEvent` fills task name as `SessionTitle` on completed/cancelled
- `emitTaskEvent` fills `ResponsePreview` via `getSessionResponsePreview` on completed

**Unified handling:**
- `broadcastToSubscription` now handles both `SessionUpdateData` and `TaskUpdateData` with the same `Done:` + title / preview alert logic (type switch)

### Example

Before (task completed):
- title="AI任务完成", alert="计划任务已完成"

After (task completed):
- title="Done:自动修复Bug", alert="已修复空指针异常，添加了nil检查"

### Files Changed
- `internal/ws/protocol.go` — add SessionTitle, ResponsePreview to TaskUpdateData
- `internal/ws/manager.go` — unified type switch for both event types
- `internal/ws/manager_test.go` — updated TaskUpdate test
- `internal/service/scheduler.go` — emitTaskEvent signature + fill title/preview
- `internal/service/session_runtime_test.go` — update emitTaskEvent calls