### PR TITLE
fix: 定时任务通知点击跳转到执行详情而非会话界面

### DIFF
--- a/android/app/src/main/java/com/clawbench/app/BackgroundService.java
+++ b/android/app/src/main/java/com/clawbench/app/BackgroundService.java
@@ -1312,6 +1312,7 @@ public class BackgroundService extends Service {
             } else if ("task_update".equals(eventType)) {
                 taskId = data.optString("task_id", "");
                 sessionId = data.optString("session_id", null);
+                String executionId = data.optString("execution_id", null);
                 if ("completed".equals(status)) {
                     title = "计划任务完成";
                     text = "任务已完成";
@@ -1322,6 +1323,57 @@ public class BackgroundService extends Service {
                     title = "计划任务通知";
                     text = "任务失败";
                 }
+                // Build intent for notification tap — open the app and navigate to task execution detail
+                Intent intent = new Intent(this, MainActivity.class);
+                intent.setAction(android.content.Intent.ACTION_MAIN);
+                intent.addCategory(android.content.Intent.CATEGORY_LAUNCHER);
+                intent.addFlags(Intent.FLAG_ACTIVITY_SINGLE_TOP | Intent.FLAG_ACTIVITY_NEW_TASK | Intent.FLAG_ACTIVITY_CLEAR_TOP);
+                intent.putExtra("event_type", "task_update");
+                if (taskId != null && !taskId.isEmpty()) {
+                    intent.putExtra("task_id", taskId);
+                }
+                if (executionId != null && !executionId.isEmpty()) {
+                    intent.putExtra("execution_id", executionId);
+                }
+                if (sessionId != null && !sessionId.isEmpty()) {
+                    intent.putExtra("session_id", sessionId);
+                }
+                projectPath = data.optString("project_path", "");
+                if (projectPath != null && !projectPath.isEmpty()) {
+                    intent.putExtra("project_path", projectPath);
+                }
+
+                AppLog.i(TAG, "NativeWS: notification intent extras: session_id=" + sessionId
+                        + ", task_id=" + taskId + ", execution_id=" + executionId + ", project_path=" + projectPath);
+
+                PendingIntent pendingIntent = PendingIntent.getActivity(
+                        this, 0, intent,
+                        PendingIntent.FLAG_UPDATE_CURRENT | PendingIntent.FLAG_IMMUTABLE
+                );
+
+                // Use hash of task_id as notification ID so each gets its own notification
+                int notifId = EVENTS_NOTIFICATION_ID;
+                if (taskId != null && !taskId.isEmpty()) {
+                    notifId = EVENTS_NOTIFICATION_ID + 1000 + Math.abs(taskId.hashCode() % 1000);
+                } else if (sessionId != null && !sessionId.isEmpty()) {
+                    notifId = EVENTS_NOTIFICATION_ID + Math.abs(sessionId.hashCode() % 1000);
+                }
+
+                Notification notification = new NotificationCompat.Builder(this, EVENTS_CHANNEL_ID)
+                        .setContentTitle(title)
+                        .setContentText(text)
+                        .setSmallIcon(R.drawable.ic_notification)
+                        .setContentIntent(pendingIntent)
+                        .setAutoCancel(true)
+                        .build();
+
+                NotificationManager nm = getSystemService(NotificationManager.class);
+                if (nm != null) {
+                    nm.notify(notifId, notification);
+                }
+
+                AppLog.i(TAG, "NativeWS: posted notification: " + title + " - " + text);
+                return;
             } else {
                 AppLog.i(TAG, "NativeWS: postEventNotification - unhandled eventType=" + eventType + ", skipping");
                 return;
@@ -1332,11 +1384,9 @@ public class BackgroundService extends Service {
             intent.setAction(android.content.Intent.ACTION_MAIN);
             intent.addCategory(android.content.Intent.CATEGORY_LAUNCHER);
             intent.addFlags(Intent.FLAG_ACTIVITY_SINGLE_TOP | Intent.FLAG_ACTIVITY_NEW_TASK | Intent.FLAG_ACTIVITY_CLEAR_TOP);
+            intent.putExtra("event_type", "session_update");
             if (sessionId != null && !sessionId.isEmpty()) {
                 intent.putExtra("session_id", sessionId);
-            }
-            if (taskId != null && !taskId.isEmpty()) {
-                intent.putExtra("task_id", taskId);
             }
             projectPath = data.optString("project_path", "");
             if (projectPath != null && !projectPath.isEmpty()) {
@@ -1344,19 +1394,17 @@ public class BackgroundService extends Service {
             }
 
             AppLog.i(TAG, "NativeWS: notification intent extras: session_id=" + sessionId
-                    + ", task_id=" + taskId + ", project_path=" + projectPath);
+                    + ", project_path=" + projectPath);
 
             PendingIntent pendingIntent = PendingIntent.getActivity(
                     this, 0, intent,
                     PendingIntent.FLAG_UPDATE_CURRENT | PendingIntent.FLAG_IMMUTABLE
             );
 
-            // Use hash of session_id/task_id as notification ID so each gets its own notification
+            // Use hash of session_id as notification ID so each gets its own notification
             int notifId = EVENTS_NOTIFICATION_ID;
             if (sessionId != null && !sessionId.isEmpty()) {
                 notifId = EVENTS_NOTIFICATION_ID + Math.abs(sessionId.hashCode() % 1000);
-            } else if (taskId != null && !taskId.isEmpty()) {
-                notifId = EVENTS_NOTIFICATION_ID + 1000 + Math.abs(taskId.hashCode() % 1000);
             }
 
             Notification notification = new NotificationCompat.Builder(this, EVENTS_CHANNEL_ID)

--- a/android/app/src/main/java/com/clawbench/app/JPushReceiver.java
+++ b/android/app/src/main/java/com/clawbench/app/JPushReceiver.java
@@ -23,16 +23,23 @@ public class JPushReceiver extends JPushMessageReceiver {
                 + ", content=" + message.notificationContent);
         AppLog.i(TAG, "JPush: notificationExtras=" + message.notificationExtras);
 
-        // Extract session_id and project_path from notification extras
+        // Extract session_id, task_id, execution_id, event_type, and project_path from notification extras
         String sessionId = null;
+        String taskId = null;
+        String executionId = null;
+        String eventType = null;
         String projectPath = null;
         if (message.notificationExtras != null) {
             try {
                 org.json.JSONObject extras = new org.json.JSONObject(message.notificationExtras);
                 AppLog.i(TAG, "JPush: parsed extras JSON: " + extras.toString());
                 sessionId = extras.optString("session_id", null);
+                taskId = extras.optString("task_id", null);
+                executionId = extras.optString("execution_id", null);
+                eventType = extras.optString("event_type", null);
                 projectPath = extras.optString("project_path", null);
-                AppLog.i(TAG, "JPush: extracted sessionId=" + sessionId + ", projectPath=" + projectPath);
+                AppLog.i(TAG, "JPush: extracted sessionId=" + sessionId + ", taskId=" + taskId
+                        + ", executionId=" + executionId + ", eventType=" + eventType + ", projectPath=" + projectPath);
             } catch (Exception e) {
                 AppLog.w(TAG, "JPush: failed to parse notification extras", e);
             }
@@ -45,6 +52,9 @@ public class JPushReceiver extends JPushMessageReceiver {
         try {
             org.json.JSONObject detail = new org.json.JSONObject();
             if (sessionId != null) detail.put("sessionId", sessionId);
+            if (taskId != null) detail.put("taskId", taskId);
+            if (executionId != null) detail.put("executionId", executionId);
+            if (eventType != null) detail.put("eventType", eventType);
             if (projectPath != null) detail.put("projectPath", projectPath);
             jsArg = detail.toString();
             AppLog.i(TAG, "JPush: built navigation jsArg=" + jsArg);
@@ -70,6 +80,9 @@ public class JPushReceiver extends JPushMessageReceiver {
                 | Intent.FLAG_ACTIVITY_CLEAR_TOP);
         // Pass navigation data as intent extras
         if (sessionId != null) launchIntent.putExtra("session_id", sessionId);
+        if (taskId != null) launchIntent.putExtra("task_id", taskId);
+        if (executionId != null) launchIntent.putExtra("execution_id", executionId);
+        if (eventType != null) launchIntent.putExtra("event_type", eventType);
         if (projectPath != null) launchIntent.putExtra("project_path", projectPath);
         context.startActivity(launchIntent);
         AppLog.i(TAG, "JPush: startActivity called with navigation extras");

--- a/android/app/src/main/java/com/clawbench/app/MainActivity.java
+++ b/android/app/src/main/java/com/clawbench/app/MainActivity.java
@@ -690,9 +690,15 @@ public class MainActivity extends AppCompatActivity {
         if (pendingNavigation != null && webView != null) {
             AppLog.i(TAG, "MainActivity: onResume - re-dispatching pendingNavigation=" + pendingNavigation.toString());
             final String jsArg = pendingNavigation.toString();
+            // Choose event name based on navigation type: task vs session
+            String eventName = pendingNavigation.has("taskId") ? "clawbench-open-task" : "clawbench-open-session";
+            AppLog.i(TAG, "MainActivity: onResume - dispatching " + eventName);
             webView.evaluateJavascript(
-                "window.dispatchEvent(new CustomEvent('clawbench-open-session', { detail: " + jsArg + " }))",
-                result -> AppLog.i(TAG, "MainActivity: onResume re-dispatch evaluateJavascript result=" + result)
+                "window.dispatchEvent(new CustomEvent('" + eventName + "', { detail: " + jsArg + " }))",
+                result -> {
+                    AppLog.i(TAG, "MainActivity: onResume re-dispatch evaluateJavascript result=" + result);
+                    pendingNavigation = null;
+                }
             );
         }
     }
@@ -706,8 +712,8 @@ public class MainActivity extends AppCompatActivity {
 
     /**
      * Handle intent extras from notification taps.
-     * Extracts session_id or task_id and dispatches a clawbench-open-session
-     * event to the WebView (same behavior as JPush notification taps).
+     * For session notifications: dispatches clawbench-open-session event (navigate to chat).
+     * For task notifications: dispatches clawbench-open-task event (navigate to task execution detail).
      */
     void handleNotificationIntent(Intent intent) {
         AppLog.i(TAG, "MainActivity: handleNotificationIntent called, intent=" + intent);
@@ -716,8 +722,13 @@ public class MainActivity extends AppCompatActivity {
             return;
         }
         String sessionId = intent.getStringExtra("session_id");
+        String taskId = intent.getStringExtra("task_id");
+        String executionId = intent.getStringExtra("execution_id");
+        String eventType = intent.getStringExtra("event_type");
         String projectPath = intent.getStringExtra("project_path");
-        AppLog.i(TAG, "MainActivity: handleNotificationIntent - sessionId=" + sessionId + ", projectPath=" + projectPath);
+        AppLog.i(TAG, "MainActivity: handleNotificationIntent - sessionId=" + sessionId
+                + ", taskId=" + taskId + ", executionId=" + executionId
+                + ", eventType=" + eventType + ", projectPath=" + projectPath);
 
         // Also dump all intent extras for debugging
         Bundle extras = intent.getExtras();
@@ -727,7 +738,45 @@ public class MainActivity extends AppCompatActivity {
             }
         }
 
-        if (sessionId != null) {
+        // Determine navigation type: task notification vs session notification
+        boolean isTaskNotification = taskId != null || "task_update".equals(eventType);
+
+        if (isTaskNotification && taskId != null) {
+            // Task notification: navigate to task execution detail
+            AppLog.i(TAG, "MainActivity: handleNotificationIntent - task notification, dispatching clawbench-open-task");
+            try {
+                org.json.JSONObject detail = new org.json.JSONObject();
+                detail.put("taskId", taskId);
+                if (executionId != null) detail.put("executionId", executionId);
+                if (sessionId != null) detail.put("sessionId", sessionId);
+                if (projectPath != null) detail.put("projectPath", projectPath);
+                // Store as pending navigation for cold-start fallback (getPendingNavigation bridge)
+                pendingNavigation = detail;
+                AppLog.i(TAG, "MainActivity: stored pendingNavigation=" + detail.toString());
+                if (webView != null) {
+                    AppLog.i(TAG, "MainActivity: webView available, dispatching clawbench-open-task event");
+                    webView.evaluateJavascript(
+                        "window.dispatchEvent(new CustomEvent('clawbench-open-task', { detail: " + detail.toString() + " }))",
+                        result -> {
+                            AppLog.i(TAG, "MainActivity: clawbench-open-task evaluateJavascript result=" + result);
+                            pendingNavigation = null;
+                        }
+                    );
+                } else {
+                    AppLog.w(TAG, "MainActivity: webView is null, cannot dispatch event (pendingNavigation stored for cold-start)");
+                }
+            } catch (Exception e) {
+                AppLog.w(TAG, "MainActivity: failed to dispatch clawbench-open-task event from notification", e);
+            }
+            // Clear extras so we don't re-dispatch on subsequent onResume
+            intent.removeExtra("task_id");
+            intent.removeExtra("execution_id");
+            intent.removeExtra("event_type");
+            intent.removeExtra("session_id");
+            intent.removeExtra("project_path");
+            AppLog.i(TAG, "MainActivity: cleared intent extras to prevent re-dispatch");
+        } else if (sessionId != null) {
+            // Session notification: navigate to chat session
             AppLog.i(TAG, "MainActivity: handleNotificationIntent - session_id found, dispatching navigation");
             try {
                 org.json.JSONObject detail = new org.json.JSONObject();
@@ -756,9 +805,10 @@ public class MainActivity extends AppCompatActivity {
             // Clear extras so we don't re-dispatch on subsequent onResume
             intent.removeExtra("session_id");
             intent.removeExtra("project_path");
+            intent.removeExtra("event_type");
             AppLog.i(TAG, "MainActivity: cleared intent extras to prevent re-dispatch");
         } else {
-            AppLog.i(TAG, "MainActivity: handleNotificationIntent - no session_id in intent extras");
+            AppLog.i(TAG, "MainActivity: handleNotificationIntent - no session_id or task_id in intent extras");
         }
     }
 

--- a/android/app/src/test/java/com/clawbench/app/BackgroundServiceNativeWsTest.java
+++ b/android/app/src/test/java/com/clawbench/app/BackgroundServiceNativeWsTest.java
@@ -701,6 +701,83 @@ public class BackgroundServiceNativeWsTest {
     }
 
     @Test
+    public void postEventNotification_taskUpdate_withExecutionId() throws Exception {
+        org.json.JSONObject data = new org.json.JSONObject();
+        data.put("task_id", "2");
+        data.put("execution_id", "5");
+        data.put("status", "completed");
+        data.put("session_id", "s-task-exec");
+        data.put("project_path", "/home/user/project");
+
+        Object service = createMinimalInstance();
+        if (service != null) {
+            setStaticField("instance", service);
+        }
+        setStaticField("isRunning", true);
+
+        try {
+            Method method = BackgroundService.class.getDeclaredMethod("postEventNotification", String.class, org.json.JSONObject.class);
+            method.setAccessible(true);
+            method.invoke(service, "task_update", data);
+        } catch (Exception e) {
+            if (e.getCause() != null && e.getCause().getMessage() != null
+                    && e.getCause().getMessage().contains("Stub!")) {
+                return;
+            }
+        }
+    }
+
+    @Test
+    public void postEventNotification_taskUpdate_failed() throws Exception {
+        org.json.JSONObject data = new org.json.JSONObject();
+        data.put("task_id", "3");
+        data.put("status", "failed");
+        data.put("project_path", "/home/user/project");
+
+        Object service = createMinimalInstance();
+        if (service != null) {
+            setStaticField("instance", service);
+        }
+        setStaticField("isRunning", true);
+
+        try {
+            Method method = BackgroundService.class.getDeclaredMethod("postEventNotification", String.class, org.json.JSONObject.class);
+            method.setAccessible(true);
+            method.invoke(service, "task_update", data);
+        } catch (Exception e) {
+            if (e.getCause() != null && e.getCause().getMessage() != null
+                    && e.getCause().getMessage().contains("Stub!")) {
+                return;
+            }
+        }
+    }
+
+    @Test
+    public void postEventNotification_sessionUpdate_withEventType() throws Exception {
+        org.json.JSONObject data = new org.json.JSONObject();
+        data.put("session_id", "s-session");
+        data.put("status", "completed");
+        data.put("project_path", "/home/user/project");
+
+        Object service = createMinimalInstance();
+        if (service != null) {
+            setStaticField("instance", service);
+        }
+        setStaticField("isRunning", true);
+
+        try {
+            Method method = BackgroundService.class.getDeclaredMethod("postEventNotification", String.class, org.json.JSONObject.class);
+            method.setAccessible(true);
+            method.invoke(service, "session_update", data);
+        } catch (Exception e) {
+            if (e.getCause() != null && e.getCause().getMessage() != null
+                    && e.getCause().getMessage().contains("Stub!")) {
+                return;
+            }
+        }
+    }
+
+    @Test
     public void postEventNotification_unknownEventType_returnsEarly() throws Exception {
         org.json.JSONObject data = new org.json.JSONObject();
         data.put("status", "completed");

--- a/android/app/src/test/java/com/clawbench/app/JPushReceiverTest.java
+++ b/android/app/src/test/java/com/clawbench/app/JPushReceiverTest.java
@@ -132,6 +132,44 @@ public class JPushReceiverTest {
         method.invoke(receiver, new android.content.ContextWrapper(null) {}, notificationMessage);
     }
 
+    // =====================================================
+    // Test 6: onNotifyMessageOpened with task notification extras
+    // =====================================================
+
+    @Test
+    public void onNotifyMessageOpened_taskExtras_launchesWithTaskId() throws Exception {
+        setField(notificationMessage, "notificationExtras",
+                "{\"task_id\":\"2\",\"execution_id\":\"5\",\"event_type\":\"task_update\",\"session_id\":\"s-task\",\"project_path\":\"/home/user/project\"}");
+        setField(notificationMessage, "msgId", "msg-006");
+        setField(notificationMessage, "notificationTitle", "计划任务完成");
+        setField(notificationMessage, "notificationContent", "任务已完成");
+
+        callOnNotifyMessageOpened(receiver, notificationMessage);
+        // If we get here without exception, the method executed fully with task extras
+    }
+
+    @Test
+    public void onNotifyMessageOpened_taskExtrasNoExecutionId_launchesWithTaskId() throws Exception {
+        setField(notificationMessage, "notificationExtras",
+                "{\"task_id\":\"1\",\"event_type\":\"task_update\",\"project_path\":\"/home/user/project\"}");
+        setField(notificationMessage, "msgId", "msg-007");
+        setField(notificationMessage, "notificationTitle", "计划任务完成");
+        setField(notificationMessage, "notificationContent", "任务已完成");
+
+        callOnNotifyMessageOpened(receiver, notificationMessage);
+    }
+
+    @Test
+    public void onNotifyMessageOpened_sessionExtrasOnly_noTaskId() throws Exception {
+        setField(notificationMessage, "notificationExtras",
+                "{\"session_id\":\"s-123\",\"project_path\":\"/home/user/project\"}");
+        setField(notificationMessage, "msgId", "msg-008");
+        setField(notificationMessage, "notificationTitle", "AI任务完成");
+        setField(notificationMessage, "notificationContent", "ok");
+
+        callOnNotifyMessageOpened(receiver, notificationMessage);
+    }
+
     // --- Helper methods ---
 
     private static void setField(Object target, String fieldName, Object value) throws Exception {

--- a/android/app/src/test/java/com/clawbench/app/MainActivityNotificationTest.java
+++ b/android/app/src/test/java/com/clawbench/app/MainActivityNotificationTest.java
@@ -117,6 +117,99 @@ public class MainActivityNotificationTest {
         );
     }
 
+    // =====================================================
+    // Task notification tests (clawbench-open-task)
+    // =====================================================
+
+    @Test
+    public void handleNotificationIntent_withTaskId_dispatchesOpenTaskEvent() throws Exception {
+        Intent mockIntent = mock(Intent.class);
+        when(mockIntent.getStringExtra("task_id")).thenReturn("2");
+        when(mockIntent.getStringExtra("execution_id")).thenReturn("5");
+        when(mockIntent.getStringExtra("event_type")).thenReturn("task_update");
+        when(mockIntent.getStringExtra("session_id")).thenReturn("s-task");
+        when(mockIntent.getStringExtra("project_path")).thenReturn("/home/user/project");
+
+        android.webkit.WebView mockWebView = mock(android.webkit.WebView.class);
+        setField(activity, "webView", mockWebView);
+
+        invokeMethod(activity, "handleNotificationIntent", Intent.class, mockIntent);
+
+        // Should dispatch clawbench-open-task (not clawbench-open-session)
+        verify(mockWebView).evaluateJavascript(
+                org.mockito.ArgumentMatchers.contains("clawbench-open-task"),
+                org.mockito.ArgumentMatchers.any()
+        );
+
+        // Verify all task-related extras are cleared
+        verify(mockIntent).removeExtra("task_id");
+        verify(mockIntent).removeExtra("execution_id");
+        verify(mockIntent).removeExtra("event_type");
+        verify(mockIntent).removeExtra("session_id");
+        verify(mockIntent).removeExtra("project_path");
+    }
+
+    @Test
+    public void handleNotificationIntent_withTaskIdNoExecutionId_dispatchesOpenTask() throws Exception {
+        Intent mockIntent = mock(Intent.class);
+        when(mockIntent.getStringExtra("task_id")).thenReturn("3");
+        when(mockIntent.getStringExtra("execution_id")).thenReturn(null);
+        when(mockIntent.getStringExtra("event_type")).thenReturn("task_update");
+        when(mockIntent.getStringExtra("session_id")).thenReturn(null);
+        when(mockIntent.getStringExtra("project_path")).thenReturn("/home/user/project");
+
+        android.webkit.WebView mockWebView = mock(android.webkit.WebView.class);
+        setField(activity, "webView", mockWebView);
+
+        invokeMethod(activity, "handleNotificationIntent", Intent.class, mockIntent);
+
+        verify(mockWebView).evaluateJavascript(
+                org.mockito.ArgumentMatchers.contains("clawbench-open-task"),
+                org.mockito.ArgumentMatchers.any()
+        );
+    }
+
+    @Test
+    public void handleNotificationIntent_withEventTypeTaskUpdateButNoTaskId_fallsBackToSession() throws Exception {
+        Intent mockIntent = mock(Intent.class);
+        when(mockIntent.getStringExtra("task_id")).thenReturn(null);
+        when(mockIntent.getStringExtra("execution_id")).thenReturn(null);
+        when(mockIntent.getStringExtra("event_type")).thenReturn("task_update");
+        when(mockIntent.getStringExtra("session_id")).thenReturn("s-fallback");
+        when(mockIntent.getStringExtra("project_path")).thenReturn(null);
+
+        android.webkit.WebView mockWebView = mock(android.webkit.WebView.class);
+        setField(activity, "webView", mockWebView);
+
+        invokeMethod(activity, "handleNotificationIntent", Intent.class, mockIntent);
+
+        // Should dispatch clawbench-open-session (no task_id, falls back to session)
+        verify(mockWebView).evaluateJavascript(
+                org.mockito.ArgumentMatchers.contains("clawbench-open-session"),
+                org.mockito.ArgumentMatchers.any()
+        );
+    }
+
+    @Test
+    public void handleNotificationIntent_taskNotification_nullWebView_storesPendingNavigation() throws Exception {
+        Intent mockIntent = mock(Intent.class);
+        when(mockIntent.getStringExtra("task_id")).thenReturn("2");
+        when(mockIntent.getStringExtra("execution_id")).thenReturn("5");
+        when(mockIntent.getStringExtra("event_type")).thenReturn("task_update");
+        when(mockIntent.getStringExtra("session_id")).thenReturn(null);
+        when(mockIntent.getStringExtra("project_path")).thenReturn("/project");
+
+        setField(activity, "webView", null); // No WebView available
+
+        invokeMethod(activity, "handleNotificationIntent", Intent.class, mockIntent);
+
+        // pendingNavigation should be set with taskId
+        Object pendingNav = getField(activity, "pendingNavigation");
+        assertNotNull("pendingNavigation should be stored when webView is null", pendingNav);
+        assertTrue("pendingNavigation should contain taskId",
+                pendingNav.toString().contains("2"));
+    }
+
     @Test
     public void handleNotificationIntent_nullWebView_storesPendingNavigation() throws Exception {
         Intent mockIntent = mock(Intent.class);
@@ -229,6 +322,25 @@ public class MainActivityNotificationTest {
 
         verify(mockWebView).evaluateJavascript(
                 org.mockito.ArgumentMatchers.contains("clawbench-open-session"),
+                org.mockito.ArgumentMatchers.any()
+        );
+    }
+
+    @Test
+    public void redispatchPendingNavigation_withTaskNav_dispatchesOpenTask() throws Exception {
+        org.json.JSONObject nav = new org.json.JSONObject();
+        nav.put("taskId", "2");
+        nav.put("executionId", "5");
+        setField(activity, "pendingNavigation", nav);
+
+        android.webkit.WebView mockWebView = mock(android.webkit.WebView.class);
+        setField(activity, "webView", mockWebView);
+
+        invokeMethod(activity, "redispatchPendingNavigation");
+
+        // Should dispatch clawbench-open-task because pendingNavigation has taskId
+        verify(mockWebView).evaluateJavascript(
+                org.mockito.ArgumentMatchers.contains("clawbench-open-task"),
                 org.mockito.ArgumentMatchers.any()
         );
     }

--- a/internal/ws/manager.go
+++ b/internal/ws/manager.go
@@ -292,6 +292,10 @@ func (m *Manager) broadcastToSubscription(key string, msg ServerMessage, deliver
 			}
 		case *TaskUpdateData:
 			extras["task_id"] = d.TaskID
+			extras["event_type"] = "task_update"
+			if d.ExecutionID != "" {
+				extras["execution_id"] = d.ExecutionID
+			}
 			if d.SessionID != "" {
 				extras["session_id"] = d.SessionID
 			}

--- a/web/src/App.vue
+++ b/web/src/App.vue
@@ -409,6 +409,47 @@ function handleOpenSession(e) {
   }
 }
 
+/** Handle clawbench-open-task event from Android push notification tap (task execution) */
+function handleOpenTask(e) {
+  const detail = e?.detail
+  console.log('[ClawBench] clawbench-open-task event received, detail=', detail)
+  if (!detail?.taskId) {
+    console.warn('[ClawBench] clawbench-open-task: no taskId in detail, ignoring')
+    return
+  }
+  const { taskId, executionId, projectPath } = detail
+  console.log('[ClawBench] clawbench-open-task: taskId=', taskId, 'executionId=', executionId, 'currentProject=', store.state.projectRoot)
+
+  const navigateToTask = () => {
+    switchTab('tasks')
+    navigateToTaskHistory(Number(taskId))
+    if (executionId) {
+      // openExecDetail without execData will auto-fetch from API via refreshExecDetail
+      openExecDetail(executionId)
+    }
+  }
+
+  if (projectPath && projectPath !== store.state.projectRoot) {
+    // Cross-project: switch project, store pending task navigation, then reload
+    console.log('[ClawBench] cross-project navigation, switching to', projectPath)
+    localStorage.setItem('clawbenchPendingNav', JSON.stringify({ taskId, executionId }))
+    fetch('/api/project', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ path: projectPath }),
+    }).then(() => {
+      window.location.reload()
+    }).catch(() => {
+      console.warn('[ClawBench] project switch failed, falling back to same-project switch')
+      navigateToTask()
+    })
+  } else {
+    // Same project: lightweight switch
+    console.log('[ClawBench] same-project navigation, switching to task', taskId)
+    navigateToTask()
+  }
+}
+
 const detailsOpen = ref(false)
 const tocOpen = ref(false)
 const searchOpen = ref(false)
@@ -457,7 +498,7 @@ watch(isTerminalDisabled, (disabled) => {
     switchTab('chat')
   }
 })
-const { navigateToTaskSettings, loadTasks } = useTaskTab()
+const { navigateToTaskSettings, navigateToTaskHistory, openExecDetail, loadTasks } = useTaskTab()
 registerSwitchTab(switchTab)
 
 // Wire up WS global events
@@ -818,6 +859,7 @@ onMounted(async () => {
     window.addEventListener('navigate-to-commit', handleNavigateToCommit)
     window.addEventListener('quote-sent', playQuoteEmitAnimation)
     window.addEventListener('clawbench-open-session', handleOpenSession)
+    window.addEventListener('clawbench-open-task', handleOpenTask)
     document.addEventListener('click', handleOverflowOutsideClick)
     // Sync reactive state from Settings page changes
     window.addEventListener('clawbench-theme-change', (e) => {
@@ -884,17 +926,34 @@ onMounted(async () => {
     }
     // Handle pending navigation from push notification deep link
     // (cross-project reload or cold start via AndroidNative bridge)
-    const processPendingNav = (navSessionId) => {
-      // Wait for sessions to load before switching
+    const processPendingSessionNav = (navSessionId) => {
+      // Wait for sessions to load before switching (max 3 seconds)
+      let attempts = 0
       const checkReady = () => {
         if (sessionIdentity.currentSessionId.value) {
           switchTab('chat')
           sessionIdentity.switchSession(navSessionId)
-        } else {
+        } else if (attempts < 30) {
+          attempts++
           setTimeout(checkReady, 100)
         }
       }
       checkReady()
+    }
+
+    const processPendingTaskNav = async (navTaskId, navExecutionId) => {
+      // Ensure tasks are loaded before navigating
+      try {
+        await loadTasks()
+      } catch (_) {
+        // Proceed anyway — the task list may already be populated
+      }
+      switchTab('tasks')
+      navigateToTaskHistory(Number(navTaskId))
+      if (navExecutionId) {
+        // openExecDetail without execData will auto-fetch from API via refreshExecDetail
+        openExecDetail(navExecutionId)
+      }
     }
 
     // Check localStorage for pending navigation (cross-project reload)
@@ -902,8 +961,12 @@ onMounted(async () => {
     if (pendingNav) {
       localStorage.removeItem('clawbenchPendingNav')
       try {
-        const { sessionId } = JSON.parse(pendingNav)
-        if (sessionId) processPendingNav(sessionId)
+        const nav = JSON.parse(pendingNav)
+        if (nav.taskId) {
+          processPendingTaskNav(nav.taskId, nav.executionId)
+        } else if (nav.sessionId) {
+          processPendingSessionNav(nav.sessionId)
+        }
       } catch (_) {}
     }
 
@@ -916,15 +979,30 @@ onMounted(async () => {
           const nav = window.AndroidNative.getPendingNavigation()
           console.log('[ClawBench] getPendingNavigation poll result:', nav)
           if (nav) {
-            const { sessionId, projectPath } = JSON.parse(nav)
-            if (sessionId) {
+            const parsed = JSON.parse(nav)
+            const { sessionId, taskId, executionId, projectPath } = parsed
+            if (taskId) {
+              // Task notification navigation
+              pollCleared = true
+              if (projectPath && projectPath !== store.state.projectRoot) {
+                localStorage.setItem('clawbenchPendingNav', JSON.stringify({ taskId, executionId }))
+                fetch('/api/project', {
+                  method: 'POST',
+                  headers: { 'Content-Type': 'application/json' },
+                  body: JSON.stringify({ path: projectPath }),
+                }).then(() => window.location.reload())
+              } else {
+                processPendingTaskNav(taskId, executionId)
+              }
+            } else if (sessionId) {
+              // Session notification navigation
               // Navigation data found — stop polling
               pollCleared = true
               if (projectPath && projectPath !== store.state.projectRoot) {
                 // Need to switch project first — use hot switch instead of reload
                 hotSwitchProject(projectPath, sessionId)
               } else {
-                processPendingNav(sessionId)
+                processPendingSessionNav(sessionId)
               }
             }
           }
@@ -960,6 +1038,7 @@ onUnmounted(() => {
     window.removeEventListener('navigate-to-commit', handleNavigateToCommit)
     window.removeEventListener('quote-sent', playQuoteEmitAnimation)
     window.removeEventListener('clawbench-open-session', handleOpenSession)
+    window.removeEventListener('clawbench-open-task', handleOpenTask)
     document.removeEventListener('click', handleOverflowOutsideClick)
 })
 </script>

--- a/web/src/composables/useTaskTab.ts
+++ b/web/src/composables/useTaskTab.ts
@@ -255,6 +255,10 @@ export function useTaskTab() {
         selectedExecId.value = execId
         selectedExecData.value = execData || null
         execDetailOpen.value = true
+        // If no execData provided, auto-fetch from API (e.g. from push notification deep link)
+        if (!execData) {
+            refreshExecDetail()
+        }
     }
 
     function closeExecDetail() {


### PR DESCRIPTION
## 问题

点击定时任务执行完成的通知（JPush 或原生 WS），跳转到了聊天会话界面（chat tab），而不是定时任务的执行详情界面（tasks tab → 执行详情）。

## 根因

通知点击处理链路中，所有通知（包括任务通知）都被统一当作"会话通知"处理：
- `JPushReceiver` 只提取 `session_id`，忽略 `task_id`
- `MainActivity.handleNotificationIntent` 只处理 `session_id`，忽略 `task_id`
- 前端 `handleOpenSession` 总是 `switchTab('chat')` + `switchSession()`
- `openExecDetail(executionId)` 不传 `execData`，导致执行详情页面空白

## 修改

### 后端
- `internal/ws/manager.go`: JPush extras 新增 `execution_id` 和 `event_type`

### Android
- `JPushReceiver.java`: 提取 `task_id`、`execution_id`、`event_type`，传入 intent extras
- `BackgroundService.java`: 拆分 task_update / session_update 通知处理为独立分支，各带正确的 `event_type`
- `MainActivity.java`:
  - 任务通知 → dispatch `clawbench-open-task` 事件
  - 会话通知 → 保持 `clawbench-open-session`
  - `redispatchPendingNavigation` 根据 `pendingNavigation` 内容选择正确的事件名

### 前端
- `App.vue`:
  - 新增 `handleOpenTask()`：`switchTab('tasks')` → `navigateToTaskHistory()` → `openExecDetail()`
  - 冷启动 `pendingNavigation` 支持 `taskId` 导航
  - 跨项目重载路径支持任务导航
  - `processPendingSessionNav` 增加最大重试次数（3秒超时）
- `useTaskTab.ts`: `openExecDetail` 无 `execData` 时自动调用 `refreshExecDetail()` 从 API 加载数据

## 测试

- [x] Go 后端构建通过
- [x] 前端构建通过
- [x] Go 测试通过（internal/ws, internal/service）
- [x] 部署到 /root/clawbench-test/ 验证