### PR TITLE
fix: 项目切换时屏幕闪烁

### DIFF
--- a/web/src/App.vue
+++ b/web/src/App.vue
@@ -7,7 +7,7 @@
     <LoginView v-else-if="!isAuthenticated" @login-success="handleLoginSuccess" />
 
     <!-- Main app -->
-    <div v-else class="app-container" :class="{ 'chrome-hidden': terminalKeyboardActive, 'chat-keyboard-open': chatKeyboardActive }">
+    <div v-else class="app-container" :class="{ 'chrome-hidden': terminalKeyboardActive, 'chat-keyboard-open': chatKeyboardActive, 'project-switching': switchingProject }" :key="projectKey">
       <AppHeader
         :hidden="terminalActive"
         :project-root="projectRoot"
@@ -274,7 +274,8 @@ import SettingsPage from './components/settings/SettingsPage.vue'
 import TaskTab from '@/components/task/TaskTab.vue'
 import { useQuoteQuestion } from './composables/useQuoteQuestion.ts'
 import { useTaskTab, registerSwitchTab, onTaskEvent } from '@/composables/useTaskTab.ts'
-import { useSessionIdentity, registerSessionDrawerRef } from './composables/useSessionIdentity.ts'
+import { resetAgents } from '@/composables/useAgents'
+import { useSessionIdentity, registerSessionDrawerRef, resetIdentity } from './composables/useSessionIdentity.ts'
 import { loadSessionsOnce } from './composables/useChatSession.ts'
 import { useToast } from './composables/useToast.ts'
 import { useAppMode } from './composables/useAppMode.ts'
@@ -295,6 +296,65 @@ import './assets/hljs-light-override.css'
 
 const isAuthenticated = ref(null)
 const { t } = useI18n()
+
+// SPA hot project switch: key forces Vue to destroy/rebuild the app-container subtree
+const projectKey = ref('initial')
+const switchingProject = ref(false)
+
+async function hotSwitchProject(newProjectPath, pendingSessionId) {
+  // ── Phase 1: Fade out ──
+  switchingProject.value = true
+  await nextTick()
+  await new Promise(r => setTimeout(r, 150))
+
+  // ── Phase 2: Reset module-level singletons ──
+  store.resetProjectState()
+  resetIdentity()
+  resetAgents()
+
+  // ── Phase 3: Change key → Vue destroys old component tree & builds new one ──
+  projectKey.value = newProjectPath
+
+  // ── Phase 4: Reload all project-scoped data (mirrors onMounted after auth) ──
+  try { await store.loadProject() } catch (_) {
+    toast.show(t('toast.projectLoadFailed'), { icon: '⚠️', type: 'error', duration: 0, onClick: () => location.reload() })
+  }
+  await sessionIdentity.initSessionFromAPI()
+  loadSessionsOnce()
+  try { await store.loadFiles('') } catch (_) {}
+  store.loadGitBranch().catch(() => {})
+  loadTasks()
+  loadConfig()
+  loadSSHInfo().catch(() => {})
+  loadTerminalStatus().catch(() => {})
+  if (isAppMode.value) syncToNative().catch(() => {})
+
+  // ── Phase 5: Restore last opened file for the new project ──
+  const lastFile = localStorage.getItem('clawbenchLastFile_' + store.state.projectRoot)
+  if (lastFile && lastFile !== store.state.currentFile?.path) {
+    const lastSlash = lastFile.lastIndexOf('/')
+    store.state.currentDir = lastSlash > 0 ? lastFile.slice(0, lastSlash) : ''
+    await store.loadFiles(store.state.currentDir)
+    await store.selectFile(lastFile)
+    if (store.state.currentFile?.error) store.state.currentFile = null
+  }
+
+  // ── Phase 6: Handle cross-project pending navigation ──
+  if (pendingSessionId) {
+    const checkReady = () => {
+      if (sessionIdentity.currentSessionId.value) {
+        switchTab('chat')
+        sessionIdentity.switchSession(pendingSessionId)
+      } else {
+        setTimeout(checkReady, 100)
+      }
+    }
+    checkReady()
+  }
+
+  // ── Phase 7: Fade in ──
+  switchingProject.value = false
+}
 
 const activeTab = ref('chat')
 
@@ -330,16 +390,9 @@ function handleOpenSession(e) {
   const { sessionId, projectPath } = detail
   console.log('[ClawBench] clawbench-open-session: sessionId=', sessionId, 'projectPath=', projectPath, 'currentProject=', store.state.projectRoot)
   if (projectPath && projectPath !== store.state.projectRoot) {
-    // Cross-project: switch project, store pending session, then reload
+    // Cross-project: hot switch without page reload
     console.log('[ClawBench] cross-project navigation, switching to', projectPath)
-    localStorage.setItem('clawbenchPendingNav', JSON.stringify({ sessionId }))
-    fetch('/api/project', {
-      method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({ path: projectPath }),
-    }).then(() => {
-      window.location.reload()
-    }).catch(() => {
+    hotSwitchProject(projectPath, sessionId).catch(() => {
       // If project switch fails, try same-project switch as fallback
       console.warn('[ClawBench] project switch failed, falling back to same-project switch')
       switchTab('chat')
@@ -702,6 +755,7 @@ provide('theme', theme)
 provide('applyTheme', applyTheme)
 provide('activeTab', activeTab)
 provide('switchTab', switchTab)
+provide('hotSwitchProject', hotSwitchProject)
 
 function handleOpenFileManager() {
     activeTab.value = 'browse'
@@ -864,13 +918,8 @@ onMounted(async () => {
               // Navigation data found — stop polling
               pollCleared = true
               if (projectPath && projectPath !== store.state.projectRoot) {
-                // Need to switch project first
-                localStorage.setItem('clawbenchPendingNav', JSON.stringify({ sessionId }))
-                fetch('/api/project', {
-                  method: 'POST',
-                  headers: { 'Content-Type': 'application/json' },
-                  body: JSON.stringify({ path: projectPath }),
-                }).then(() => window.location.reload())
+                // Need to switch project first — use hot switch instead of reload
+                hotSwitchProject(projectPath, sessionId)
               } else {
                 processPendingNav(sessionId)
               }
@@ -913,6 +962,14 @@ onUnmounted(() => {
 </script>
 
 <style scoped>
+/* SPA hot project switch: fade transition to mask intermediate state */
+.app-container {
+    transition: opacity 0.15s ease;
+}
+.app-container.project-switching {
+    opacity: 0;
+}
+
 .viewer-panel {
   flex: 1;
   display: flex;

--- a/web/src/App.vue
+++ b/web/src/App.vue
@@ -307,15 +307,18 @@ async function hotSwitchProject(newProjectPath, pendingSessionId) {
   await nextTick()
   await new Promise(r => setTimeout(r, 150))
 
-  // ── Phase 2: Reset module-level singletons ──
-  store.resetProjectState()
+  // ── Phase 2: POST to backend to set new project cookie ──
+  await store.setProject(newProjectPath)
+
+  // ── Phase 3: Reset module-level singletons ──
+  // (store state already reset by setProject, but identity/agents need explicit reset)
   resetIdentity()
   resetAgents()
 
-  // ── Phase 3: Change key → Vue destroys old component tree & builds new one ──
+  // ── Phase 4: Change key → Vue destroys old component tree & builds new one ──
   projectKey.value = newProjectPath
 
-  // ── Phase 4: Reload all project-scoped data (mirrors onMounted after auth) ──
+  // ── Phase 5: Reload all project-scoped data (mirrors onMounted after auth) ──
   try { await store.loadProject() } catch (_) {
     toast.show(t('toast.projectLoadFailed'), { icon: '⚠️', type: 'error', duration: 0, onClick: () => location.reload() })
   }
@@ -329,7 +332,7 @@ async function hotSwitchProject(newProjectPath, pendingSessionId) {
   loadTerminalStatus().catch(() => {})
   if (isAppMode.value) syncToNative().catch(() => {})
 
-  // ── Phase 5: Restore last opened file for the new project ──
+  // ── Phase 6: Restore last opened file for the new project ──
   const lastFile = localStorage.getItem('clawbenchLastFile_' + store.state.projectRoot)
   if (lastFile && lastFile !== store.state.currentFile?.path) {
     const lastSlash = lastFile.lastIndexOf('/')
@@ -339,7 +342,7 @@ async function hotSwitchProject(newProjectPath, pendingSessionId) {
     if (store.state.currentFile?.error) store.state.currentFile = null
   }
 
-  // ── Phase 6: Handle cross-project pending navigation ──
+  // ── Phase 7: Handle cross-project pending navigation ──
   if (pendingSessionId) {
     const checkReady = () => {
       if (sessionIdentity.currentSessionId.value) {
@@ -352,7 +355,7 @@ async function hotSwitchProject(newProjectPath, pendingSessionId) {
     checkReady()
   }
 
-  // ── Phase 7: Fade in ──
+  // ── Phase 8: Fade in ──
   switchingProject.value = false
 }
 

--- a/web/src/components/ProjectDialog.vue
+++ b/web/src/components/ProjectDialog.vue
@@ -72,6 +72,7 @@ const props = defineProps({
 })
 const emit = defineEmits(['close'])
 const toast = inject('toast', null)
+const hotSwitchProject = inject('hotSwitchProject', null)
 
 const loading = ref(false)
 const selectedPath = ref('')
@@ -204,18 +205,24 @@ async function confirm() {
     }
     if (!path) return
     try {
-        const resp = await fetch('/api/project', {
-            method: 'POST',
-            headers: { 'Content-Type': 'application/json' },
-            body: JSON.stringify({ path })
-        })
-        if (resp.ok) {
-            window.location.reload()
+        if (hotSwitchProject) {
+            emit('close')
+            await hotSwitchProject(path)
         } else {
-            const text = await resp.text()
-            let msg = text
-            try { msg = JSON.parse(text).error || msg } catch (_) {}
-            await dialog.alert(t('projectDialog.setProjectFailedDetail', { error: msg }))
+            // Fallback: legacy full reload
+            const resp = await fetch('/api/project', {
+                method: 'POST',
+                headers: { 'Content-Type': 'application/json' },
+                body: JSON.stringify({ path })
+            })
+            if (resp.ok) {
+                window.location.reload()
+            } else {
+                const text = await resp.text()
+                let msg = text
+                try { msg = JSON.parse(text).error || msg } catch (_) {}
+                await dialog.alert(t('projectDialog.setProjectFailedDetail', { error: msg }))
+            }
         }
     } catch (err) {
         await dialog.alert(t('projectDialog.setProjectFailedDetail', { error: err.message }))

--- a/web/src/components/common/AppHeader.vue
+++ b/web/src/components/common/AppHeader.vue
@@ -84,6 +84,7 @@ const props = defineProps({
 const emit = defineEmits(['openProjectDialog'])
 
 const toast = inject('toast')
+const hotSwitchProject = inject('hotSwitchProject')
 
 // Connection status menu state
 const statusBtnRef = ref(null)
@@ -204,14 +205,19 @@ async function selectRecent(item) {
     dropdownOpen.value = false
     if (item.path === props.projectRoot) return
     try {
-        const resp = await fetch('/api/project', {
-            method: 'POST',
-            headers: { 'Content-Type': 'application/json' },
-            body: JSON.stringify({ path: item.path })
-        })
-        if (resp.ok) {
-            window.location.reload()
+        if (hotSwitchProject) {
+            await hotSwitchProject(item.path)
         } else {
+            // Fallback: legacy full reload
+            const resp = await fetch('/api/project', {
+                method: 'POST',
+                headers: { 'Content-Type': 'application/json' },
+                body: JSON.stringify({ path: item.path })
+            })
+            if (resp.ok) {
+                window.location.reload()
+                return
+            }
             const text = await resp.text()
             let msg = text
             let msgKey = ''
@@ -222,13 +228,11 @@ async function selectRecent(item) {
             } catch (_) {}
             if (msgKey === 'NotADirectory') {
                 toast?.show(t('appHeader.projectPathNotFound'), { icon: '⚠️', type: 'error', duration: 3000 })
-                // Remove stale entry from recent projects
                 fetch('/api/recent-projects', {
                     method: 'DELETE',
                     headers: { 'Content-Type': 'application/json' },
                     body: JSON.stringify({ path: item.path })
                 }).catch(() => {})
-                // Remove from local list immediately
                 recentItems.value = recentItems.value.filter(r => r.path !== item.path)
             } else {
                 toast?.show(t('appHeader.switchProjectFailed', { error: msg }), { icon: '⚠️', type: 'error', duration: 3000 })

--- a/web/src/components/git/GitManageContent.vue
+++ b/web/src/components/git/GitManageContent.vue
@@ -31,7 +31,7 @@
 </template>
 
 <script setup lang="ts">
-import { ref, onMounted } from 'vue'
+import { ref, onMounted, inject } from 'vue'
 import { useI18n } from 'vue-i18n'
 import { store } from '@/stores/app.ts'
 import { apiGet, apiPost } from '@/utils/api'
@@ -42,6 +42,7 @@ import GitBranchList from './GitBranchList.vue'
 
 const { t } = useI18n()
 const dialog = useDialog()
+const hotSwitchProject = inject('hotSwitchProject', null) as ((path: string, pendingSessionId?: string) => Promise<void>) | null
 
 const worktrees = ref<any[]>([])
 const branches = ref<any[]>([])
@@ -103,7 +104,11 @@ async function onSwitchWorktree(wt: any) {
     { title: t('git.manage.switchWorktree') },
   )
   if (!confirmed) return
-  await store.setProject(wt.path)
+  if (hotSwitchProject) {
+    await hotSwitchProject(wt.path)
+  } else {
+    await store.setProject(wt.path)
+  }
 }
 
 async function onSwitchBranch(branch: any) {

--- a/web/src/composables/__tests__/useAgents.test.ts
+++ b/web/src/composables/__tests__/useAgents.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it, vi, beforeEach } from 'vitest'
-import { useAgents } from '@/composables/useAgents'
+import { useAgents, resetAgents } from '@/composables/useAgents'
 
 // Mock apiGet to control agent data
 const mockApiGet = vi.fn()
@@ -338,6 +338,37 @@ describe('useAgents', () => {
 
     it('returns false for unknown agent', () => {
       expect(hasThinkingEffortLevels('nonexistent')).toBe(false)
+    })
+  })
+
+  // --- resetAgents ---
+
+  describe('resetAgents', () => {
+    it('clears agents and defaultAgentId', async () => {
+      // After beforeEach, agents are loaded
+      expect(agents.value).toHaveLength(3)
+      expect(defaultAgentId.value).toBe('claude')
+
+      resetAgents()
+
+      expect(agents.value).toEqual([])
+      expect(defaultAgentId.value).toBe('')
+    })
+
+    it('clears loadPromise so next loadAgents re-fetches', async () => {
+      // After beforeEach, loadAgents is cached (loadPromise was set and cleared)
+      // Reset should clear the cache so a new loadAgents() triggers an API call
+      const callCountBefore = mockApiGet.mock.calls.length
+      await loadAgents()
+      expect(mockApiGet.mock.calls.length).toBe(callCountBefore) // cached, no new call
+
+      resetAgents()
+      mockApiGet.mockResolvedValue({ agents: testAgents, defaultAgent: 'gpt' })
+      await loadAgents()
+      expect(mockApiGet.mock.calls.length).toBe(callCountBefore + 1) // new API call made
+
+      // New default loaded
+      expect(defaultAgentId.value).toBe('gpt')
     })
   })
 

--- a/web/src/composables/__tests__/useSessionIdentity.test.ts
+++ b/web/src/composables/__tests__/useSessionIdentity.test.ts
@@ -46,7 +46,7 @@ vi.mock('@/utils/chatSessionUtils', () => ({
     parseMessages: vi.fn().mockReturnValue([]),
 }))
 
-import { useSessionIdentity, registerSessionActions, initSessionFromAPI } from '@/composables/useSessionIdentity'
+import { useSessionIdentity, registerSessionActions, initSessionFromAPI, resetIdentity } from '@/composables/useSessionIdentity'
 
 describe('useSessionIdentity', () => {
     beforeEach(() => {
@@ -460,6 +460,73 @@ describe('useSessionIdentity', () => {
             expect(identity.currentThinkingEffort.value).toBe('medium')
 
             vi.unstubAllGlobals()
+        })
+    })
+
+    // ── resetIdentity ──
+
+    describe('resetIdentity', () => {
+        it('clears all identity refs to defaults', async () => {
+            const identity = useSessionIdentity()
+
+            // Set some state
+            identity.currentSessionId.value = 'session-1'
+            identity.currentSessionTitle.value = 'Title'
+            identity.currentBackend.value = 'codebuddy'
+            identity.currentAgentId.value = 'agent-1'
+            identity.currentModelId.value = 'model-1'
+            identity.currentModelName.value = 'Model One'
+            identity.currentThinkingEffort.value = 'high'
+            identity.runningSessions.value = new Set(['s1', 's2'])
+            identity.sessionDrawerOpen.value = true
+
+            resetIdentity()
+
+            expect(identity.currentSessionId.value).toBe('')
+            expect(identity.currentSessionTitle.value).toBe('')
+            expect(identity.currentBackend.value).toBe('')
+            expect(identity.currentAgentId.value).toBe('')
+            expect(identity.currentModelId.value).toBe('')
+            expect(identity.currentModelName.value).toBe('')
+            expect(identity.currentThinkingEffort.value).toBe('')
+            expect(identity.runningSessions.value.size).toBe(0)
+            expect(identity.sessionDrawerOpen.value).toBe(false)
+        })
+
+        it('clears registered session action callbacks', async () => {
+            const mockSwitch = vi.fn()
+            registerSessionActions({
+                switchSession: mockSwitch,
+                createSession: vi.fn(),
+                deleteSession: vi.fn(),
+                sendMessage: vi.fn(),
+                openChatPanel: vi.fn(),
+            })
+
+            resetIdentity()
+
+            // After reset, the identity should have null callbacks
+            // so calling switchSession should not invoke the old callback
+            const identity = useSessionIdentity()
+            await identity.switchSession('session-2')
+            expect(mockSwitch).not.toHaveBeenCalled()
+        })
+
+        it('clears openChatPanel callback', () => {
+            const mockOpen = vi.fn()
+            registerSessionActions({
+                switchSession: vi.fn(),
+                createSession: vi.fn(),
+                deleteSession: vi.fn(),
+                sendMessage: vi.fn(),
+                openChatPanel: mockOpen,
+            })
+
+            resetIdentity()
+
+            const identity = useSessionIdentity()
+            identity.openChatPanel()
+            expect(mockOpen).not.toHaveBeenCalled()
         })
     })
 })

--- a/web/src/composables/useAgents.ts
+++ b/web/src/composables/useAgents.ts
@@ -7,6 +7,13 @@ const agents = ref<any[]>([])
 const defaultAgentId = ref('')
 let loadPromise: Promise<void> | null = null
 
+/** Reset all module-level singleton refs — used by SPA hot project switch. */
+export function resetAgents(): void {
+    agents.value = []
+    defaultAgentId.value = ''
+    loadPromise = null
+}
+
 async function loadAgents(force = false): Promise<void> {
     if (!force && agents.value.length > 0) return // already loaded
     if (!force && loadPromise) return loadPromise  // load in progress

--- a/web/src/composables/useSessionIdentity.ts
+++ b/web/src/composables/useSessionIdentity.ts
@@ -27,6 +27,26 @@ const runningSessionsVersion = ref(0)
 // instance that's accessible from any tab (chat, viewer, QuoteQuestionBar).
 const sessionDrawerOpen = ref(false)
 
+/** Reset all module-level singleton refs — used by SPA hot project switch. */
+export function resetIdentity(): void {
+  currentSessionId.value = ''
+  currentSessionTitle.value = ''
+  currentBackend.value = ''
+  currentAgentId.value = ''
+  currentModelId.value = ''
+  currentModelName.value = ''
+  currentThinkingEffort.value = ''
+  runningSessions.value = new Set()
+  runningSessionsVersion.value = 0
+  sessionDrawerOpen.value = false
+  _switchSession = null
+  _createSession = null
+  _deleteSession = null
+  _sendMessage = null
+  _openChatPanel = null
+  _sessionDrawerRef = null
+}
+
 // ───────────────────────────────────────────────────────────
 // Agent preference persistence — stored in agent YAML files via PATCH /api/agents.
 // preferredModel / preferredThinkingEffort are the source of truth for

--- a/web/src/stores/__tests__/app.test.ts
+++ b/web/src/stores/__tests__/app.test.ts
@@ -1,0 +1,161 @@
+import { describe, expect, it, vi, beforeEach } from 'vitest'
+
+// Mock apiGet and apiPost
+const mockApiPost = vi.fn()
+const mockApiGet = vi.fn()
+vi.mock('@/utils/api', () => ({
+    apiGet: (...args: any[]) => mockApiGet(...args),
+    apiPost: (...args: any[]) => mockApiPost(...args),
+}))
+
+// Mock path utils
+vi.mock('@/utils/path.ts', () => ({
+    baseName: (p: string) => p.split('/').pop() || '',
+    dirName: (p: string) => p.split('/').slice(0, -1).join('/') || '/',
+}))
+
+// Mock useLocale
+vi.mock('@/composables/useLocale', () => ({
+    gt: (key: string) => key,
+}))
+
+// Mock useToast
+vi.mock('@/composables/useToast', () => ({
+    useToast: () => ({ show: vi.fn() }),
+}))
+
+// Mock useDialog
+vi.mock('@/composables/useDialog', () => ({
+    useDialog: () => ({ confirm: vi.fn().mockResolvedValue(true) }),
+}))
+
+import { store } from '@/stores/app'
+
+describe('store', () => {
+    beforeEach(() => {
+        vi.clearAllMocks()
+        // Reset state to defaults before each test
+        store.resetProjectState()
+    })
+
+    // ── resetProjectState ──
+
+    describe('resetProjectState', () => {
+        it('clears project fields', () => {
+            store.state.projectRoot = '/some/project'
+            store.state.projectName = 'project'
+            store.state.watchDir = '/watch'
+
+            store.resetProjectState()
+
+            expect(store.state.projectRoot).toBe('')
+            expect(store.state.projectName).toBe('')
+            expect(store.state.watchDir).toBe('')
+        })
+
+        it('clears file browser state', () => {
+            store.state.currentDir = '/some/dir'
+            store.state.dirEntries = [{ name: 'file.ts', type: 'file' }] as any
+            store.state.dirLoading = true
+            store.state.currentFile = { name: 'file.ts', path: '/file.ts' } as any
+
+            store.resetProjectState()
+
+            expect(store.state.currentDir).toBe('')
+            expect(store.state.dirEntries).toEqual([])
+            expect(store.state.dirLoading).toBe(false)
+            expect(store.state.currentFile).toBeNull()
+        })
+
+        it('clears file history', () => {
+            store.state.fileHistory = ['/a', '/b']
+            store.state.fileHistoryIndex = 1
+
+            store.resetProjectState()
+
+            expect(store.state.fileHistory).toEqual([])
+            expect(store.state.fileHistoryIndex).toBe(-1)
+        })
+
+        it('clears git state', () => {
+            store.state.gitBranch = 'main'
+            store.state.gitHead = 'abc123'
+            store.state.gitDirty = true
+
+            store.resetProjectState()
+
+            expect(store.state.gitBranch).toBe('')
+            expect(store.state.gitHead).toBe('')
+            expect(store.state.gitDirty).toBe(false)
+        })
+
+        it('clears chat/task badges', () => {
+            store.state.chatUnread = true
+            store.state.chatRunning = true
+            store.state.taskUnread = true
+            store.state.taskRunning = true
+            store.state.taskJustCompleted = true
+            store.state.tasks = [{ id: 'task-1' }]
+
+            store.resetProjectState()
+
+            expect(store.state.chatUnread).toBe(false)
+            expect(store.state.chatRunning).toBe(false)
+            expect(store.state.taskUnread).toBe(false)
+            expect(store.state.taskRunning).toBe(false)
+            expect(store.state.taskJustCompleted).toBe(false)
+            expect(store.state.tasks).toEqual([])
+        })
+
+        it('resets config defaults', () => {
+            store.state.uploadMaxSizeMB = 999
+            store.state.uploadMaxFiles = 99
+            store.state.chatInitialMessages = 999
+            store.state.chatPageSize = 999
+            store.state.chatSessionPageSize = 999
+            store.state.chatCollapsedHeight = 999
+            store.state.sessionMaxCount = 999
+
+            store.resetProjectState()
+
+            expect(store.state.uploadMaxSizeMB).toBe(100)
+            expect(store.state.uploadMaxFiles).toBe(20)
+            expect(store.state.chatInitialMessages).toBe(20)
+            expect(store.state.chatPageSize).toBe(20)
+            expect(store.state.chatSessionPageSize).toBe(10)
+            expect(store.state.chatCollapsedHeight).toBe(150)
+            expect(store.state.sessionMaxCount).toBe(10)
+        })
+    })
+
+    // ── setProject ──
+
+    describe('setProject', () => {
+        it('calls API and resets project state', async () => {
+            // Set some state that should be cleared
+            store.state.projectRoot = '/old/project'
+            store.state.gitBranch = 'old-branch'
+            store.state.chatRunning = true
+
+            mockApiPost.mockResolvedValue({ ok: 'ok', path: '/new/project' })
+
+            const result = await store.setProject('/new/project')
+
+            expect(mockApiPost).toHaveBeenCalledWith('/api/project', { path: '/new/project' })
+            // After setProject, resetProjectState should have been called
+            expect(store.state.projectRoot).toBe('')
+            expect(store.state.gitBranch).toBe('')
+            expect(store.state.chatRunning).toBe(false)
+            // Returns the path from API response
+            expect(result).toBe('/new/project')
+        })
+
+        it('returns the input path when API does not return a path', async () => {
+            mockApiPost.mockResolvedValue({ ok: 'ok' })
+
+            const result = await store.setProject('/my/project')
+
+            expect(result).toBe('/my/project')
+        })
+    })
+})

--- a/web/src/stores/app.ts
+++ b/web/src/stores/app.ts
@@ -161,9 +161,43 @@ async function loadProject(): Promise<void> {
     }
 }
 
-async function setProject(path: string): Promise<void> {
-    await apiPost('/api/project', { path })
-    window.location.reload()
+async function setProject(path: string): Promise<string> {
+    const data = await apiPost<{ ok: string; path: string }>('/api/project', { path })
+    resetProjectState()
+    return data.path || path
+}
+
+function resetProjectState(): void {
+    // Project
+    state.projectRoot = ''
+    state.projectName = ''
+    state.watchDir = ''
+    // File browser
+    state.currentDir = ''
+    state.dirEntries = []
+    state.dirLoading = false
+    state.currentFile = null
+    state.fileHistory = []
+    state.fileHistoryIndex = -1
+    // Git
+    state.gitBranch = ''
+    state.gitHead = ''
+    state.gitDirty = false
+    // Chat/task badges
+    state.chatUnread = false
+    state.chatRunning = false
+    state.taskUnread = false
+    state.taskRunning = false
+    state.taskJustCompleted = false
+    state.tasks = []
+    // Config defaults
+    state.uploadMaxSizeMB = 100
+    state.uploadMaxFiles = 20
+    state.chatInitialMessages = 20
+    state.chatPageSize = 20
+    state.chatSessionPageSize = 10
+    state.chatCollapsedHeight = 150
+    state.sessionMaxCount = 10
 }
 
 // =============================================
@@ -428,6 +462,7 @@ export const store = {
     state,
     loadProject,
     setProject,
+    resetProjectState,
     loadGitBranch,
     loadFiles,
     selectFile,


### PR DESCRIPTION
## 问题描述

Closes #53

项目切换时屏幕短暂白屏闪烁，切换过程生硬。

## 根因

所有项目切换路径最终调用 `window.location.reload()`，浏览器全页面刷新导致白屏。`isAuthenticated` 初始为 `null` → 渲染 `display:none` 空 div → 串行异步初始化 → 白屏时间叠加。

## 修复方案

用 SPA 热切换替代 `window.location.reload()`：

1. **`:key` 强制重建** — `app-container` 绑定 `:key="projectKey"`，切换时改变 key 值，Vue 自动销毁旧组件树、创建新组件树
2. **模块级单例手动重置** — store、sessionIdentity、agents 三个模块级单例添加 reset 函数
3. **fade 过渡遮挡** — 切换时 150ms fade-out → 重建 → 数据加载 → fade-in
4. **5 个 reload 调用点全部替换** — AppHeader、ProjectDialog、GitManageContent、Android 推送导航、跨项目 session 导航

## 修改文件

| 文件 | 变更 |
|------|------|
| `stores/app.ts` | `setProject()` 不再 reload；新增 `resetProjectState()` |
| `composables/useSessionIdentity.ts` | 新增 `resetIdentity()` |
| `composables/useAgents.ts` | 新增 `resetAgents()` |
| `App.vue` | 新增 `hotSwitchProject()` + `projectKey` + fade 过渡 + provide |
| `AppHeader.vue` | inject `hotSwitchProject` 替换 reload |
| `ProjectDialog.vue` | inject `hotSwitchProject` 替换 reload |
| `GitManageContent.vue` | inject `hotSwitchProject` 替换 `store.setProject()` |