### PR TITLE
fix: worktree path annotation — prevent partial file-path match and add file-open button

### DIFF
--- a/web/src/composables/__tests__/useFilePathAnnotation.test.ts
+++ b/web/src/composables/__tests__/useFilePathAnnotation.test.ts
@@ -475,6 +475,50 @@ describe('annotateFilePaths', () => {
     const result = annotateFilePaths(input, { projectRoot, baseDir: 'src' })
     expect(result.detectedPaths).toContain('src/components/App.vue')
   })
+
+  it('does not partially match directory prefix followed by more path segments (worktree-like)', () => {
+    // Regression: /home/user/project/.worktrees/gitgraph-fix
+    // The FILE_PATH_RE would match /home/user/project/.worktrees (treating .worktrees as extension)
+    // but the full path is a directory, not a file. The trailing /gitgraph-fix indicates the
+    // match is incomplete — this should be skipped so worktree annotation can handle the full path.
+    const input = '<p>/home/user/project/.worktrees/gitgraph-fix</p>'
+    const result = annotateFilePaths(input, { projectRoot })
+    // Should NOT detect .worktrees as a file path (it's a directory prefix)
+    expect(result.detectedPaths).toHaveLength(0)
+    expect(result.html).not.toContain('chat-file-path')
+  })
+
+  it('does not partially match .worktrees directory prefix with non-hyphen continuation', () => {
+    // Same bug with a worktree name that has no hyphen (e.g. featurex)
+    const input = '<p>/home/user/project/.worktrees/featurex</p>'
+    const result = annotateFilePaths(input, { projectRoot })
+    expect(result.detectedPaths).toHaveLength(0)
+    expect(result.html).not.toContain('chat-file-path')
+  })
+
+  it('still annotates legitimate paths ending in .worktrees when there is no continuation', () => {
+    // If the text is just /home/user/project/.worktrees (no trailing path), it's a
+    // legitimate path that should be annotated — even though it's a directory,
+    // the user may want to navigate to it.
+    const input = '<p>/home/user/project/.worktrees</p>'
+    const result = annotateFilePaths(input, { projectRoot })
+    expect(result.detectedPaths).toContain('.worktrees')
+  })
+
+  it('skips text nodes inside chat-worktree-path elements', () => {
+    // After worktree annotation runs first, file path annotation should not
+    // re-annotate text inside worktree-annotated elements
+    const input = '<span class="chat-worktree-path" data-worktree-path="/home/user/project/.worktrees/fix">.worktrees/fix</span>'
+    const result = annotateFilePaths(input, { projectRoot })
+    expect(result.detectedPaths).toHaveLength(0)
+  })
+
+  it('skips <code> elements already annotated as worktree', () => {
+    // <code> with chat-worktree-path class should be skipped in step 2
+    const input = '<code class="chat-worktree-path" data-worktree-path="/home/user/project/.worktrees/fix">.worktrees/fix</code>'
+    const result = annotateFilePaths(input, { projectRoot })
+    expect(result.detectedPaths).toHaveLength(0)
+  })
 })
 
 // --- clearVerifiedCache ---

--- a/web/src/composables/__tests__/useWorktreeAnnotation.test.ts
+++ b/web/src/composables/__tests__/useWorktreeAnnotation.test.ts
@@ -376,6 +376,87 @@ describe('annotateWorktreePaths', () => {
         const result = annotateWorktreePaths('<pre><code class="chat-file-path">.worktrees/feature-x</code></pre>', { projectRoot: PROJECT_ROOT })
         expect(result.detectedWorktreePaths).toEqual([])
     })
+
+    it('annotates full absolute worktree path in text node', async () => {
+        await seedCache(PROJECT_ROOT, MOCK_WORKTREES)
+        const absPath = '/home/user/project/.worktrees/feature-x'
+        const result = annotateWorktreePaths(`<p>${absPath}</p>`, { projectRoot: PROJECT_ROOT })
+        expect(result.detectedWorktreePaths).toContain(absPath)
+        expect(result.html).toContain('chat-worktree-path')
+        expect(result.html).toContain('chat-worktree-switch-btn')
+        // The full absolute path should be inside the span, not just a partial match
+        expect(result.html).toContain('data-worktree-path="/home/user/project/.worktrees/feature-x"')
+    })
+
+    it('annotates full absolute worktree path in <code> tag', async () => {
+        await seedCache(PROJECT_ROOT, MOCK_WORKTREES)
+        const absPath = '/home/user/project/.worktrees/feature-x'
+        const result = annotateWorktreePaths(`<code>${absPath}</code>`, { projectRoot: PROJECT_ROOT })
+        expect(result.detectedWorktreePaths).toContain(absPath)
+        expect(result.html).toContain('chat-worktree-path')
+        expect(result.html).toContain('chat-worktree-switch-btn')
+    })
+
+    it('adds file-open button alongside worktree switch button for absolute path', async () => {
+        await seedCache(PROJECT_ROOT, MOCK_WORKTREES)
+        const absPath = '/home/user/project/.worktrees/feature-x'
+        const result = annotateWorktreePaths(`<p>${absPath}</p>`, { projectRoot: PROJECT_ROOT })
+        // Both buttons should be present
+        expect(result.html).toContain('chat-worktree-switch-btn')
+        expect(result.html).toContain('chat-file-open-btn')
+        // The span should have both data attributes
+        expect(result.html).toContain('data-worktree-path="/home/user/project/.worktrees/feature-x"')
+        expect(result.html).toContain('data-file-path=".worktrees/feature-x"')
+    })
+
+    it('adds file-open button alongside worktree switch button for <code> element', async () => {
+        await seedCache(PROJECT_ROOT, MOCK_WORKTREES)
+        const absPath = '/home/user/project/.worktrees/feature-x'
+        const result = annotateWorktreePaths(`<code>${absPath}</code>`, { projectRoot: PROJECT_ROOT })
+        expect(result.html).toContain('chat-worktree-switch-btn')
+        expect(result.html).toContain('chat-file-open-btn')
+        expect(result.html).toContain('data-file-path=".worktrees/feature-x"')
+    })
+
+    it('adds file-open button alongside worktree switch button for <a> element', async () => {
+        await seedCache(PROJECT_ROOT, MOCK_WORKTREES)
+        const result = annotateWorktreePaths('<a href=".worktrees/feature-x">link</a>', { projectRoot: PROJECT_ROOT })
+        expect(result.html).toContain('chat-worktree-switch-btn')
+        expect(result.html).toContain('chat-file-open-btn')
+    })
+
+    it('does NOT add file-open button for worktree path outside projectRoot', async () => {
+        // If a worktree path is not under projectRoot, only worktree switch button is added
+        const externalWorktrees = [
+            {
+                path: '/home/user/project',
+                displayPath: '.',
+                branch: 'main',
+                isCurrent: true,
+                dirty: false,
+                changeCount: 0,
+                untrackedCount: 0,
+                locked: false,
+                missing: false,
+            },
+            {
+                path: '/other/location/worktree-x',
+                displayPath: './worktree-x',
+                branch: 'worktree-x',
+                isCurrent: false,
+                dirty: false,
+                changeCount: 0,
+                untrackedCount: 0,
+                locked: false,
+                missing: false,
+            },
+        ]
+        await seedCache(PROJECT_ROOT, externalWorktrees)
+        const result = annotateWorktreePaths('<p>/other/location/worktree-x</p>', { projectRoot: PROJECT_ROOT })
+        expect(result.html).toContain('chat-worktree-switch-btn')
+        // No file-open button because /other/location/worktree-x is outside projectRoot
+        expect(result.html).not.toContain('chat-file-open-btn')
+    })
 })
 
 // ── useWorktreeAnnotation composable ──

--- a/web/src/composables/useChatRender.ts
+++ b/web/src/composables/useChatRender.ts
@@ -145,10 +145,15 @@ export function useChatRender(options) {
     html = html.replace(/<table>/g, '<div class="table-wrap"><table>').replace(/<\/table>/g, '</table></div>')
 
     if (!skipEnhancements) {
-      // Image styling, audio links, file path annotation: deferred to post-streaming
+      // Image styling, audio links, annotations: deferred to post-streaming
       const projectRoot = store.state.projectRoot
       html = rewriteImageUrls(html, projectRoot)
       html = convertAudioLinks(html)
+      // Annotate worktree paths BEFORE file paths — prevents file-path regex from
+      // partially matching worktree directory paths (e.g. matching
+      // /home/x/project/.worktrees instead of the full /home/x/project/.worktrees/fix)
+      const { html: worktreeHtml } = annotateWorktreePaths(html, { projectRoot })
+      html = worktreeHtml
       const { html: annotatedHtml, detectedPaths } = annotateFilePaths(html, { projectRoot })
       html = annotatedHtml
       if (detectedPaths.length > 0) {
@@ -170,9 +175,6 @@ export function useChatRender(options) {
       }
       // Annotate localhost URLs (e.g. http://localhost:30080) with clickable tags
       html = annotateLocalhostUrls(html)
-      // Annotate worktree paths using cached worktree list
-      const { html: worktreeHtml } = annotateWorktreePaths(html, { projectRoot })
-      html = worktreeHtml
     }
 
     return html

--- a/web/src/composables/useFilePathAnnotation.ts
+++ b/web/src/composables/useFilePathAnnotation.ts
@@ -139,6 +139,8 @@ export function annotateFilePaths(
     for (const code of doc.querySelectorAll('code')) {
         // Skip <code> inside <pre> blocks (multi-line code blocks should not get buttons)
         if (code.closest('pre')) continue
+        // Skip <code> already annotated as worktree (worktree annotation runs first)
+        if (code.classList.contains('chat-worktree-path')) continue
         const stripped = (code.textContent || '').trim()
         if (!looksLikeFilePath(stripped)) continue
         const resolved = resolveFilePath(stripped, projectRoot)
@@ -149,7 +151,7 @@ export function annotateFilePaths(
         code.insertAdjacentHTML('afterend', fileOpenButtonHtml(resolved))
     }
 
-    // ── Step 3: Text nodes (outside pre/a/code) → regex match paths ──
+    // ── Step 3: Text nodes (outside pre/a/code/worktree) → regex match paths ──
     const textNodes: Text[] = []
     const walker = doc.createTreeWalker(doc.body, NodeFilter.SHOW_TEXT, {
         acceptNode(node: Text) {
@@ -161,6 +163,8 @@ export function annotateFilePaths(
             if (parent.tagName === 'A' || parent.closest('a')) return NodeFilter.FILTER_REJECT
             // Skip text inside <code> tags (handled in step 2)
             if (parent.tagName === 'CODE' || parent.closest('code')) return NodeFilter.FILTER_REJECT
+            // Skip text inside worktree-annotated elements (worktree annotation runs first)
+            if (parent.classList.contains('chat-worktree-path') || parent.closest('.chat-worktree-path')) return NodeFilter.FILTER_REJECT
             return NodeFilter.FILTER_ACCEPT
         }
     })
@@ -181,7 +185,23 @@ export function annotateFilePaths(
         let match: RegExpExecArray | null
         while ((match = FILE_PATH_RE.exec(text)) !== null) {
             const pathStr = match[0]
-            const resolved = resolveFilePath(pathStr, projectRoot)
+            let resolved = resolveFilePath(pathStr, projectRoot)
+            // If the text immediately after this match continues with a path segment
+            // (e.g. "/.worktrees" followed by "/gitgraph-fix"), the regex only matched
+            // a directory prefix — skip it so worktree annotation can handle the full path.
+            // Note: This may over-suppress in rare cases (e.g. "src/utils.ts/v2"),
+            // but directory-prefix false matches are far more common and harmful.
+            if (resolved) {
+                const afterIdx = match.index + pathStr.length
+                if (afterIdx < text.length && text[afterIdx] === '/') {
+                    const rest = text.slice(afterIdx + 1)
+                    // If there's a continuation that looks like a path segment, this
+                    // match is incomplete (a directory prefix, not a full file path).
+                    if (rest.length > 0 && /^[a-zA-Z0-9_.-]/.test(rest)) {
+                        resolved = null // incomplete match — likely a directory prefix
+                    }
+                }
+            }
             // Push the text before this match
             if (match.index > lastIndex) {
                 parts.push({ text: text.slice(lastIndex, match.index), resolved: null })

--- a/web/src/composables/useWorktreeAnnotation.ts
+++ b/web/src/composables/useWorktreeAnnotation.ts
@@ -1,5 +1,6 @@
 import { escapeHtml } from '@/utils/html.ts'
 import { gt } from '@/composables/useLocale'
+import { fileOpenButtonHtml, resolveFilePath } from '@/composables/useFilePathAnnotation.ts'
 
 /**
  * SVG icon markup for the worktree-switch button (GitBranch icon from lucide).
@@ -134,13 +135,27 @@ export function annotateWorktreePaths(
     const detectedWorktreePaths: string[] = []
     const doc = new DOMParser().parseFromString(html, 'text/html')
 
+    /**
+     * Generate annotation buttons for a worktree path.
+     * Always generates the worktree switch button.
+     * Also generates a file-open button if the worktree path resolves within projectRoot.
+     */
+    function worktreeAnnotationButtons(absPath: string): string {
+        let html = worktreeSwitchButtonHtml(absPath)
+        const resolved = resolveFilePath(absPath, projectRoot)
+        if (resolved) {
+            html += fileOpenButtonHtml(resolved)
+        }
+        return html
+    }
+
     // ── Step 1: <a href> tags matching a worktree path ──
     for (const a of doc.querySelectorAll('a[href]')) {
         const href = a.getAttribute('href') || ''
         const match = findWorktreeMatch(href, searchEntries)
         if (!match) continue
         detectedWorktreePaths.push(match.absPath)
-        a.insertAdjacentHTML('afterend', worktreeSwitchButtonHtml(match.absPath))
+        a.insertAdjacentHTML('afterend', worktreeAnnotationButtons(match.absPath))
     }
 
     // ── Step 2: <code> and <span class="chat-file-path"> matching a worktree ──
@@ -156,7 +171,12 @@ export function annotateWorktreePaths(
         detectedWorktreePaths.push(match.absPath)
         el.classList.add('chat-worktree-path')
         el.setAttribute('data-worktree-path', match.absPath)
-        el.insertAdjacentHTML('afterend', worktreeSwitchButtonHtml(match.absPath))
+        // Also add data-file-path if the worktree path resolves within projectRoot
+        const resolved = resolveFilePath(match.absPath, projectRoot)
+        if (resolved) {
+            el.setAttribute('data-file-path', resolved)
+        }
+        el.insertAdjacentHTML('afterend', worktreeAnnotationButtons(match.absPath))
     }
 
     // ── Step 3: Text nodes (outside pre/a/code) → search worktree paths ──
@@ -220,11 +240,16 @@ export function annotateWorktreePaths(
             const span = doc.createElement('span')
             span.className = 'chat-worktree-path'
             span.setAttribute('data-worktree-path', m.entry.absPath)
+            // Also add data-file-path if the worktree path resolves within projectRoot
+            const resolved = resolveFilePath(m.entry.absPath, projectRoot)
+            if (resolved) {
+                span.setAttribute('data-file-path', resolved)
+            }
             span.textContent = m.entry.keyword
             frag.appendChild(span)
-            // Worktree-switch button
+            // Worktree switch + file open buttons
             const btnContainer = doc.createElement('span')
-            btnContainer.innerHTML = worktreeSwitchButtonHtml(m.entry.absPath)
+            btnContainer.innerHTML = worktreeAnnotationButtons(m.entry.absPath)
             while (btnContainer.firstChild) frag.appendChild(btnContainer.firstChild)
             lastIndex = m.index + m.length
         }


### PR DESCRIPTION
## Summary

Fix worktree path annotation in chat messages. Two related issues addressed:

### Issue 1: FILE_PATH_RE partially matches worktree directory paths
When a path like `/home/x/project/.worktrees/gitgraph-fix` appears in chat, the regex matches `/home/x/project/.worktrees` (treating `.worktrees` as a file extension), creating a wrong file-open button pointing to the `.worktrees` directory. Meanwhile the full worktree path is split and worktree annotation fails to detect it.

**Fix — three layers:**
1. **Pipeline reorder**: worktree annotation now runs BEFORE file path annotation, so worktree paths are consumed first
2. **Skip worktree-annotated elements**: file path annotation skips `chat-worktree-path` elements in both step 2 (`<code>`) and step 3 (text nodes)
3. **Directory-prefix detection**: if a regex match is immediately followed by `/segment-name`, skip it as an incomplete match (defense for worktree cache miss on first render)

### Issue 2: Worktree paths only show switch button, missing file-open button
Worktree paths should be both switchable (go to worktree project) AND browsable (open in file manager). Currently only the worktree switch button is shown.

**Fix**: worktree annotation now generates both buttons when the worktree path resolves within projectRoot. The `<span>` element gets both `data-worktree-path` and `data-file-path` attributes.

## Test plan
- [x] 11 new test cases added (partial match prevention, worktree element skipping, file/worktree button coexistence)
- [x] All 2899 frontend tests pass
- [x] Frontend coverage gate: Tier 1 PASS, Tier 2 100% diff coverage PASS
- [x] Go coverage gate: PASS (no Go changes)