### PR TITLE
fix: Safari 浏览器 Git 提交历史 Invalid date 修复

### DIFF
--- a/internal/handler/git.go
+++ b/internal/handler/git.go
@@ -139,7 +139,7 @@ func ServeGitProjectHistory(w http.ResponseWriter, r *http.Request) {
 	// Format: SHA|parents|subject|date|author+refs
 	// --topo-order ensures branches display contiguously
 	// --decorate-refs-exclude hides remote-tracking refs
-	logArgs := []string{"log", "--format=%H|%P|%s|%ad|%an%d", "--date=iso", "--topo-order", "--decorate-refs-exclude=refs/remotes", "-30"}
+	logArgs := []string{"log", "--format=%H|%P|%s|%ad|%an%d", "--date=iso-strict", "--topo-order", "--decorate-refs-exclude=refs/remotes", "-30"}
 	if skip > 0 {
 		logArgs = append(logArgs, "--skip", fmt.Sprintf("%d", skip))
 	}
@@ -651,8 +651,8 @@ func ServeGitHistory(w http.ResponseWriter, r *http.Request) {
 	lsOut, lsErr := lsCmd.CombinedOutput()
 	untracked := lsErr != nil || len(lsOut) == 0
 
-	// git log --format="%H|%P|%s|%ad|%an%d" --date=iso --topo-order -- <path>
-	cmd := exec.Command("git", "log", "--format=%H|%P|%s|%ad|%an%d", "--date=iso", "--topo-order", "--decorate-refs-exclude=refs/remotes", "--", relPath)
+	// git log --format="%H|%P|%s|%ad|%an%d" --date=iso-strict --topo-order -- <path>
+	cmd := exec.Command("git", "log", "--format=%H|%P|%s|%ad|%an%d", "--date=iso-strict", "--topo-order", "--decorate-refs-exclude=refs/remotes", "--", relPath)
 	cmd.Dir = projectPath
 	output, _ := cmd.CombinedOutput()
 
@@ -812,7 +812,7 @@ func ServeGitVerifyCommits(w http.ResponseWriter, r *http.Request) {
 	logArgs := []string{
 		"log", "--no-walk=sorted", "--ignore-missing",
 		"--format=%H|%P|%s|%ad|%an%d",
-		"--date=iso",
+		"--date=iso-strict",
 	}
 	logArgs = append(logArgs, body.SHAs...)
 


### PR DESCRIPTION
## 变更说明

修复 Safari 浏览器中 Git 提交历史显示 `Invalid date` 的问题。

将后端 `git log --date=iso` 改为 `--date=iso-strict`，使输出的日期格式完全符合 ISO 8601 标准（时区带冒号 `+08:00` 而非 `+0800`），Safari 的 `Date` 解析器可以正确识别。

## 变更类型

- [x] fix: Bug 修复

## 关联 Issue

Fixes #80

## 测试

- [x] 已通过现有测试（`go test ./...` / `npm test`）
- [x] 手动验证：`git log --date=iso-strict` 输出 `2026-05-22T19:57:51+08:00`，Safari `new Date()` 可正确解析
- [ ] 在 Safari 浏览器中验证提交历史日期显示正常

## 自检清单

- [x] 代码遵循项目现有风格
- [x] 无硬编码密钥或敏感信息
- [x] 变更已反映在文档中（如适用）