### PR TITLE
fix(ci): auto-merge 使用 ADMIN_TOKEN 绕过分支保护

### DIFF
--- a/.github/workflows/auto-merge.yml
+++ b/.github/workflows/auto-merge.yml
@@ -20,7 +20,7 @@ jobs:
       - name: Find eligible PRs
         id: find-prs
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ secrets.ADMIN_TOKEN }}
         run: |
           # Use GitHub API directly instead of gh pr list to avoid search index delay
           # when triggered by pull_request: labeled events
@@ -58,7 +58,7 @@ jobs:
       - name: Wait for CI and merge
         if: steps.find-prs.outputs.has_prs == 'true'
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ secrets.ADMIN_TOKEN }}
         run: |
           MAX_ATTEMPTS=40
           INTERVAL=15


### PR DESCRIPTION
## 问题

Auto Merge workflow 使用 `GITHUB_TOKEN` 调用 `gh pr merge --admin`，但 `GITHUB_TOKEN` 即使带 `--admin` 标志也无法绕过 main 分支的 "Restrict who can push" 保护规则，导致合并失败：

```
GraphQL: You're not authorized to push to this branch.
```

## 修改

将两个 step 的 `GH_TOKEN` 从 `secrets.GITHUB_TOKEN` 改为 `secrets.ADMIN_TOKEN`（已有 repo admin 权限的 personal access token）。