### PR TITLE
fix: 已删除项目从最近列表过滤并显示正确错误提示

### DIFF
--- a/internal/handler/coverage_new_test.go
+++ b/internal/handler/coverage_new_test.go
@@ -1561,12 +1561,12 @@ func TestServeQuickCommandByID_DelegateToServeQuickCommands(t *testing.T) {
 // ============================================================================
 
 func TestServeRecentProjects_AddAndList(t *testing.T) {
-	_, teardown := setupTestEnv(t)
+	env, teardown := setupTestEnv(t)
 	defer teardown()
 
-	// Add a project via POST
+	// Add a project via POST (use a real directory so GetRecentProjects doesn't filter it out)
 	addReq := newRequest(t, http.MethodPost, "/api/recent-projects", map[string]string{
-		"path": "/home/user/myproject",
+		"path": env.ProjectDir,
 	})
 	w := callHandler(ServeRecentProjects, addReq)
 	assert.Equal(t, http.StatusOK, w.Code)
@@ -1579,7 +1579,7 @@ func TestServeRecentProjects_AddAndList(t *testing.T) {
 	// GetRecentProjects returns []string
 	var projects []string
 	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &projects))
-	assert.Contains(t, projects, "/home/user/myproject")
+	assert.Contains(t, projects, env.ProjectDir)
 }
 
 func TestServeRecentProjects_Delete(t *testing.T) {

--- a/internal/service/chat.go
+++ b/internal/service/chat.go
@@ -4,6 +4,8 @@ import (
 	"database/sql"
 	"encoding/json"
 	"fmt"
+	"log/slog"
+	"os"
 	"time"
 
 	"clawbench/internal/model"
@@ -200,6 +202,8 @@ func AddChatMessage(projectPath, backend, sessionID, role, content string, files
 }
 
 // GetRecentProjects returns the most recent 10 project paths.
+// It filters out paths whose directories no longer exist on disk
+// and removes those stale entries from the database.
 func GetRecentProjects() ([]string, error) {
 	var paths []string
 	rows, err := DBRead.Query("SELECT project_path FROM recent_projects ORDER BY accessed_at DESC LIMIT 10")
@@ -214,7 +218,32 @@ func GetRecentProjects() ([]string, error) {
 		}
 		paths = append(paths, p)
 	}
-	return paths, rows.Err()
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+
+	// Filter out projects whose directories no longer exist
+	var valid []string
+	var stale []string
+	for _, p := range paths {
+		info, statErr := os.Stat(p)
+		if statErr == nil && info.IsDir() {
+			valid = append(valid, p)
+		} else {
+			stale = append(stale, p)
+		}
+	}
+
+	// Clean up stale entries from database
+	for _, p := range stale {
+		if delErr := RemoveRecentProject(p); delErr != nil {
+			slog.Warn("failed to remove stale recent project", slog.String("path", p), slog.String("err", delErr.Error()))
+		} else {
+			slog.Info("removed stale recent project", slog.String("path", p))
+		}
+	}
+
+	return valid, nil
 }
 
 // AddRecentProject upserts a project path and prunes old entries beyond 10.

--- a/internal/service/recent_projects_test.go
+++ b/internal/service/recent_projects_test.go
@@ -3,6 +3,7 @@ package service_test
 import (
 	"database/sql"
 	"fmt"
+	"os"
 	"testing"
 	"time"
 
@@ -52,6 +53,16 @@ func insertProjectWithTime(t *testing.T, db *sql.DB, path string, accessedAt tim
 	assert.NoError(t, err)
 }
 
+// createTempProjectDir creates a temporary directory and returns its path.
+// The directory is cleaned up after the test.
+func createTempProjectDir(t *testing.T) string {
+	t.Helper()
+	dir, err := os.MkdirTemp("", "recent-project-test-*")
+	assert.NoError(t, err)
+	t.Cleanup(func() { os.RemoveAll(dir) })
+	return dir
+}
+
 func TestGetRecentProjects_Empty(t *testing.T) {
 	setupRecentProjectsDB(t)
 
@@ -62,53 +73,61 @@ func TestGetRecentProjects_Empty(t *testing.T) {
 
 func TestAddRecentProject(t *testing.T) {
 	setupRecentProjectsDB(t)
+	projectDir := createTempProjectDir(t)
 
-	err := service.AddRecentProject("/home/user/project1")
+	err := service.AddRecentProject(projectDir)
 	assert.NoError(t, err)
 
 	paths, err := service.GetRecentProjects()
 	assert.NoError(t, err)
-	assert.Equal(t, []string{"/home/user/project1"}, paths)
+	assert.Equal(t, []string{projectDir}, paths)
 }
 
 func TestGetRecentProjects_OrderedByAccessedAtDesc(t *testing.T) {
 	db := setupRecentProjectsDB(t)
 
+	dirA := createTempProjectDir(t)
+	dirB := createTempProjectDir(t)
+	dirC := createTempProjectDir(t)
+
 	// Insert with explicit timestamps to guarantee ordering
 	baseTime := time.Date(2024, 1, 1, 0, 0, 0, 0, time.UTC)
-	insertProjectWithTime(t, db, "/project/a", baseTime)
-	insertProjectWithTime(t, db, "/project/b", baseTime.Add(1*time.Second))
-	insertProjectWithTime(t, db, "/project/c", baseTime.Add(2*time.Second))
+	insertProjectWithTime(t, db, dirA, baseTime)
+	insertProjectWithTime(t, db, dirB, baseTime.Add(1*time.Second))
+	insertProjectWithTime(t, db, dirC, baseTime.Add(2*time.Second))
 
 	paths, err := service.GetRecentProjects()
 	assert.NoError(t, err)
 	assert.Len(t, paths, 3)
 
 	// Most recently accessed should be first
-	assert.Equal(t, "/project/c", paths[0])
-	assert.Equal(t, "/project/b", paths[1])
-	assert.Equal(t, "/project/a", paths[2])
+	assert.Equal(t, dirC, paths[0])
+	assert.Equal(t, dirB, paths[1])
+	assert.Equal(t, dirA, paths[2])
 }
 
 func TestAddRecentProject_Upsert(t *testing.T) {
 	db := setupRecentProjectsDB(t)
 
+	dirA := createTempProjectDir(t)
+	dirB := createTempProjectDir(t)
+
 	// Insert with explicit timestamps so the upsert bump is testable
 	baseTime := time.Date(2024, 1, 1, 0, 0, 0, 0, time.UTC)
-	insertProjectWithTime(t, db, "/project/a", baseTime)
-	insertProjectWithTime(t, db, "/project/b", baseTime.Add(1*time.Second))
+	insertProjectWithTime(t, db, dirA, baseTime)
+	insertProjectWithTime(t, db, dirB, baseTime.Add(1*time.Second))
 
-	// Re-add project/a via the service function - should update timestamp
-	err := service.AddRecentProject("/project/a")
+	// Re-add dirA via the service function - should update timestamp
+	err := service.AddRecentProject(dirA)
 	assert.NoError(t, err)
 
 	paths, err := service.GetRecentProjects()
 	assert.NoError(t, err)
 	assert.Len(t, paths, 2) // Still only 2 entries, not 3
 
-	// project/a should now be the most recent (its timestamp was just updated)
-	assert.Equal(t, "/project/a", paths[0])
-	assert.Equal(t, "/project/b", paths[1])
+	// dirA should now be the most recent (its timestamp was just updated)
+	assert.Equal(t, dirA, paths[0])
+	assert.Equal(t, dirB, paths[1])
 }
 
 func TestAddRecentProject_PruneBeyond10(t *testing.T) {
@@ -116,7 +135,8 @@ func TestAddRecentProject_PruneBeyond10(t *testing.T) {
 
 	// Add 12 projects via the service (timestamps will be close but pruning still works)
 	for i := 0; i < 12; i++ {
-		err := service.AddRecentProject(fmt.Sprintf("/project/%02d", i))
+		dir := createTempProjectDir(t)
+		err := service.AddRecentProject(dir)
 		assert.NoError(t, err)
 	}
 
@@ -130,7 +150,8 @@ func TestGetRecentProjects_Limit10(t *testing.T) {
 
 	// Add exactly 10 projects
 	for i := 0; i < 10; i++ {
-		err := service.AddRecentProject(fmt.Sprintf("/project/%02d", i))
+		dir := createTempProjectDir(t)
+		err := service.AddRecentProject(dir)
 		assert.NoError(t, err)
 	}
 
@@ -143,43 +164,213 @@ func TestAddRecentProject_PruneKeepsMostRecent(t *testing.T) {
 	db := setupRecentProjectsDB(t)
 
 	// Insert 10 projects with explicit timestamps
+	var dirs []string
 	baseTime := time.Date(2024, 1, 1, 0, 0, 0, 0, time.UTC)
 	for i := 0; i < 10; i++ {
-		insertProjectWithTime(t, db, fmt.Sprintf("/project/%02d", i), baseTime.Add(time.Duration(i)*time.Second))
+		dir := createTempProjectDir(t)
+		dirs = append(dirs, dir)
+		insertProjectWithTime(t, db, dir, baseTime.Add(time.Duration(i)*time.Second))
 	}
 
-	// Add an 11th via service - should prune the oldest (/project/00)
-	err := service.AddRecentProject("/project/new")
+	// Add an 11th via service - should prune the oldest (dirs[0])
+	newDir := createTempProjectDir(t)
+	err := service.AddRecentProject(newDir)
 	assert.NoError(t, err)
 
 	paths, err := service.GetRecentProjects()
 	assert.NoError(t, err)
 	assert.Len(t, paths, 10)
 
-	// /project/00 should have been pruned (it had the oldest timestamp)
+	// dirs[0] should have been pruned (it had the oldest timestamp)
 	for _, p := range paths {
-		assert.NotEqual(t, "/project/00", p)
+		assert.NotEqual(t, dirs[0], p)
 	}
 
-	// /project/new should be present (it was just added)
+	// newDir should be present (it was just added)
 	found := false
 	for _, p := range paths {
-		if p == "/project/new" {
+		if p == newDir {
 			found = true
 			break
 		}
 	}
-	assert.True(t, found, "/project/new should be in the list")
+	assert.True(t, found, "new project should be in the list")
 }
 
 func TestAddRecentProject_DuplicateDoesNotIncreaseCount(t *testing.T) {
 	setupRecentProjectsDB(t)
 
-	service.AddRecentProject("/project/a")
-	service.AddRecentProject("/project/a")
-	service.AddRecentProject("/project/a")
+	dir := createTempProjectDir(t)
+	service.AddRecentProject(dir)
+	service.AddRecentProject(dir)
+	service.AddRecentProject(dir)
 
 	paths, err := service.GetRecentProjects()
 	assert.NoError(t, err)
-	assert.Len(t, paths, 1) // Still just one entry for /project/a
+	assert.Len(t, paths, 1) // Still just one entry
+}
+
+func TestGetRecentProjects_FiltersNonExistent(t *testing.T) {
+	db := setupRecentProjectsDB(t)
+
+	existingDir := createTempProjectDir(t)
+	nonExistentPath := "/tmp/clawbench-test-nonexistent-" + fmt.Sprintf("%d", time.Now().UnixNano())
+
+	baseTime := time.Date(2024, 1, 1, 0, 0, 0, 0, time.UTC)
+	insertProjectWithTime(t, db, existingDir, baseTime)
+	insertProjectWithTime(t, db, nonExistentPath, baseTime.Add(1*time.Second))
+
+	paths, err := service.GetRecentProjects()
+	assert.NoError(t, err)
+	assert.Equal(t, []string{existingDir}, paths)
+
+	// Verify the non-existent entry was cleaned from the database
+	var count int
+	err = db.QueryRow("SELECT COUNT(*) FROM recent_projects WHERE project_path = ?", nonExistentPath).Scan(&count)
+	assert.NoError(t, err)
+	assert.Equal(t, 0, count, "non-existent project should be removed from DB")
+}
+
+func TestGetRecentProjects_FiltersFilePath(t *testing.T) {
+	db := setupRecentProjectsDB(t)
+
+	existingDir := createTempProjectDir(t)
+	// Create a regular file (not a directory)
+	tmpFile, err := os.CreateTemp("", "recent-project-file-*")
+	assert.NoError(t, err)
+	filePath := tmpFile.Name()
+	tmpFile.Close()
+	t.Cleanup(func() { os.Remove(filePath) })
+
+	baseTime := time.Date(2024, 1, 1, 0, 0, 0, 0, time.UTC)
+	insertProjectWithTime(t, db, existingDir, baseTime)
+	insertProjectWithTime(t, db, filePath, baseTime.Add(1*time.Second))
+
+	paths, err := service.GetRecentProjects()
+	assert.NoError(t, err)
+	assert.Equal(t, []string{existingDir}, paths)
+
+	// File path should have been removed from the database
+	var count int
+	err = db.QueryRow("SELECT COUNT(*) FROM recent_projects WHERE project_path = ?", filePath).Scan(&count)
+	assert.NoError(t, err)
+	assert.Equal(t, 0, count, "file path (not a directory) should be removed from DB")
+}
+
+func TestGetRecentProjects_AllNonExistent(t *testing.T) {
+	db := setupRecentProjectsDB(t)
+
+	// Insert only non-existent paths
+	baseTime := time.Date(2024, 1, 1, 0, 0, 0, 0, time.UTC)
+	for i := 0; i < 3; i++ {
+		insertProjectWithTime(t, db, fmt.Sprintf("/tmp/clawbench-nonexistent-%d-%d", time.Now().UnixNano(), i), baseTime.Add(time.Duration(i)*time.Second))
+	}
+
+	paths, err := service.GetRecentProjects()
+	assert.NoError(t, err)
+	assert.Empty(t, paths)
+
+	// Database should be empty now
+	var count int
+	err = db.QueryRow("SELECT COUNT(*) FROM recent_projects").Scan(&count)
+	assert.NoError(t, err)
+	assert.Equal(t, 0, count, "all stale entries should be removed from DB")
+}
+
+func TestGetRecentProjects_DeletedAfterListed(t *testing.T) {
+	db := setupRecentProjectsDB(t)
+
+	dir := createTempProjectDir(t)
+
+	// Insert and verify it shows up
+	baseTime := time.Date(2024, 1, 1, 0, 0, 0, 0, time.UTC)
+	insertProjectWithTime(t, db, dir, baseTime)
+
+	paths, err := service.GetRecentProjects()
+	assert.NoError(t, err)
+	assert.Equal(t, []string{dir}, paths)
+
+	// Now delete the directory on disk
+	os.RemoveAll(dir)
+
+	// GetRecentProjects should filter it out and clean up the database
+	paths, err = service.GetRecentProjects()
+	assert.NoError(t, err)
+	assert.Empty(t, paths)
+
+	var count int
+	err = db.QueryRow("SELECT COUNT(*) FROM recent_projects WHERE project_path = ?", dir).Scan(&count)
+	assert.NoError(t, err)
+	assert.Equal(t, 0, count, "deleted project should be removed from DB")
+}
+
+func TestGetRecentProjects_DBQueryError(t *testing.T) {
+	// Set up a closed DB to trigger query errors
+	db, err := sql.Open("sqlite", ":memory:")
+	assert.NoError(t, err)
+
+	origDB := service.DB
+	origDBRead := service.DBRead
+	service.DB = db
+	service.DBRead = db
+	t.Cleanup(func() {
+		service.DB = origDB
+		service.DBRead = origDBRead
+	})
+
+	// Close the DB before querying to trigger an error
+	db.Close()
+
+	_, err = service.GetRecentProjects()
+	assert.Error(t, err, "should return error when DB query fails")
+}
+
+func TestGetRecentProjects_RemoveStaleFails(t *testing.T) {
+	// Set up DB but close it mid-way to make RemoveRecentProject fail
+	db := setupRecentProjectsDB(t)
+
+	existingDir := createTempProjectDir(t)
+	nonExistentPath := "/tmp/clawbench-stale-remove-fail-" + fmt.Sprintf("%d", time.Now().UnixNano())
+
+	baseTime := time.Date(2024, 1, 1, 0, 0, 0, 0, time.UTC)
+	insertProjectWithTime(t, db, existingDir, baseTime)
+	insertProjectWithTime(t, db, nonExistentPath, baseTime.Add(1*time.Second))
+
+	// Close the write DB to make RemoveRecentProject fail
+	// but keep the read DB (same instance for :memory:) working for the query
+	// We need to set DB to a closed connection
+	origDB := service.DB
+	closedDB, _ := sql.Open("sqlite", ":memory:")
+	closedDB.Close()
+	service.DB = closedDB
+	t.Cleanup(func() {
+		service.DB = origDB
+	})
+
+	// GetRecentProjects should still succeed (return valid paths)
+	// even though RemoveRecentProject fails for stale entries
+	paths, err := service.GetRecentProjects()
+	assert.NoError(t, err)
+	assert.Equal(t, []string{existingDir}, paths)
+}
+
+func TestAddRecentProject_DBError(t *testing.T) {
+	// Set up a closed DB to trigger exec errors
+	db, err := sql.Open("sqlite", ":memory:")
+	assert.NoError(t, err)
+
+	origDB := service.DB
+	origDBRead := service.DBRead
+	service.DB = db
+	service.DBRead = db
+	t.Cleanup(func() {
+		service.DB = origDB
+		service.DBRead = origDBRead
+	})
+
+	// Close the DB before operation
+	db.Close()
+
+	err = service.AddRecentProject("/some/path")
+	assert.Error(t, err, "should return error when DB exec fails")
 }

--- a/web/src/App.vue
+++ b/web/src/App.vue
@@ -308,7 +308,25 @@ async function hotSwitchProject(newProjectPath, pendingSessionId) {
   await new Promise(r => setTimeout(r, 150))
 
   // ── Phase 2: POST to backend to set new project cookie ──
-  await store.setProject(newProjectPath)
+  try {
+    await store.setProject(newProjectPath)
+  } catch (err) {
+    // Project doesn't exist — revert fade-out and show error
+    switchingProject.value = false
+    const msgKey = err?.msgKey
+    if (msgKey === 'NotADirectory') {
+      toast.show(t('appHeader.projectPathNotFound'), { icon: '⚠️', type: 'error', duration: 3000 })
+      // Remove stale project from recent list
+      fetch('/api/recent-projects', {
+        method: 'DELETE',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ path: newProjectPath })
+      }).catch(() => {})
+    } else {
+      toast.show(t('appHeader.switchProjectFailed', { error: err.message }), { icon: '⚠️', type: 'error', duration: 3000 })
+    }
+    return
+  }
 
   // ── Phase 3: Reset module-level singletons ──
   // (store state already reset by setProject, but identity/agents need explicit reset)

--- a/web/src/utils/api.ts
+++ b/web/src/utils/api.ts
@@ -66,7 +66,11 @@ export async function apiPost<T = unknown>(url: string, body: unknown, opts: Api
             signal,
         })
         const data = await resp.json().catch(() => ({})) as Record<string, unknown>
-        if (!resp.ok) throw new Error(data.error ? String(data.error) : resp.statusText)
+        if (!resp.ok) {
+            const err = new Error(data.error ? String(data.error) : resp.statusText)
+            if (data.msgKey) (err as Error & { msgKey?: string }).msgKey = String(data.msgKey)
+            throw err
+        }
         return data as T
     } finally {
         cleanup()


### PR DESCRIPTION
## 问题

项目在文件系统上被删除后，最近项目列表仍然显示该条目，用户点击后显示"网络错误"而不是"项目不存在"。

## 修改内容

### 后端 (`internal/service/chat.go`)
- `GetRecentProjects()` 现在会检查每个路径的目录是否仍然存在于磁盘
- 不存在的路径会被过滤掉，并自动从数据库中删除
- 路径存在但不是目录（是文件）也会被过滤

### 前端 (`web/src/App.vue`)
- `hotSwitchProject()` 捕获 `setProject()` 的错误
- 如果是 `NotADirectory` 错误，显示"项目路径不存在或已被删除"的 toast 提示
- 自动从最近项目列表中删除该失效条目
- 回退淡出动画，用户停留在当前项目

### 前端 (`web/src/utils/api.ts`)
- `apiPost()` 现在会将后端返回的 `msgKey` 附加到 Error 对象上，以便前端区分错误类型

### 测试
- 更新所有最近项目测试，使用真实临时目录而非假路径
- 新增测试：文件路径过滤、全部不存在、删除后检测、DB 查询错误、失效清理失败、AddRecentProject DB 错误
- Go Tier 2 Diff Coverage: 84.2% (>= 80% ✓)
- Frontend Tier 2 Diff Coverage: 100% ✓