### PR TITLE
fix: 修复 iOS PWA 刘海遮盖 Toast、Lightbox 工具栏和 Git 提示框

### DIFF
--- a/web/src/components/common/ToastNotification.vue
+++ b/web/src/components/common/ToastNotification.vue
@@ -21,7 +21,7 @@ defineProps({
 <style>
 .toast {
     position: fixed;
-    top: 8px;
+    top: calc(8px + var(--header-safe-area-top, 0px));
     left: 0;
     right: 0;
     margin: 0 auto;

--- a/web/src/components/git/GitGraph.vue
+++ b/web/src/components/git/GitGraph.vue
@@ -230,6 +230,8 @@ const tooltipStyle = computed(() => {
   let y = tooltip.value.y
   const vw = window.innerWidth
   const vh = window.innerHeight
+  // Account for iOS notch / safe area so tooltip isn't hidden behind it
+  const safeTop = parseInt(getComputedStyle(document.documentElement).getPropertyValue('--header-safe-area-top')) || 0
   // Use measured dimensions if available, fall back to estimates
   const el = tooltipEl.value
   const tw = el ? el.offsetWidth : Math.max(80, tooltip.value.items.length * 80)
@@ -240,8 +242,9 @@ const tooltipStyle = computed(() => {
   if (x < 8) x = 8
   // Clamp bottom edge
   if (y + th > vh - 8) y = y - th - 16
-  // Clamp top edge
-  if (y < 8) y = 8
+  // Clamp top edge — respect safe area
+  const minTop = 8 + safeTop
+  if (y < minTop) y = minTop
   return {
     left: x + 'px',
     top: y + 'px',

--- a/web/src/components/media/Lightbox.vue
+++ b/web/src/components/media/Lightbox.vue
@@ -552,7 +552,7 @@ onUnmounted(() => {
 
 .lightbox-toolbar {
     position: absolute;
-    top: 16px;
+    top: calc(16px + var(--header-safe-area-top, 0px));
     left: 16px;
     right: 16px;
     display: flex;


### PR DESCRIPTION
## 变更说明

iOS PWA 模式下，Toast 通知、Lightbox 工具栏和 Git 提交图 tooltip 使用硬编码的 top 值定位，未考虑顶部安全区域，导致被刘海/灵动岛遮挡。本 PR 将所有顶部偏移加上 `var(--header-safe-area-top)` 适配。

## 变更类型

- [x] fix: Bug 修复

## 关联 Issue

Fixes #74

## 测试

- [x] 已通过现有测试（2704 个前端测试全部通过）
- [x] 手动验证（iPhone PWA 模式下 Toast、Lightbox 工具栏不再被刘海遮挡）

## 自检清单

- [x] 代码遵循项目现有风格
- [x] 无硬编码密钥或敏感信息

## 具体变更

| 文件 | 变更 |
|------|------|
| `web/src/components/common/ToastNotification.vue` | `top: 8px` → `top: calc(8px + var(--header-safe-area-top, 0px))` |
| `web/src/components/media/Lightbox.vue` | `top: 16px` → `top: calc(16px + var(--header-safe-area-top, 0px))` |
| `web/src/components/git/GitGraph.vue` | tooltip top clamp 从 `8` 改为 `8 + safeTop` |

### 兼容性

- 普通浏览器：`--header-safe-area-top` 为 `0px`，无任何视觉变化
- iOS PWA：元素自动下移至刘海下方