### PR TITLE
feat(settings): 新增「项目」分类，配置最近项目下拉数量

### DIFF
--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -210,6 +210,7 @@ func main() {
 	model.ChatCollapsedHeight = cfg.Chat.CollapsedHeight
 	model.ChatSystemPromptInterval = cfg.Chat.SystemPromptInterval
 	model.SessionMaxCount = cfg.Session.MaxCount
+	model.RecentProjectsMaxCount = cfg.RecentProjects.MaxCount
 	model.TTSMaxCacheFiles = cfg.TTS.MaxCacheFiles
 
 	// Apply TTS text processing config (defaults applied in ApplyDefaults)

--- a/config/config.example.yaml
+++ b/config/config.example.yaml
@@ -83,6 +83,10 @@
 # session:
 #   max_count: 10  # Maximum chat sessions per project (default: 10) / 会话数量上限（默认: 10）
 
+# Recent projects limit / 最近项目数量限制
+# recent_projects:
+#   max_count: 10  # Maximum recent projects shown in the header dropdown (default: 10) / 标题栏下拉显示的最近项目数量上限（默认: 10）
+
 # TTS (Text-to-Speech) configuration / 语音合成配置
 # Supported engines / 支持的引擎：
 #   edge      — Microsoft Edge TTS, free and unlimited (default) / 微软 Edge TTS，免费无限制（默认）

--- a/internal/handler/project.go
+++ b/internal/handler/project.go
@@ -177,5 +177,6 @@ func ServeWatchDir(w http.ResponseWriter, r *http.Request) {
 		"chatSessionPageSize":   model.ChatSessionPageSize,
 		"chatCollapsedHeight":   model.ChatCollapsedHeight,
 		"sessionMaxCount":       model.SessionMaxCount,
+		"recentProjectsMaxCount": model.RecentProjectsMaxCount,
 	})
 }

--- a/internal/handler/settings.go
+++ b/internal/handler/settings.go
@@ -33,6 +33,7 @@ var hotReloadFields = map[string]bool{
 	"chat.page_size":             true,
 	"chat.system_prompt_interval": true,
 	"session.max_count":          true,
+	"recent_projects.max_count":  true,
 	"upload.max_size_mb":        true,
 	"upload.max_files":          true,
 	"tts.max_cache_files":       true,
@@ -56,17 +57,18 @@ func SetRestartFunc(f func()) {
 // It only contains fields safe for frontend display — no passwords, keys, or
 // internal paths.
 type configResponse struct {
-	Version       string         `json:"version"`
-	DefaultAgent  string         `json:"default_agent"`
-	Chat          configChat     `json:"chat"`
-	Session       configSession  `json:"session"`
-	Upload        configUpload   `json:"upload"`
-	Terminal      configTerminal `json:"terminal"`
-	TTS           configTTS      `json:"tts"`
-	RAG           configRAG      `json:"rag"`
-	PortForward    configPortForward `json:"port_forward"`
-	Push          configPush     `json:"push"`
-	Summarize      configSummarize `json:"summarize"`
+	Version        string               `json:"version"`
+	DefaultAgent   string               `json:"default_agent"`
+	Chat           configChat           `json:"chat"`
+	Session        configSession        `json:"session"`
+	RecentProjects configRecentProjects `json:"recent_projects"`
+	Upload         configUpload         `json:"upload"`
+	Terminal       configTerminal       `json:"terminal"`
+	TTS            configTTS            `json:"tts"`
+	RAG            configRAG            `json:"rag"`
+	PortForward    configPortForward    `json:"port_forward"`
+	Push           configPush          `json:"push"`
+	Summarize      configSummarize     `json:"summarize"`
 }
 
 type configChat struct {
@@ -77,6 +79,10 @@ type configChat struct {
 }
 
 type configSession struct {
+	MaxCount int `json:"max_count"`
+}
+
+type configRecentProjects struct {
 	MaxCount int `json:"max_count"`
 }
 
@@ -170,6 +176,7 @@ var PatchableConfigPaths = map[string]bool{
 	"chat.collapsed_height":        true,
 	"chat.system_prompt_interval":  true,
 	"session.max_count":            true,
+	"recent_projects.max_count":   true,
 	"upload.max_size_mb":           true,
 	"upload.max_files":             true,
 	"terminal.enabled":             true,
@@ -312,6 +319,9 @@ func serveConfigGet(w http.ResponseWriter, r *http.Request) {
 		},
 		Session: configSession{
 			MaxCount: cfg.Session.MaxCount,
+		},
+		RecentProjects: configRecentProjects{
+			MaxCount: cfg.RecentProjects.MaxCount,
 		},
 		Upload: configUpload{
 			MaxSizeMB: cfg.Upload.MaxSizeMB,
@@ -687,6 +697,12 @@ func validatePatchValues(patch map[string]any) error {
 			return fmt.Errorf("session.max_count must be non-negative")
 		}
 	}
+	recentProjects, ok := patch["recent_projects"].(map[string]any)
+	if ok {
+		if v, ok := recentProjects["max_count"].(float64); ok && v < 1 {
+			return fmt.Errorf("recent_projects.max_count must be at least 1")
+		}
+	}
 	upload, ok := patch["upload"].(map[string]any)
 	if ok {
 		if v, ok := upload["max_size_mb"].(float64); ok && v < 0 {
@@ -727,6 +743,12 @@ func applyConfigPatch(patch map[string]any) error {
 	if session, ok := patch["session"].(map[string]any); ok {
 		if v, ok := session["max_count"].(float64); ok {
 			cfg.Session.MaxCount = int(v)
+		}
+	}
+
+	if rp, ok := patch["recent_projects"].(map[string]any); ok {
+		if v, ok := rp["max_count"].(float64); ok {
+			cfg.RecentProjects.MaxCount = int(v)
 		}
 	}
 
@@ -903,6 +925,7 @@ func applyHotReloadGlobals() {
 	model.ChatPageSize = cfg.Chat.PageSize
 	model.ChatSystemPromptInterval = cfg.Chat.SystemPromptInterval
 	model.SessionMaxCount = cfg.Session.MaxCount
+	model.RecentProjectsMaxCount = cfg.RecentProjects.MaxCount
 	model.UploadMaxSizeMB = cfg.Upload.MaxSizeMB
 	model.UploadMaxFiles = cfg.Upload.MaxFiles
 	model.TTSMaxCacheFiles = cfg.TTS.MaxCacheFiles

--- a/internal/handler/settings_test.go
+++ b/internal/handler/settings_test.go
@@ -1414,3 +1414,111 @@ func TestServeConfig_Patch_SummarizeAPIFormatInvalid(t *testing.T) {
 	assert.Equal(t, http.StatusBadRequest, w.Code)
 	assert.Contains(t, w.Body.String(), "summarize.api.format must be one of")
 }
+
+// --- recent_projects.max_count tests ---
+
+func TestServeConfig_Get_RecentProjects(t *testing.T) {
+	_, teardown := setupTestEnv(t)
+	defer teardown()
+
+	cfg := model.Config{}
+	cfg.RecentProjects.MaxCount = 15
+	model.ConfigInstance = cfg
+
+	req := newRequest(t, http.MethodGet, "/api/config", nil)
+	withAuthCookie(req, model.SessionToken)
+	w := callHandler(ServeConfig, req)
+
+	assert.Equal(t, http.StatusOK, w.Code)
+
+	var resp map[string]any
+	err := json.Unmarshal(w.Body.Bytes(), &resp)
+	assert.NoError(t, err)
+
+	// recent_projects section should be present
+	assert.Contains(t, resp, "recent_projects")
+	rp, ok := resp["recent_projects"].(map[string]any)
+	assert.True(t, ok, "recent_projects should be a map")
+	assert.Equal(t, float64(15), rp["max_count"])
+}
+
+func TestServeConfig_Patch_RecentProjectsMaxCount(t *testing.T) {
+	_, teardown := setupTestEnv(t)
+	defer teardown()
+
+	cfg := model.Config{}
+	cfg.RecentProjects.MaxCount = 10
+	model.ConfigInstance = cfg
+
+	body := `{"recent_projects":{"max_count":20}}`
+	req := httptest.NewRequest(http.MethodPatch, "/api/config", strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	withAuthCookie(req, model.SessionToken)
+	w := callHandler(ServeConfig, req)
+
+	assert.Equal(t, http.StatusOK, w.Code)
+	assert.Equal(t, 20, model.ConfigInstance.RecentProjects.MaxCount)
+	assert.Equal(t, 20, model.RecentProjectsMaxCount, "global variable should be updated via hot-reload")
+}
+
+func TestServeConfig_Patch_RecentProjectsMaxCount_IsHotField(t *testing.T) {
+	_, teardown := setupTestEnv(t)
+	defer teardown()
+
+	cfg := model.Config{}
+	cfg.RecentProjects.MaxCount = 10
+	model.ConfigInstance = cfg
+
+	// recent_projects.max_count is a hot-reload field — no restart should be needed
+	body := `{"recent_projects":{"max_count":25}}`
+	req := httptest.NewRequest(http.MethodPatch, "/api/config", strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	withAuthCookie(req, model.SessionToken)
+	w := callHandler(ServeConfig, req)
+
+	assert.Equal(t, http.StatusOK, w.Code)
+
+	var resp map[string]any
+	err := json.Unmarshal(w.Body.Bytes(), &resp)
+	assert.NoError(t, err)
+	assert.False(t, resp["needs_restart"].(bool), "recent_projects.max_count is hot-reloadable, should not need restart")
+	changed, ok := resp["changed_cold_fields"].([]any)
+	assert.True(t, ok)
+	assert.Empty(t, changed)
+}
+
+func TestServeConfig_Patch_RecentProjectsMaxCount_ZeroRejected(t *testing.T) {
+	_, teardown := setupTestEnv(t)
+	defer teardown()
+
+	cfg := model.Config{}
+	cfg.RecentProjects.MaxCount = 10
+	model.ConfigInstance = cfg
+
+	// 0 should be rejected (min is 1)
+	body := `{"recent_projects":{"max_count":0}}`
+	req := httptest.NewRequest(http.MethodPatch, "/api/config", strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	withAuthCookie(req, model.SessionToken)
+	w := callHandler(ServeConfig, req)
+
+	assert.Equal(t, http.StatusBadRequest, w.Code)
+	assert.Contains(t, w.Body.String(), "recent_projects.max_count must be at least 1")
+}
+
+func TestServeConfig_Patch_RecentProjectsMaxCount_NegativeRejected(t *testing.T) {
+	_, teardown := setupTestEnv(t)
+	defer teardown()
+
+	cfg := model.Config{}
+	model.ConfigInstance = cfg
+
+	body := `{"recent_projects":{"max_count":-5}}`
+	req := httptest.NewRequest(http.MethodPatch, "/api/config", strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	withAuthCookie(req, model.SessionToken)
+	w := callHandler(ServeConfig, req)
+
+	assert.Equal(t, http.StatusBadRequest, w.Code)
+	assert.Contains(t, w.Body.String(), "recent_projects.max_count must be at least 1")
+}

--- a/internal/model/config.go
+++ b/internal/model/config.go
@@ -30,6 +30,9 @@ type Config struct {
 	Session struct {
 		MaxCount int `yaml:"max_count"` // Maximum number of chat sessions per project (default: 10)
 	} `yaml:"session"`
+	RecentProjects struct {
+		MaxCount int `yaml:"max_count"` // Maximum number of recent projects to keep (default: 10)
+	} `yaml:"recent_projects"`
 	TTS struct {
 		Engine            string         `yaml:"engine"`             // TTS engine: "edge" (default), "piper", "kokoro", "moss-nano"
 		TTSModel          string         `yaml:"tts_model"`          // TTS model for speech synthesis (default: "Speech-2.8-Turbo")
@@ -153,6 +156,9 @@ var (
 
 	// Session limits (set from config, with defaults)
 	SessionMaxCount int // Default: 10
+
+	// Recent projects limits (set from config, with defaults)
+	RecentProjectsMaxCount int // Default: 10
 
 	// TTS cache limits (set from config, with defaults)
 	TTSMaxCacheFiles int // Default: 100; 0 = unlimited

--- a/internal/model/defaults.go
+++ b/internal/model/defaults.go
@@ -132,6 +132,11 @@ func ApplyDefaults(cfg *Config, presence map[string]bool) string {
 		cfg.Session.MaxCount = 10
 	}
 
+	// --- Recent Projects ---
+	if cfg.RecentProjects.MaxCount <= 0 {
+		cfg.RecentProjects.MaxCount = 10
+	}
+
 	// --- Proxy (legacy) ---
 	// proxy.enabled and proxy.allowed_ports have been removed.
 	// ProxyConfig is kept for backward-compatible YAML reading only.

--- a/internal/model/defaults_test.go
+++ b/internal/model/defaults_test.go
@@ -478,3 +478,28 @@ func TestApplyDefaults_PortForwardHostKey(t *testing.T) {
 		t.Error("PortForward.HostKey should have a default value")
 	}
 }
+
+func TestApplyDefaults_RecentProjectsMaxCount(t *testing.T) {
+	setupTestBinDir(t)
+
+	// Default: 10
+	cfg := Config{}
+	ApplyDefaults(&cfg, nil)
+
+	if cfg.RecentProjects.MaxCount != 10 {
+		t.Errorf("RecentProjects.MaxCount = %d, want 10", cfg.RecentProjects.MaxCount)
+	}
+}
+
+func TestApplyDefaults_RecentProjectsMaxCountExplicit(t *testing.T) {
+	setupTestBinDir(t)
+
+	// Explicitly set value should be preserved
+	cfg := Config{}
+	cfg.RecentProjects.MaxCount = 25
+	ApplyDefaults(&cfg, map[string]bool{"recent_projects": true, "recent_projects.max_count": true})
+
+	if cfg.RecentProjects.MaxCount != 25 {
+		t.Errorf("RecentProjects.MaxCount = %d, want 25 (explicitly set)", cfg.RecentProjects.MaxCount)
+	}
+}

--- a/internal/service/chat.go
+++ b/internal/service/chat.go
@@ -201,12 +201,16 @@ func AddChatMessage(projectPath, backend, sessionID, role, content string, files
 	return messageID, nil
 }
 
-// GetRecentProjects returns the most recent 10 project paths.
+// GetRecentProjects returns the most recent project paths.
 // It filters out paths whose directories no longer exist on disk
 // and removes those stale entries from the database.
 func GetRecentProjects() ([]string, error) {
+	limit := model.RecentProjectsMaxCount
+	if limit <= 0 {
+		limit = 10
+	}
 	var paths []string
-	rows, err := DBRead.Query("SELECT project_path FROM recent_projects ORDER BY accessed_at DESC LIMIT 10")
+	rows, err := DBRead.Query("SELECT project_path FROM recent_projects ORDER BY accessed_at DESC LIMIT ?", limit)
 	if err != nil {
 		return nil, err
 	}
@@ -246,7 +250,7 @@ func GetRecentProjects() ([]string, error) {
 	return valid, nil
 }
 
-// AddRecentProject upserts a project path and prunes old entries beyond 10.
+// AddRecentProject upserts a project path and prunes old entries beyond configured limit.
 func AddRecentProject(projectPath string) error {
 	_, err := DB.Exec(
 		"INSERT INTO recent_projects (project_path, accessed_at) VALUES (?, CURRENT_TIMESTAMP) "+
@@ -256,8 +260,13 @@ func AddRecentProject(projectPath string) error {
 	if err != nil {
 		return err
 	}
+	limit := model.RecentProjectsMaxCount
+	if limit <= 0 {
+		limit = 10
+	}
 	_, err = DB.Exec(
-		"DELETE FROM recent_projects WHERE id NOT IN (SELECT id FROM recent_projects ORDER BY accessed_at DESC LIMIT 10)",
+		"DELETE FROM recent_projects WHERE id NOT IN (SELECT id FROM recent_projects ORDER BY accessed_at DESC LIMIT ?)",
+		limit,
 	)
 	return err
 }

--- a/internal/service/recent_projects_test.go
+++ b/internal/service/recent_projects_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 	"time"
 
+	"clawbench/internal/model"
 	"clawbench/internal/service"
 
 	_ "modernc.org/sqlite"
@@ -373,4 +374,108 @@ func TestAddRecentProject_DBError(t *testing.T) {
 
 	err = service.AddRecentProject("/some/path")
 	assert.Error(t, err, "should return error when DB exec fails")
+}
+
+// --- Configurable limit tests ---
+
+func TestGetRecentProjects_ConfigurableLimit(t *testing.T) {
+	setupRecentProjectsDB(t)
+
+	// Set limit to 3
+	origLimit := model.RecentProjectsMaxCount
+	model.RecentProjectsMaxCount = 3
+	t.Cleanup(func() { model.RecentProjectsMaxCount = origLimit })
+
+	// Add 5 projects
+	for i := 0; i < 5; i++ {
+		dir := createTempProjectDir(t)
+		err := service.AddRecentProject(dir)
+		assert.NoError(t, err)
+	}
+
+	paths, err := service.GetRecentProjects()
+	assert.NoError(t, err)
+	assert.Len(t, paths, 3, "should return at most 3 projects when limit is 3")
+}
+
+func TestAddRecentProject_PruneToConfigurableLimit(t *testing.T) {
+	setupRecentProjectsDB(t)
+
+	// Set limit to 5
+	origLimit := model.RecentProjectsMaxCount
+	model.RecentProjectsMaxCount = 5
+	t.Cleanup(func() { model.RecentProjectsMaxCount = origLimit })
+
+	// Add 8 projects
+	for i := 0; i < 8; i++ {
+		dir := createTempProjectDir(t)
+		err := service.AddRecentProject(dir)
+		assert.NoError(t, err)
+	}
+
+	paths, err := service.GetRecentProjects()
+	assert.NoError(t, err)
+	assert.Len(t, paths, 5, "should be pruned to 5 when limit is 5")
+}
+
+func TestGetRecentProjects_FallbackToDefaultLimit(t *testing.T) {
+	setupRecentProjectsDB(t)
+
+	// Set limit to 0 (should fallback to 10)
+	origLimit := model.RecentProjectsMaxCount
+	model.RecentProjectsMaxCount = 0
+	t.Cleanup(func() { model.RecentProjectsMaxCount = origLimit })
+
+	// Add 12 projects
+	for i := 0; i < 12; i++ {
+		dir := createTempProjectDir(t)
+		err := service.AddRecentProject(dir)
+		assert.NoError(t, err)
+	}
+
+	paths, err := service.GetRecentProjects()
+	assert.NoError(t, err)
+	assert.Len(t, paths, 10, "should fallback to default 10 when limit is 0")
+}
+
+func TestAddRecentProject_PruneKeepsMostRecentWithCustomLimit(t *testing.T) {
+	db := setupRecentProjectsDB(t)
+
+	// Set limit to 3
+	origLimit := model.RecentProjectsMaxCount
+	model.RecentProjectsMaxCount = 3
+	t.Cleanup(func() { model.RecentProjectsMaxCount = origLimit })
+
+	// Insert 3 projects with explicit timestamps
+	var dirs []string
+	baseTime := time.Date(2024, 1, 1, 0, 0, 0, 0, time.UTC)
+	for i := 0; i < 3; i++ {
+		dir := createTempProjectDir(t)
+		dirs = append(dirs, dir)
+		insertProjectWithTime(t, db, dir, baseTime.Add(time.Duration(i)*time.Second))
+	}
+
+	// Add a 4th via service — should prune the oldest (dirs[0])
+	newDir := createTempProjectDir(t)
+	err := service.AddRecentProject(newDir)
+	assert.NoError(t, err)
+
+	paths, err := service.GetRecentProjects()
+	assert.NoError(t, err)
+	assert.Len(t, paths, 3)
+
+	// dirs[0] should have been pruned (oldest timestamp)
+	for _, p := range paths {
+		assert.NotEqual(t, dirs[0], p)
+	}
+
+	// newDir should be present
+	found := false
+	for _, p := range paths {
+		if p == newDir {
+			found = true
+			break
+		}
+	}
+	assert.True(t, found, "new project should be in the list")
 }

--- a/web/src/components/__tests__/appHeader.test.ts
+++ b/web/src/components/__tests__/appHeader.test.ts
@@ -200,4 +200,33 @@ describe('AppHeader', () => {
     mountAndTrack({ projectRoot: '' })
     expect(loadGitBranchFn).not.toHaveBeenCalled()
   })
+
+  // ── Recent projects dropdown with scroll area (2) ──
+  // These tests set internal refs directly and suppress the known
+  // "Maximum recursive updates" error from the mock store's shared reactive
+  // state (documented at the top of this file). The error is a test-only
+  // artifact; the dropdown renders correctly in production.
+
+  it('renders dropdown-scroll-area when dropdown is open with recent items', async () => {
+    const wrapper = mountAndTrack()
+    wrapper.vm.dropdownOpen = true
+    wrapper.vm.recentItems = [
+      { name: 'proj-a', path: '/home/user/proj-a', displayPath: 'proj-a' },
+      { name: 'proj-b', path: '/home/user/proj-b', displayPath: 'proj-b' },
+    ]
+    try { await wrapper.vm.$nextTick() } catch {}
+
+    expect(wrapper.find('.dropdown-scroll-area').exists()).toBe(true)
+    expect(wrapper.findAll('.dropdown-scroll-area .dropdown-item').length).toBe(2)
+  })
+
+  it('renders dropdown-empty when dropdown is open with no recent items', async () => {
+    const wrapper = mountAndTrack()
+    wrapper.vm.dropdownOpen = true
+    wrapper.vm.recentItems = []
+    try { await wrapper.vm.$nextTick() } catch {}
+
+    expect(wrapper.find('.dropdown-scroll-area').exists()).toBe(false)
+    expect(wrapper.find('.dropdown-empty').exists()).toBe(true)
+  })
 })

--- a/web/src/components/common/AppHeader.vue
+++ b/web/src/components/common/AppHeader.vue
@@ -16,16 +16,18 @@
           <div v-if="loadingRecent" class="dropdown-loading">{{ t('common.loading') }}</div>
           <template v-else>
             <div v-if="recentItems.length === 0" class="dropdown-empty">{{ t('appHeader.noRecentProjects') }}</div>
-            <div
-              v-for="item in recentItems"
-              :key="item.path"
-              class="dropdown-item"
-              :class="{ active: item.path === projectRoot }"
-              @click="selectRecent(item)"
-            >
-              <Projector :size="14" class="item-icon" />
-              <span class="item-label">{{ item.name }}</span>
-              <span class="item-path" @mousedown.prevent="onPathMouseDown" @click="onPathClick">{{ item.displayPath }}</span>
+            <div v-else class="dropdown-scroll-area">
+              <div
+                v-for="item in recentItems"
+                :key="item.path"
+                class="dropdown-item"
+                :class="{ active: item.path === projectRoot }"
+                @click="selectRecent(item)"
+              >
+                <Projector :size="14" class="item-icon" />
+                <span class="item-label">{{ item.name }}</span>
+                <span class="item-path" @mousedown.prevent="onPathMouseDown" @click="onPathClick">{{ item.displayPath }}</span>
+              </div>
             </div>
             <div class="dropdown-divider"></div>
             <div class="dropdown-item other-item" @click="openBrowse">
@@ -518,6 +520,28 @@ onUnmounted(() => {
     z-index: 9999;
     overflow: hidden;
     padding: 3px 0;
+    display: flex;
+    flex-direction: column;
+}
+
+.project-dropdown .dropdown-scroll-area {
+    overflow-y: auto;
+    overflow-x: hidden;
+    max-height: 300px;
+    scrollbar-width: thin;
+}
+
+.project-dropdown .dropdown-scroll-area::-webkit-scrollbar {
+    width: 4px;
+}
+
+.project-dropdown .dropdown-scroll-area::-webkit-scrollbar-thumb {
+    background: var(--border-color);
+    border-radius: 2px;
+}
+
+.project-dropdown .dropdown-scroll-area::-webkit-scrollbar-track {
+    background: transparent;
 }
 
 .project-dropdown .dropdown-loading,

--- a/web/src/components/settings/SettingsIndex.vue
+++ b/web/src/components/settings/SettingsIndex.vue
@@ -19,6 +19,7 @@
 import { computed } from 'vue'
 import {
   Palette,
+  MapPin,
   MessageSquare,
   Bot,
   FolderOpen,
@@ -43,6 +44,7 @@ const { isAppMode } = useAppMode()
 
 const categoryDefs = computed(() => [
   { id: 'appearance', icon: Palette },
+  { id: 'project', icon: MapPin },
   { id: 'chat', icon: MessageSquare },
   { id: 'agents', icon: Bot },
   { id: 'files', icon: FolderOpen },

--- a/web/src/components/settings/__tests__/SettingsIndex.test.ts
+++ b/web/src/components/settings/__tests__/SettingsIndex.test.ts
@@ -12,6 +12,7 @@ const i18n = createI18n({
       settings: {
         categories: {
           appearance: '外观',
+          project: '项目',
           chat: '聊天',
           agents: 'Agent偏好',
           files: '文件',
@@ -31,6 +32,7 @@ const i18n = createI18n({
 const globalStubs = {
   'lucide-chevron-right': true,
   'lucide-palette': true,
+  'lucide-map-pin': true,
   'lucide-message-square': true,
   'lucide-bot': true,
   'lucide-folder-open': true,
@@ -55,12 +57,12 @@ function mountIndex() {
 }
 
 describe('SettingsIndex', () => {
-  it('renders 10 category rows in web mode (no Android)', () => {
+  it('renders 11 category rows in web mode (no Android)', () => {
     isAppModeRef.value = false
     const wrapper = mountIndex()
 
     const rows = wrapper.findAll('.settings-index__row')
-    expect(rows.length).toBe(10)
+    expect(rows.length).toBe(11)
   })
 
   it('renders category labels in web mode', () => {
@@ -69,6 +71,7 @@ describe('SettingsIndex', () => {
 
     const labels = wrapper.findAll('.settings-index__label').map(el => el.text())
     expect(labels).toContain('外观')
+    expect(labels).toContain('项目')
     expect(labels).toContain('聊天')
     expect(labels).toContain('Agent偏好')
     expect(labels).toContain('文件')
@@ -92,7 +95,7 @@ describe('SettingsIndex', () => {
     const wrapper = mountIndex()
 
     const expectedIds = [
-      'appearance', 'chat', 'agents', 'files', 'terminal',
+      'appearance', 'project', 'chat', 'agents', 'files', 'terminal',
       'tts', 'summarization', 'rag', 'network', 'about',
     ]
 
@@ -103,12 +106,12 @@ describe('SettingsIndex', () => {
     }
   })
 
-  it('shows 11 categories including Android in app mode', () => {
+  it('shows 12 categories including Android in app mode', () => {
     isAppModeRef.value = true
     const wrapper = mountIndex()
 
     const rows = wrapper.findAll('.settings-index__row')
-    expect(rows.length).toBe(11)
+    expect(rows.length).toBe(12)
 
     const labels = wrapper.findAll('.settings-index__label').map(el => el.text())
     expect(labels).toContain('Android')

--- a/web/src/components/settings/__tests__/settingsFieldMap.test.ts
+++ b/web/src/components/settings/__tests__/settingsFieldMap.test.ts
@@ -47,6 +47,20 @@ describe('settingsFieldMap', () => {
     expect(map['rag.search_pool_size']).toBeTruthy()
   })
 
+  it('includes recent_projects.max_count', () => {
+    const map = getServerFieldToLabelKey()
+    expect(map['recent_projects.max_count']).toBeTruthy()
+  })
+
+  it('recent_projects.max_count is in project category items', () => {
+    const projectItems = categoryItems['project']
+    const rpItem = projectItems.find(item => item.key === 'recent_projects.max_count')
+    expect(rpItem).toBeDefined()
+    expect(rpItem!.source).toBe('server')
+    expect(rpItem!.type).toBe('number')
+    expect(rpItem!.min).toBe(1)
+  })
+
   it('does not map orphaned ssh.* keys (renamed to port_forward)', () => {
     const map = getServerFieldToLabelKey()
     // SSH was renamed to port_forward — ssh.enabled/ssh.port are backend-internal only
@@ -55,7 +69,7 @@ describe('settingsFieldMap', () => {
   })
 
   it('categoryItems covers all expected categories', () => {
-    const expectedCategories = ['appearance', 'chat', 'agents', 'files', 'terminal', 'tts', 'summarization', 'rag', 'network', 'android', 'about']
+    const expectedCategories = ['appearance', 'project', 'chat', 'agents', 'files', 'terminal', 'tts', 'summarization', 'rag', 'network', 'android', 'about']
     for (const cat of expectedCategories) {
       expect(categoryItems[cat]).toBeDefined()
     }

--- a/web/src/components/settings/settingsFieldMap.ts
+++ b/web/src/components/settings/settingsFieldMap.ts
@@ -55,6 +55,9 @@ export const categoryItems: Record<string, ItemSpec[]> = {
     { labelKey: 'settings.items.chatSystemPromptInterval', descriptionKey: 'settings.items.chatSystemPromptIntervalDesc', key: 'chat.system_prompt_interval', type: 'number', source: 'server' },
     { labelKey: 'settings.items.sessionMaxCount', descriptionKey: 'settings.items.sessionMaxCountDesc', key: 'session.max_count', type: 'number', source: 'server' },
   ],
+  project: [
+    { labelKey: 'settings.items.recentProjectsMaxCount', descriptionKey: 'settings.items.recentProjectsMaxCountDesc', key: 'recent_projects.max_count', type: 'number', source: 'server', min: 1 },
+  ],
   agents: [],  // Dynamically built in computed items
   files: [
     { labelKey: 'settings.items.showHidden', descriptionKey: 'settings.items.showHiddenDesc', key: 'showHidden', type: 'switch', source: 'local' },

--- a/web/src/composables/useSettingsConfig.ts
+++ b/web/src/composables/useSettingsConfig.ts
@@ -216,6 +216,7 @@ const serverDefaults: Record<string, any> = {
   'chat.collapsed_height': 150,
   'chat.system_prompt_interval': 10,
   'session.max_count': 10,
+  'recent_projects.max_count': 10,
   'upload.max_size_mb': 100,
   'upload.max_files': 20,
   'terminal.enabled': true,

--- a/web/src/i18n/locales/en.ts
+++ b/web/src/i18n/locales/en.ts
@@ -768,6 +768,7 @@ export default {
   settings: {
     categories: {
       appearance: 'Appearance',
+      project: 'Project',
       chat: 'Chat',
       agents: 'Agent Prefs',
       files: 'Files',
@@ -805,6 +806,8 @@ export default {
       chatSystemPromptIntervalDesc: 'Insert a system prompt every N messages',
       sessionMaxCount: 'Max Sessions',
       sessionMaxCountDesc: 'Maximum number of concurrent chat sessions',
+      recentProjectsMaxCount: 'Recent Projects Count',
+      recentProjectsMaxCountDesc: 'Number of recent projects shown in the project dropdown',
       showHidden: 'Show Hidden Files',
       showHiddenDesc: 'Show dot-prefixed hidden files in the file manager',
       wordWrap: 'Word Wrap',

--- a/web/src/i18n/locales/zh.ts
+++ b/web/src/i18n/locales/zh.ts
@@ -768,6 +768,7 @@ export default {
   settings: {
     categories: {
       appearance: '外观',
+      project: '项目',
       chat: '聊天',
       agents: 'Agent偏好',
       files: '文件',
@@ -805,6 +806,8 @@ export default {
       chatSystemPromptIntervalDesc: '每隔多少条消息插入一次系统提示',
       sessionMaxCount: '最大会话数',
       sessionMaxCountDesc: '允许同时存在的聊天会话上限',
+      recentProjectsMaxCount: '最近项目数量',
+      recentProjectsMaxCountDesc: '点击项目名称下拉显示的最近项目数量',
       showHidden: '显示隐藏文件',
       showHiddenDesc: '在文件管理器中显示以 . 开头的隐藏文件',
       wordWrap: '自动换行',

--- a/web/src/stores/__tests__/app.test.ts
+++ b/web/src/stores/__tests__/app.test.ts
@@ -130,6 +130,47 @@ describe('store', () => {
         })
     })
 
+    // ── loadProject ──
+
+    describe('loadProject', () => {
+        it('reads recentProjectsMaxCount from watch-dir API', async () => {
+            mockApiGet.mockImplementation((url: string) => {
+                if (url === '/api/watch-dir') {
+                    return { watchDir: '/watch', recentProjectsMaxCount: 5 }
+                }
+                if (url === '/api/project') {
+                    return { path: '/home/user/project' }
+                }
+                return {}
+            })
+            mockApiPost.mockResolvedValue({})
+
+            await store.loadProject()
+
+            expect(store.state.recentProjectsMaxCount).toBe(5)
+        })
+
+        it('does not update recentProjectsMaxCount when API returns 0 or undefined', async () => {
+            store.state.recentProjectsMaxCount = 10
+
+            mockApiGet.mockImplementation((url: string) => {
+                if (url === '/api/watch-dir') {
+                    return { watchDir: '/watch', recentProjectsMaxCount: 0 }
+                }
+                if (url === '/api/project') {
+                    return { path: '/home/user/project' }
+                }
+                return {}
+            })
+            mockApiPost.mockResolvedValue({})
+
+            await store.loadProject()
+
+            // 0 is not > 0, so it stays at the default set by resetProjectState
+            expect(store.state.recentProjectsMaxCount).toBe(10)
+        })
+    })
+
     // ── setProject ──
 
     describe('setProject', () => {

--- a/web/src/stores/__tests__/app.test.ts
+++ b/web/src/stores/__tests__/app.test.ts
@@ -115,6 +115,7 @@ describe('store', () => {
             store.state.chatSessionPageSize = 999
             store.state.chatCollapsedHeight = 999
             store.state.sessionMaxCount = 999
+            store.state.recentProjectsMaxCount = 999
 
             store.resetProjectState()
 
@@ -125,6 +126,7 @@ describe('store', () => {
             expect(store.state.chatSessionPageSize).toBe(10)
             expect(store.state.chatCollapsedHeight).toBe(150)
             expect(store.state.sessionMaxCount).toBe(10)
+            expect(store.state.recentProjectsMaxCount).toBe(10)
         })
     })
 

--- a/web/src/stores/app.ts
+++ b/web/src/stores/app.ts
@@ -45,6 +45,9 @@ interface AppState {
     chatCollapsedHeight: number
     sessionMaxCount: number
 
+    // Recent projects config
+    recentProjectsMaxCount: number
+
     // Chat unread badge
     chatUnread: boolean
 
@@ -101,6 +104,7 @@ const state = reactive<AppState>({
     chatSessionPageSize: 10,
     chatCollapsedHeight: 150,
     sessionMaxCount: 10,
+    recentProjectsMaxCount: 10,
     chatUnread: false,
     chatRunning: false,
     taskUnread: false,
@@ -137,7 +141,7 @@ const state = reactive<AppState>({
 async function loadProject(): Promise<void> {
     try {
         try {
-            const wd = await apiGet<{ watchDir: string; uploadMaxSizeMB: number; uploadMaxFiles: number; chatInitialMessages?: number; chatPageSize?: number; chatSessionPageSize?: number; chatCollapsedHeight?: number; sessionMaxCount?: number }>('/api/watch-dir')
+            const wd = await apiGet<{ watchDir: string; uploadMaxSizeMB: number; uploadMaxFiles: number; chatInitialMessages?: number; chatPageSize?: number; chatSessionPageSize?: number; chatCollapsedHeight?: number; sessionMaxCount?: number; recentProjectsMaxCount?: number }>('/api/watch-dir')
             state.watchDir = wd.watchDir || ''
             if (wd.uploadMaxSizeMB > 0) state.uploadMaxSizeMB = wd.uploadMaxSizeMB
             if (wd.uploadMaxFiles > 0) state.uploadMaxFiles = wd.uploadMaxFiles
@@ -146,6 +150,7 @@ async function loadProject(): Promise<void> {
             if (wd.chatSessionPageSize > 0) state.chatSessionPageSize = wd.chatSessionPageSize
             if (wd.chatCollapsedHeight > 0) state.chatCollapsedHeight = wd.chatCollapsedHeight
             if (wd.sessionMaxCount > 0) state.sessionMaxCount = wd.sessionMaxCount
+            if (wd.recentProjectsMaxCount > 0) state.recentProjectsMaxCount = wd.recentProjectsMaxCount
         } catch (error) {
             console.error('[loadProject] watchDir failed:', error)
         }
@@ -198,6 +203,7 @@ function resetProjectState(): void {
     state.chatSessionPageSize = 10
     state.chatCollapsedHeight = 150
     state.sessionMaxCount = 10
+    state.recentProjectsMaxCount = 10
 }
 
 // =============================================


### PR DESCRIPTION
## 功能概述

在设置面板中新增「项目」分类，允许用户配置 AppHeader 中点击项目名称下拉显示的最近项目数量。

### 后端改动
- `Config` 新增 `RecentProjects.MaxCount` 字段（默认 10）
- `GetRecentProjects()` / `AddRecentProject()` 使用 `model.RecentProjectsMaxCount` 替代硬编码 `LIMIT 10`
- 支持 PATCH 热重载（无需重启），验证 `min ≥ 1`
- `ServeWatchDir` 响应新增 `recentProjectsMaxCount`

### 前端改动
- `settingsFieldMap` 新增 `project` 分类，含 `recent_projects.max_count` 配置项
- `SettingsIndex` 新增「项目」行（MapPin 图标）
- `AppHeader` 下拉改为 scroll area（`max-height: 300px`），浏览按钮固定底部不随滚动
- i18n 中英翻译

### 测试覆盖
**Go 后端（11 个新测试）：**
- `defaults_test`: 默认值 10、显式值保留
- `recent_projects_test`: 可配置 limit、裁剪、回退默认、保留最近
- `settings_test`: GET 返回 recent_projects 段、PATCH 更新+热重载、热字段验证、0 拒绝、负数拒绝

**前端（3 个新/扩展测试）：**
- `settingsFieldMap.test`: `recent_projects.max_count` 映射 + project 分类项验证
- `app.test`: `recentProjectsMaxCount` 在 resetProjectState 中重置
- `SettingsIndex.test`: 分类数量更新（11 web / 12 app）