### PR TITLE
fix: SSH tunnel port forwarding — privileged ports, Host header, reverse proxy, UI layout

### DIFF
--- a/android/app/src/main/java/com/clawbench/app/BackgroundService.java
+++ b/android/app/src/main/java/com/clawbench/app/BackgroundService.java
@@ -96,7 +96,20 @@ public class BackgroundService extends Service {
 
     private JSch jsch;
     private Session sshSession;
-    private final Map<Integer, String> forwardedPorts = new java.util.concurrent.ConcurrentHashMap<>();
+
+    // PortInfo tracks both the target port and host for a forwarded port.
+    // This is needed because localPort may differ from targetPort when
+    // the same target port is forwarded to different hosts (auto-allocation).
+    static class PortInfo {
+        final int targetPort;
+        final String host;
+        PortInfo(int targetPort, String host) {
+            this.targetPort = targetPort;
+            this.host = host != null ? host : "";
+        }
+    }
+
+    private final Map<Integer, PortInfo> forwardedPorts = new java.util.concurrent.ConcurrentHashMap<>();
     private String serverHost;
     private int sshPort;
     private String password;
@@ -275,12 +288,13 @@ public class BackgroundService extends Service {
         if (intent != null) {
             String action = intent.getAction();
             if ("ADD_PORT".equals(action)) {
-                int port = intent.getIntExtra("port", 0);
+                int localPort = intent.getIntExtra("localPort", 0);
+                int targetPort = intent.getIntExtra("targetPort", localPort); // backward compat: default to localPort
                 String host = intent.getStringExtra("host");
                 if (host == null) host = "";
-                if (port > 0) {
+                if (localPort > 0) {
                     String finalHost = host;
-                    networkExecutor.execute(() -> addPortForward(port, finalHost));
+                    networkExecutor.execute(() -> addPortForward(localPort, targetPort, finalHost));
                 }
             } else if ("REMOVE_PORT".equals(action)) {
                 int port = intent.getIntExtra("port", 0);
@@ -382,14 +396,18 @@ public class BackgroundService extends Service {
 
     /**
      * Save the current forwarded ports set to SharedPreferences.
+     * Format: "localPort:targetPort:host" or "localPort:targetPort" (when host is empty)
+     * Backward compat for old format: "localPort" or "localPort:host" (targetPort assumed == localPort)
      */
     private void saveForwardedPorts() {
         Set<String> portStrings = new HashSet<>();
-        for (Map.Entry<Integer, String> entry : forwardedPorts.entrySet()) {
-            if (entry.getValue().isEmpty()) {
-                portStrings.add(String.valueOf(entry.getKey()));
+        for (Map.Entry<Integer, PortInfo> entry : forwardedPorts.entrySet()) {
+            int localPort = entry.getKey();
+            PortInfo info = entry.getValue();
+            if (info.host.isEmpty()) {
+                portStrings.add(localPort + ":" + info.targetPort);
             } else {
-                portStrings.add(entry.getKey() + ":" + entry.getValue());
+                portStrings.add(localPort + ":" + info.targetPort + ":" + info.host);
             }
         }
         getSharedPreferences(PREFS_NAME, MODE_PRIVATE)
@@ -401,6 +419,10 @@ public class BackgroundService extends Service {
     /**
      * Restore forwarded ports from SharedPreferences (without actually connecting).
      * The actual SSH connection and port forward setup happens when restoreAndReconnect() is called.
+     *
+     * Supports formats:
+     * - New: "localPort:targetPort:host" or "localPort:targetPort"
+     * - Legacy: "localPort:host" or "localPort" (targetPort assumed == localPort)
      */
     private void restoreForwardedPorts() {
         Set<String> portStrings = getSharedPreferences(PREFS_NAME, MODE_PRIVATE)
@@ -408,18 +430,32 @@ public class BackgroundService extends Service {
         if (portStrings != null && !portStrings.isEmpty()) {
             for (String ps : portStrings) {
                 try {
-                    String host = "";
-                    int port;
-                    int colonIdx = ps.indexOf(':');
-                    if (colonIdx >= 0) {
-                        // "port:host" format
-                        port = Integer.parseInt(ps.substring(0, colonIdx));
-                        host = ps.substring(colonIdx + 1);
+                    String[] parts = ps.split(":", 3);
+                    int localPort = Integer.parseInt(parts[0]);
+                    int targetPort;
+                    String host;
+
+                    if (parts.length >= 3) {
+                        // New format: "localPort:targetPort:host"
+                        targetPort = Integer.parseInt(parts[1]);
+                        host = parts[2];
+                    } else if (parts.length == 2) {
+                        // Could be new format "localPort:targetPort" or legacy "localPort:host"
+                        // If the second part is a number, it's "localPort:targetPort"
+                        try {
+                            targetPort = Integer.parseInt(parts[1]);
+                            host = "";
+                        } catch (NumberFormatException e) {
+                            // Legacy format: "localPort:host" — targetPort == localPort
+                            targetPort = localPort;
+                            host = parts[1];
+                        }
                     } else {
-                        // Backward compat: plain port number
-                        port = Integer.parseInt(ps);
+                        // Plain port number — targetPort == localPort
+                        targetPort = localPort;
+                        host = "";
                     }
-                    forwardedPorts.put(port, host);
+                    forwardedPorts.put(localPort, new PortInfo(targetPort, host));
                 } catch (NumberFormatException ignored) {}
             }
             AppLog.i(TAG, "SSH: restored " + forwardedPorts.size() + " forwarded ports from prefs");
@@ -656,16 +692,16 @@ public class BackgroundService extends Service {
 
         // Re-establish any previously forwarded ports
         int reEstablished = 0;
-        for (Map.Entry<Integer, String> entry : forwardedPorts.entrySet()) {
-            int port = entry.getKey();
-            String host = entry.getValue();
-            String targetHost = host.isEmpty() ? "127.0.0.1" : host;
+        for (Map.Entry<Integer, PortInfo> entry : forwardedPorts.entrySet()) {
+            int localPort = entry.getKey();
+            PortInfo info = entry.getValue();
+            String targetHost = info.host.isEmpty() ? "127.0.0.1" : info.host;
             try {
-                sshSession.setPortForwardingL("127.0.0.1", port, targetHost, port);
+                sshSession.setPortForwardingL("127.0.0.1", localPort, targetHost, info.targetPort);
                 reEstablished++;
-                AppLog.i(TAG, "SSH: re-established port forward " + port + " -> " + targetHost + ":" + port);
+                AppLog.i(TAG, "SSH: re-established port forward " + localPort + " -> " + targetHost + ":" + info.targetPort);
             } catch (Exception e) {
-                AppLog.e(TAG, "SSH: failed to re-establish port forward " + port, e);
+                AppLog.e(TAG, "SSH: failed to re-establish port forward " + localPort, e);
             }
         }
         AppLog.i(TAG, "SSH: re-established " + reEstablished + "/" + forwardedPorts.size() + " port forwards");
@@ -688,19 +724,19 @@ public class BackgroundService extends Service {
      *
      * MUST be called from a background thread (network I/O).
      */
-    private synchronized void addPortForward(int port, String host) {
-        boolean alreadyInSet = forwardedPorts.containsKey(port);
+    private synchronized void addPortForward(int localPort, int targetPort, String host) {
+        boolean alreadyInSet = forwardedPorts.containsKey(localPort);
         boolean sessionAlive = sshSession != null && sshSession.isConnected();
 
         if (alreadyInSet && sessionAlive) {
             // Port is tracked and SSH session is alive — nothing to do.
-            AppLog.d(TAG, "SSH: port " + port + " already forwarded and session active");
+            AppLog.d(TAG, "SSH: port " + localPort + " already forwarded and session active");
             return;
         }
 
         // Port is in the set but session is dead — need to reconnect.
         if (alreadyInSet && !sessionAlive) {
-            AppLog.i(TAG, "SSH: port " + port + " in set but session disconnected, reconnecting...");
+            AppLog.i(TAG, "SSH: port " + localPort + " in set but session disconnected, reconnecting...");
         }
 
         String targetHost = (host == null || host.isEmpty()) ? "127.0.0.1" : host;
@@ -710,29 +746,29 @@ public class BackgroundService extends Service {
             // ensureConnection() rebuilds ALL ports in forwardedPorts when it reconnects.
             // For new ports (not in set yet), we need to explicitly set up forwarding.
             if (!alreadyInSet) {
-                sshSession.setPortForwardingL("127.0.0.1", port, targetHost, port);
-                forwardedPorts.put(port, host != null ? host : "");
+                sshSession.setPortForwardingL("127.0.0.1", localPort, targetHost, targetPort);
+                forwardedPorts.put(localPort, new PortInfo(targetPort, host));
                 saveForwardedPorts();
             }
-            AppLog.i(TAG, "SSH: port forward ready: localhost:" + port + " → " + targetHost + ":" + port);
+            AppLog.i(TAG, "SSH: port forward ready: localhost:" + localPort + " → " + targetHost + ":" + targetPort);
             updateNotification(forwardedPorts.size(), null);
         } catch (Exception e) {
             lastError = e.getMessage();
-            AppLog.e(TAG, "SSH: failed to add port forward for " + port + ", retrying...", e);
+            AppLog.e(TAG, "SSH: failed to add port forward for " + localPort + ", retrying...", e);
             // Disconnect and retry once (password may have been updated, or session stale)
             disconnectInternal();
             try {
                 ensureConnection();
                 if (!alreadyInSet) {
-                    sshSession.setPortForwardingL("127.0.0.1", port, targetHost, port);
-                    forwardedPorts.put(port, host != null ? host : "");
+                    sshSession.setPortForwardingL("127.0.0.1", localPort, targetHost, targetPort);
+                    forwardedPorts.put(localPort, new PortInfo(targetPort, host));
                     saveForwardedPorts();
                 }
-                AppLog.i(TAG, "SSH: port forward added on retry: localhost:" + port + " → " + targetHost + ":" + port);
+                AppLog.i(TAG, "SSH: port forward added on retry: localhost:" + localPort + " → " + targetHost + ":" + targetPort);
                 updateNotification(forwardedPorts.size(), null);
             } catch (Exception e2) {
                 lastError = e2.getMessage();
-                AppLog.e(TAG, "SSH: failed to add port forward for " + port + " on retry", e2);
+                AppLog.e(TAG, "SSH: failed to add port forward for " + localPort + " on retry", e2);
             }
         }
     }
@@ -987,11 +1023,15 @@ public class BackgroundService extends Service {
 
     /**
      * Add a port forward via the service.
+     * @param localPort the local port to listen on (may differ from targetPort)
+     * @param targetPort the remote port to forward to on the target host
+     * @param host the target host (empty = 127.0.0.1)
      */
-    public static void addForwardedPort(Context context, int port, String host) {
+    public static void addForwardedPort(Context context, int localPort, int targetPort, String host) {
         Intent intent = new Intent(context, BackgroundService.class);
         intent.setAction("ADD_PORT");
-        intent.putExtra("port", port);
+        intent.putExtra("localPort", localPort);
+        intent.putExtra("targetPort", targetPort);
         intent.putExtra("host", host != null ? host : "");
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
             context.startForegroundService(intent);

--- a/android/app/src/main/java/com/clawbench/app/BrowserActivity.java
+++ b/android/app/src/main/java/com/clawbench/app/BrowserActivity.java
@@ -6,7 +6,6 @@ import android.content.Intent;
 import android.net.Uri;
 import android.net.http.SslError;
 import android.os.Bundle;
-import android.util.Log;
 import android.view.View;
 import android.view.inputmethod.EditorInfo;
 import android.webkit.CookieManager;
@@ -48,6 +47,11 @@ public class BrowserActivity extends AppCompatActivity {
     private EditText urlBar;
     private ProgressBar progressBar;
 
+    private int tunnelRetryCount = 0;
+    private static final int MAX_TUNNEL_RETRIES = 5;
+    private static final long TUNNEL_RETRY_DELAY_MS = 1000;
+    private String pendingUrl = null;
+
     @SuppressLint("SetJavaScriptEnabled")
     @Override
     protected void onCreate(Bundle savedInstanceState) {
@@ -62,10 +66,16 @@ public class BrowserActivity extends AppCompatActivity {
         setupToolbar();
 
         // Load initial URL from Intent
+        // Note: host is stored but NOT used in the URL — all traffic goes through
+        // the SSH tunnel which listens on localhost:localPort on the device.
+        // host only affects the server-side tunnel destination.
         int port = getIntent().getIntExtra("port", 0);
         String protocol = getIntent().getStringExtra("protocol");
+        String host = getIntent().getStringExtra("host");
         if (port > 0 && protocol != null) {
             String initialUrl = protocol + "://localhost:" + port + "/";
+            pendingUrl = initialUrl;
+            AppLog.i(TAG, "BrowserActivity: loading " + initialUrl + " (tunnel target: " + (host != null && !host.isEmpty() ? host : "localhost") + ":" + port + ")");
             webView.loadUrl(initialUrl);
             urlBar.setText(initialUrl);
         }
@@ -310,7 +320,13 @@ public class BrowserActivity extends AppCompatActivity {
         public void onReceivedError(WebView view, WebResourceRequest request, WebResourceError error) {
             super.onReceivedError(view, request, error);
             if (request.isForMainFrame()) {
-                Toast.makeText(BrowserActivity.this, R.string.error_connection_failed, Toast.LENGTH_SHORT).show();
+                if (tunnelRetryCount < MAX_TUNNEL_RETRIES && pendingUrl != null) {
+                    tunnelRetryCount++;
+                    AppLog.i(TAG, "BrowserActivity: page load failed (attempt " + tunnelRetryCount + "/" + MAX_TUNNEL_RETRIES + "), retrying in " + TUNNEL_RETRY_DELAY_MS + "ms");
+                    webView.postDelayed(() -> webView.loadUrl(pendingUrl), TUNNEL_RETRY_DELAY_MS);
+                } else {
+                    Toast.makeText(BrowserActivity.this, R.string.error_connection_failed, Toast.LENGTH_SHORT).show();
+                }
             }
         }
     }

--- a/android/app/src/main/java/com/clawbench/app/BrowserActivity.java
+++ b/android/app/src/main/java/com/clawbench/app/BrowserActivity.java
@@ -13,6 +13,7 @@ import android.webkit.SslErrorHandler;
 import android.webkit.WebChromeClient;
 import android.webkit.WebResourceError;
 import android.webkit.WebResourceRequest;
+import android.webkit.WebResourceResponse;
 import android.webkit.WebSettings;
 import android.webkit.WebStorage;
 import android.webkit.WebView;
@@ -22,6 +23,20 @@ import android.widget.ProgressBar;
 import android.widget.Toast;
 
 import androidx.appcompat.app.AppCompatActivity;
+
+import java.io.InputStream;
+import java.net.HttpURLConnection;
+import java.net.URL;
+import java.security.SecureRandom;
+import java.security.cert.X509Certificate;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import javax.net.ssl.HttpsURLConnection;
+import javax.net.ssl.SSLContext;
+import javax.net.ssl.TrustManager;
+import javax.net.ssl.X509TrustManager;
 
 /**
  * Sandbox browser Activity for testing forwarded ports.
@@ -52,6 +67,12 @@ public class BrowserActivity extends AppCompatActivity {
     private static final long TUNNEL_RETRY_DELAY_MS = 1000;
     private String pendingUrl = null;
 
+    /** Target host:port for Host header rewriting (e.g. "192.168.100.1"). Empty if localhost. */
+    private String targetHost = "";
+
+    /** The local port that the SSH tunnel listens on. */
+    private int localPort = 0;
+
     @SuppressLint("SetJavaScriptEnabled")
     @Override
     protected void onCreate(Bundle savedInstanceState) {
@@ -66,12 +87,27 @@ public class BrowserActivity extends AppCompatActivity {
         setupToolbar();
 
         // Load initial URL from Intent
-        // Note: host is stored but NOT used in the URL — all traffic goes through
-        // the SSH tunnel which listens on localhost:localPort on the device.
-        // host only affects the server-side tunnel destination.
         int port = getIntent().getIntExtra("port", 0);
         String protocol = getIntent().getStringExtra("protocol");
         String host = getIntent().getStringExtra("host");
+        localPort = port;
+        // Build targetHost for Host header rewriting: strip default ports per HTTP spec
+        if (host != null && !host.isEmpty()) {
+            // Strip default port from host:port for Host header
+            String hostPart = host;
+            if (host.contains(":")) {
+                String[] parts = host.split(":", 2);
+                try {
+                    int targetPort = Integer.parseInt(parts[1]);
+                    boolean isDefault = ("http".equals(protocol) && targetPort == 80) ||
+                            ("https".equals(protocol) && targetPort == 443);
+                    hostPart = isDefault ? parts[0] : host;
+                } catch (NumberFormatException e) {
+                    hostPart = host;
+                }
+            }
+            targetHost = hostPart;
+        }
         if (port > 0 && protocol != null) {
             String initialUrl = protocol + "://localhost:" + port + "/";
             pendingUrl = initialUrl;
@@ -270,6 +306,107 @@ public class BrowserActivity extends AppCompatActivity {
     // --- WebView Client ---
 
     private class SandboxWebViewClient extends WebViewClient {
+
+        /**
+         * Intercept requests to localhost:localPort and rewrite the Host header
+         * when forwarding to a non-localhost target (e.g. 192.168.100.1).
+         *
+         * Without this, the browser sends "Host: localhost:port" which the target
+         * server doesn't recognize, causing 404 errors on virtual-host-based servers.
+         *
+         * When targetHost is empty (forwarding to localhost itself), we skip
+         * interception and let WebView handle the request normally via the SSH tunnel.
+         */
+        @Override
+        public WebResourceResponse shouldInterceptRequest(WebView view, WebResourceRequest request) {
+            Uri uri = request.getUrl();
+            String host = uri.getHost();
+
+            // Only intercept localhost requests when we have a target host to rewrite to
+            if (targetHost.isEmpty() || !("localhost".equals(host) || "127.0.0.1".equals(host))) {
+                return super.shouldInterceptRequest(view, request);
+            }
+
+            try {
+                URL url = new URL(uri.toString());
+                HttpURLConnection conn = (HttpURLConnection) url.openConnection();
+
+                // Trust all certs for localhost (SSH tunnel is plaintext, self-signed HTTPS)
+                if (conn instanceof HttpsURLConnection && ("localhost".equals(host) || "127.0.0.1".equals(host))) {
+                    HttpsURLConnection httpsConn = (HttpsURLConnection) conn;
+                    SSLContext sc = SSLContext.getInstance("TLS");
+                    sc.init(null, new TrustManager[]{new X509TrustManager() {
+                        public X509Certificate[] getAcceptedIssuers() { return new X509Certificate[0]; }
+                        public void checkClientTrusted(X509Certificate[] certs, String authType) {}
+                        public void checkServerTrusted(X509Certificate[] certs, String authType) {}
+                    }}, new SecureRandom());
+                    httpsConn.setSSLSocketFactory(sc.getSocketFactory());
+                    httpsConn.setHostnameVerifier((hostname, session) -> true);
+                }
+
+                // Set method
+                String method = request.getMethod();
+                conn.setRequestMethod(method);
+
+                // Rewrite Host header to the target host (default port already stripped)
+                conn.setRequestProperty("Host", targetHost);
+
+                AppLog.i(TAG, "BrowserActivity: intercept " + method + " " + uri + " → Host: " + targetHost);
+
+                // Copy other request headers (except Host which we already set)
+                Map<String, String> reqHeaders = request.getRequestHeaders();
+                for (Map.Entry<String, String> entry : reqHeaders.entrySet()) {
+                    String key = entry.getKey();
+                    if ("Host".equalsIgnoreCase(key)) continue;  // already set
+                    conn.setRequestProperty(key, entry.getValue());
+                }
+
+                // Get response
+                int statusCode = conn.getResponseCode();
+                String reason = conn.getResponseMessage();
+                String contentType = conn.getContentType();
+                String encoding = conn.getContentEncoding();
+
+                AppLog.i(TAG, "BrowserActivity: response " + statusCode + " " + reason + " contentType=" + contentType);
+
+                // Collect response headers
+                Map<String, String> respHeaders = new HashMap<>();
+                for (Map.Entry<String, List<String>> entry : conn.getHeaderFields().entrySet()) {
+                    if (entry.getKey() != null && !entry.getValue().isEmpty()) {
+                        respHeaders.put(entry.getKey(), entry.getValue().get(0));
+                    }
+                }
+
+                InputStream inputStream = conn.getErrorStream();
+                if (inputStream == null) {
+                    inputStream = conn.getInputStream();
+                }
+
+                // Determine MIME type
+                String mime = contentType;
+                if (mime == null || mime.isEmpty()) {
+                    mime = "application/octet-stream";
+                } else {
+                    int semiIdx = mime.indexOf(';');
+                    if (semiIdx > 0) {
+                        mime = mime.substring(0, semiIdx).trim();
+                    }
+                }
+
+                return new WebResourceResponse(
+                        mime,
+                        encoding != null ? encoding : "utf-8",
+                        statusCode,
+                        reason != null ? reason : "OK",
+                        respHeaders,
+                        inputStream
+                );
+
+            } catch (Exception e) {
+                AppLog.w(TAG, "BrowserActivity: shouldInterceptRequest failed for " + uri, e);
+                return super.shouldInterceptRequest(view, request);
+            }
+        }
 
         @Override
         public boolean shouldOverrideUrlLoading(WebView view, WebResourceRequest request) {

--- a/android/app/src/main/java/com/clawbench/app/BrowserActivity.java
+++ b/android/app/src/main/java/com/clawbench/app/BrowserActivity.java
@@ -369,6 +369,20 @@ public class BrowserActivity extends AppCompatActivity {
 
                 AppLog.i(TAG, "BrowserActivity: response " + statusCode + " " + reason + " contentType=" + contentType);
 
+                // Log error response body preview for diagnostics
+                if (statusCode >= 400) {
+                    try {
+                        InputStream errStream = conn.getErrorStream();
+                        if (errStream != null) {
+                            byte[] preview = new byte[Math.min(256, errStream.available() > 0 ? errStream.available() : 256)];
+                            int read = errStream.read(preview);
+                            if (read > 0) {
+                                AppLog.w(TAG, "BrowserActivity: error response body: " + new String(preview, 0, read, "UTF-8"));
+                            }
+                        }
+                    } catch (Exception ignored) {}
+                }
+
                 // Collect response headers
                 Map<String, String> respHeaders = new HashMap<>();
                 for (Map.Entry<String, List<String>> entry : conn.getHeaderFields().entrySet()) {

--- a/android/app/src/main/java/com/clawbench/app/MainActivity.java
+++ b/android/app/src/main/java/com/clawbench/app/MainActivity.java
@@ -1120,10 +1120,10 @@ public class MainActivity extends AppCompatActivity {
          * Also requests battery optimization exemption on first port forward.
          */
         @JavascriptInterface
-        public void addForwardedPort(int port, String host) {
+        public void addForwardedPort(int localPort, int targetPort, String host) {
             activity.runOnUiThread(() -> {
-                activity.forwardedPorts.put(port, host != null ? host : "");
-                BackgroundService.addForwardedPort(activity, port, host != null ? host : "");
+                activity.forwardedPorts.put(localPort, host != null ? host : "");
+                BackgroundService.addForwardedPort(activity, localPort, targetPort, host != null ? host : "");
 
                 // Request battery optimization exemption if not already granted.
                 // Re-check every time in case the user previously dismissed the dialog.

--- a/android/app/src/main/java/com/clawbench/app/MainActivity.java
+++ b/android/app/src/main/java/com/clawbench/app/MainActivity.java
@@ -17,7 +17,6 @@ import android.os.Environment;
 import android.os.PowerManager;
 import android.provider.MediaStore;
 import android.provider.Settings;
-import android.util.Log;
 import android.view.KeyEvent;
 import android.view.View;
 import android.view.WindowManager;
@@ -863,12 +862,12 @@ public class MainActivity extends AppCompatActivity {
     private void fetchPushConfig() {
         String serverUrl = prefs.getString(KEY_SERVER_URL, "");
         if (serverUrl.isEmpty()) {
-            Log.w(TAG, "No server URL configured, skipping push config fetch");
+            AppLog.w(TAG, "No server URL configured, skipping push config fetch");
             return;
         }
 
         if (jpushInitStarted) {
-            Log.i(TAG, "JPush init already started, skipping duplicate fetchPushConfig");
+            AppLog.i(TAG, "JPush init already started, skipping duplicate fetchPushConfig");
             return;
         }
         jpushInitStarted = true;
@@ -898,7 +897,7 @@ public class MainActivity extends AppCompatActivity {
 
                 int responseCode = conn.getResponseCode();
                 if (responseCode != 200) {
-                    Log.w(TAG, "Push config endpoint returned " + responseCode);
+                    AppLog.w(TAG, "Push config endpoint returned " + responseCode);
                     conn.disconnect();
                     return;
                 }
@@ -923,7 +922,7 @@ public class MainActivity extends AppCompatActivity {
                 // This lets native WS suppress notifications during the init window.
                 if (jpushEnabled && !jpushAppKey.isEmpty()) {
                     jpushEnabledOnServer = true;
-                    Log.i(TAG, "JPush enabled on server, initializing with AppKey: " + jpushAppKey.substring(0, 4) + "...");
+                    AppLog.i(TAG, "JPush enabled on server, initializing with AppKey: " + jpushAppKey.substring(0, 4) + "...");
                     runOnUiThread(() -> {
                         JPushInterface.setDebugMode(false);
                         JPushConfig config = new JPushConfig();
@@ -936,13 +935,13 @@ public class MainActivity extends AppCompatActivity {
                         // the native WS prematurely, even if init fails (e.g. 1005 error).
                         // Instead, pushAvailable is set in JPushReceiver.onRegister() only
                         // after the SDK confirms successful registration.
-                        Log.i(TAG, "JPush init called with server-provided AppKey, awaiting onRegister callback");
+                        AppLog.i(TAG, "JPush init called with server-provided AppKey, awaiting onRegister callback");
                     });
                 } else {
-                    Log.i(TAG, "JPush not configured on server — will keep WebSocket alive in background");
+                    AppLog.i(TAG, "JPush not configured on server — will keep WebSocket alive in background");
                 }
             } catch (Exception e) {
-                Log.w(TAG, "Failed to fetch push config: " + e.getMessage());
+                AppLog.w(TAG, "Failed to fetch push config: " + e.getMessage());
             }
         }).start();
     }

--- a/android/app/src/main/java/com/clawbench/app/MainActivity.java
+++ b/android/app/src/main/java/com/clawbench/app/MainActivity.java
@@ -1264,8 +1264,8 @@ public class MainActivity extends AppCompatActivity {
             AppLog.i(TAG, "openInBrowser: port=" + port + ", protocol=" + protocol + ", host=" + host);
             activity.runOnUiThread(() -> {
                 String scheme = "https".equalsIgnoreCase(protocol) ? "https" : "http";
-                String targetHost = (host != null && !host.isEmpty()) ? host : "localhost";
-                String url = scheme + "://" + targetHost + ":" + port;
+                // External browser accesses the SSH tunnel on localhost, not the original host
+                String url = scheme + "://localhost:" + port;
                 Intent intent = new Intent(Intent.ACTION_VIEW, Uri.parse(url));
                 intent.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK);
                 activity.startActivity(intent);

--- a/android/app/src/main/java/com/clawbench/app/MainActivity.java
+++ b/android/app/src/main/java/com/clawbench/app/MainActivity.java
@@ -1120,6 +1120,7 @@ public class MainActivity extends AppCompatActivity {
          */
         @JavascriptInterface
         public void addForwardedPort(int localPort, int targetPort, String host) {
+            AppLog.i(TAG, "addForwardedPort: localPort=" + localPort + ", targetPort=" + targetPort + ", host=" + host);
             activity.runOnUiThread(() -> {
                 activity.forwardedPorts.put(localPort, host != null ? host : "");
                 BackgroundService.addForwardedPort(activity, localPort, targetPort, host != null ? host : "");
@@ -1260,6 +1261,7 @@ public class MainActivity extends AppCompatActivity {
          */
         @JavascriptInterface
         public void openInBrowser(int port, String protocol, String host) {
+            AppLog.i(TAG, "openInBrowser: port=" + port + ", protocol=" + protocol + ", host=" + host);
             activity.runOnUiThread(() -> {
                 String scheme = "https".equalsIgnoreCase(protocol) ? "https" : "http";
                 String targetHost = (host != null && !host.isEmpty()) ? host : "localhost";
@@ -1277,6 +1279,7 @@ public class MainActivity extends AppCompatActivity {
          */
         @JavascriptInterface
         public void openInSandbox(int port, String protocol, String host) {
+            AppLog.i(TAG, "openInSandbox: port=" + port + ", protocol=" + protocol + ", host=" + host);
             activity.runOnUiThread(() -> {
                 String scheme = "https".equalsIgnoreCase(protocol) ? "https" : "http";
                 Intent intent = new Intent(activity, BrowserActivity.class);

--- a/android/app/src/test/java/com/clawbench/app/BackgroundServicePortHostTest.java
+++ b/android/app/src/test/java/com/clawbench/app/BackgroundServicePortHostTest.java
@@ -7,7 +7,6 @@ import android.content.SharedPreferences;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
-import org.mockito.ArgumentCaptor;
 
 import java.lang.reflect.Field;
 import java.lang.reflect.Method;
@@ -23,11 +22,11 @@ import static org.mockito.Mockito.*;
 /**
  * Unit tests for BackgroundService's port-host serialization changes.
  *
- * Tests the new Map<Integer, String> forwardedPorts (port -> host) behavior:
- * - saveForwardedPorts() saves as "port" or "port:host" format
- * - restoreForwardedPorts() parses both formats
+ * Tests the new Map<Integer, PortInfo> forwardedPorts (localPort -> PortInfo) behavior:
+ * - saveForwardedPorts() saves as "localPort:targetPort" or "localPort:targetPort:host" format
+ * - restoreForwardedPorts() parses both new and legacy formats
  * - removePortForward() checks the map (not a set)
- * - static addForwardedPort(Context, int, String) includes host in intent extras
+ * - static addForwardedPort(Context, int, int, String) includes host in intent extras
  *
  * Uses Unsafe.allocateInstance() + Mockito spy to create a BackgroundService
  * with mocked SharedPreferences support.
@@ -54,7 +53,7 @@ public class BackgroundServicePortHostTest {
         // Initialize forwardedPorts (Unsafe allocation skips field initializers)
         Field fpField = BackgroundService.class.getDeclaredField("forwardedPorts");
         fpField.setAccessible(true);
-        fpField.set(service, new ConcurrentHashMap<Integer, String>());
+        fpField.set(service, new ConcurrentHashMap<Integer, BackgroundService.PortInfo>());
 
         // Set static fields for consistent test state
         setStaticField("instance", service);
@@ -101,46 +100,45 @@ public class BackgroundServicePortHostTest {
     // =====================================================
 
     @Test
-    public void testSaveForwardedPorts_portOnly_savesAsPlainNumber() throws Exception {
+    public void testSaveForwardedPorts_noHost_savesAsLocalPortTargetPort() throws Exception {
         @SuppressWarnings("unchecked")
-        Map<Integer, String> ports = (Map<Integer, String>) getField(service, "forwardedPorts");
-        ports.put(20000, "");
+        Map<Integer, BackgroundService.PortInfo> ports = (Map<Integer, BackgroundService.PortInfo>) getField(service, "forwardedPorts");
+        ports.put(20000, new BackgroundService.PortInfo(20000, ""));
 
         // Call the real saveForwardedPorts method
         invokeMethod(service, "saveForwardedPorts");
 
         Set<String> saved = prefsData.get("forwarded_ports");
         assertNotNull("SharedPreferences should have forwarded_ports", saved);
-        assertTrue("Should contain plain port number '20000'", saved.contains("20000"));
-        assertFalse("Should NOT contain '20000:'", saved.toString().contains("20000:"));
+        assertTrue("Should contain '20000:20000'", saved.contains("20000:20000"));
     }
 
     @Test
-    public void testSaveForwardedPorts_portWithHost_savesAsPortHostFormat() throws Exception {
+    public void testSaveForwardedPorts_portWithHost_savesAsLocalPortTargetPortHost() throws Exception {
         @SuppressWarnings("unchecked")
-        Map<Integer, String> ports = (Map<Integer, String>) getField(service, "forwardedPorts");
-        ports.put(20000, "192.168.1.5");
+        Map<Integer, BackgroundService.PortInfo> ports = (Map<Integer, BackgroundService.PortInfo>) getField(service, "forwardedPorts");
+        ports.put(20000, new BackgroundService.PortInfo(80, "192.168.1.5"));
 
         invokeMethod(service, "saveForwardedPorts");
 
         Set<String> saved = prefsData.get("forwarded_ports");
         assertNotNull(saved);
-        assertTrue("Should contain '20000:192.168.1.5'", saved.contains("20000:192.168.1.5"));
+        assertTrue("Should contain '20000:80:192.168.1.5'", saved.contains("20000:80:192.168.1.5"));
     }
 
     @Test
     public void testSaveForwardedPorts_mixedPorts_savesCorrectFormats() throws Exception {
         @SuppressWarnings("unchecked")
-        Map<Integer, String> ports = (Map<Integer, String>) getField(service, "forwardedPorts");
-        ports.put(20000, "");
-        ports.put(30000, "10.0.0.1");
+        Map<Integer, BackgroundService.PortInfo> ports = (Map<Integer, BackgroundService.PortInfo>) getField(service, "forwardedPorts");
+        ports.put(20000, new BackgroundService.PortInfo(20000, ""));
+        ports.put(3080, new BackgroundService.PortInfo(80, "10.0.0.1"));
 
         invokeMethod(service, "saveForwardedPorts");
 
         Set<String> saved = prefsData.get("forwarded_ports");
         assertNotNull(saved);
-        assertTrue("Should contain plain port number '20000'", saved.contains("20000"));
-        assertTrue("Should contain '30000:10.0.0.1'", saved.contains("30000:10.0.0.1"));
+        assertTrue("Should contain '20000:20000'", saved.contains("20000:20000"));
+        assertTrue("Should contain '3080:80:10.0.0.1'", saved.contains("3080:80:10.0.0.1"));
     }
 
     // =====================================================
@@ -148,24 +146,26 @@ public class BackgroundServicePortHostTest {
     // =====================================================
 
     @Test
-    public void testRestoreForwardedPorts_plainNumber_restoresWithEmptyHost() throws Exception {
-        // Set up SharedPreferences with plain port number
+    public void testRestoreForwardedPorts_legacyPlainNumber_restoresWithSameTargetPort() throws Exception {
+        // Legacy format: plain port number "20000" — targetPort assumed == localPort
         Set<String> portStrings = new HashSet<>();
         portStrings.add("20000");
         prefsData.put("forwarded_ports", portStrings);
 
-        // Call the real restoreForwardedPorts method
         invokeMethod(service, "restoreForwardedPorts");
 
         @SuppressWarnings("unchecked")
-        Map<Integer, String> ports = (Map<Integer, String>) getField(service, "forwardedPorts");
+        Map<Integer, BackgroundService.PortInfo> ports = (Map<Integer, BackgroundService.PortInfo>) getField(service, "forwardedPorts");
         assertEquals(1, ports.size());
         assertTrue("Should contain port 20000", ports.containsKey(20000));
-        assertEquals("Host should be empty string", "", ports.get(20000));
+        BackgroundService.PortInfo info = ports.get(20000);
+        assertEquals("Target port should equal local port", 20000, info.targetPort);
+        assertEquals("Host should be empty string", "", info.host);
     }
 
     @Test
-    public void testRestoreForwardedPorts_portHostFormat_restoresWithHost() throws Exception {
+    public void testRestoreForwardedPorts_legacyPortHostFormat_restoresWithHost() throws Exception {
+        // Legacy format: "20000:192.168.1.5" — targetPort assumed == localPort
         Set<String> portStrings = new HashSet<>();
         portStrings.add("20000:192.168.1.5");
         prefsData.put("forwarded_ports", portStrings);
@@ -173,26 +173,51 @@ public class BackgroundServicePortHostTest {
         invokeMethod(service, "restoreForwardedPorts");
 
         @SuppressWarnings("unchecked")
-        Map<Integer, String> ports = (Map<Integer, String>) getField(service, "forwardedPorts");
+        Map<Integer, BackgroundService.PortInfo> ports = (Map<Integer, BackgroundService.PortInfo>) getField(service, "forwardedPorts");
         assertEquals(1, ports.size());
         assertTrue("Should contain port 20000", ports.containsKey(20000));
-        assertEquals("192.168.1.5", ports.get(20000));
+        BackgroundService.PortInfo info = ports.get(20000);
+        assertEquals("Target port should equal local port (legacy)", 20000, info.targetPort);
+        assertEquals("192.168.1.5", info.host);
     }
 
     @Test
-    public void testRestoreForwardedPorts_mixedFormats_restoresAll() throws Exception {
+    public void testRestoreForwardedPorts_newFormat_restoresWithTargetPort() throws Exception {
+        // New format: "3080:80:192.168.1.5"
         Set<String> portStrings = new HashSet<>();
-        portStrings.add("20000");
-        portStrings.add("30000:10.0.0.1");
+        portStrings.add("3080:80:192.168.1.5");
         prefsData.put("forwarded_ports", portStrings);
 
         invokeMethod(service, "restoreForwardedPorts");
 
         @SuppressWarnings("unchecked")
-        Map<Integer, String> ports = (Map<Integer, String>) getField(service, "forwardedPorts");
-        assertEquals(2, ports.size());
-        assertEquals("", ports.get(20000));
-        assertEquals("10.0.0.1", ports.get(30000));
+        Map<Integer, BackgroundService.PortInfo> ports = (Map<Integer, BackgroundService.PortInfo>) getField(service, "forwardedPorts");
+        assertEquals(1, ports.size());
+        assertTrue("Should contain local port 3080", ports.containsKey(3080));
+        BackgroundService.PortInfo info = ports.get(3080);
+        assertEquals("Target port should be 80", 80, info.targetPort);
+        assertEquals("192.168.1.5", info.host);
+    }
+
+    @Test
+    public void testRestoreForwardedPorts_mixedFormats_restoresAll() throws Exception {
+        Set<String> portStrings = new HashSet<>();
+        portStrings.add("20000");               // Legacy: plain number
+        portStrings.add("30000:10.0.0.1");      // Legacy: port:host
+        portStrings.add("4080:80:192.168.1.5"); // New: localPort:targetPort:host
+        prefsData.put("forwarded_ports", portStrings);
+
+        invokeMethod(service, "restoreForwardedPorts");
+
+        @SuppressWarnings("unchecked")
+        Map<Integer, BackgroundService.PortInfo> ports = (Map<Integer, BackgroundService.PortInfo>) getField(service, "forwardedPorts");
+        assertEquals(3, ports.size());
+        assertEquals(20000, ports.get(20000).targetPort);
+        assertEquals("", ports.get(20000).host);
+        assertEquals(30000, ports.get(30000).targetPort);
+        assertEquals("10.0.0.1", ports.get(30000).host);
+        assertEquals(80, ports.get(4080).targetPort);
+        assertEquals("192.168.1.5", ports.get(4080).host);
     }
 
     @Test
@@ -202,7 +227,7 @@ public class BackgroundServicePortHostTest {
         invokeMethod(service, "restoreForwardedPorts");
 
         @SuppressWarnings("unchecked")
-        Map<Integer, String> ports = (Map<Integer, String>) getField(service, "forwardedPorts");
+        Map<Integer, BackgroundService.PortInfo> ports = (Map<Integer, BackgroundService.PortInfo>) getField(service, "forwardedPorts");
         assertTrue("No ports should be restored from empty set", ports.isEmpty());
     }
 
@@ -214,7 +239,7 @@ public class BackgroundServicePortHostTest {
         invokeMethod(service, "restoreForwardedPorts");
 
         @SuppressWarnings("unchecked")
-        Map<Integer, String> ports = (Map<Integer, String>) getField(service, "forwardedPorts");
+        Map<Integer, BackgroundService.PortInfo> ports = (Map<Integer, BackgroundService.PortInfo>) getField(service, "forwardedPorts");
         assertTrue("No ports should be restored when prefs has null set", ports.isEmpty());
     }
 
@@ -225,9 +250,9 @@ public class BackgroundServicePortHostTest {
     @Test
     public void testRemovePortForward_containsKey_checksMap() throws Exception {
         @SuppressWarnings("unchecked")
-        Map<Integer, String> ports = (Map<Integer, String>) getField(service, "forwardedPorts");
-        ports.put(20000, "192.168.1.5");
-        ports.put(30000, "10.0.0.1");
+        Map<Integer, BackgroundService.PortInfo> ports = (Map<Integer, BackgroundService.PortInfo>) getField(service, "forwardedPorts");
+        ports.put(20000, new BackgroundService.PortInfo(20000, "192.168.1.5"));
+        ports.put(30000, new BackgroundService.PortInfo(30000, "10.0.0.1"));
 
         // Call the real removePortForward method
         invokeMethod(service, "removePortForward", 20000);
@@ -239,8 +264,8 @@ public class BackgroundServicePortHostTest {
     @Test
     public void testRemovePortForward_notInMap_returnsEarly() throws Exception {
         @SuppressWarnings("unchecked")
-        Map<Integer, String> ports = (Map<Integer, String>) getField(service, "forwardedPorts");
-        ports.put(20000, "192.168.1.5");
+        Map<Integer, BackgroundService.PortInfo> ports = (Map<Integer, BackgroundService.PortInfo>) getField(service, "forwardedPorts");
+        ports.put(20000, new BackgroundService.PortInfo(20000, "192.168.1.5"));
 
         // Remove a port that doesn't exist — should return early without error
         invokeMethod(service, "removePortForward", 99999);
@@ -249,9 +274,6 @@ public class BackgroundServicePortHostTest {
         assertEquals(1, ports.size());
         assertTrue("Port 20000 should still exist", ports.containsKey(20000));
     }
-
-    // =====================================================
-    // addPortForward tests — calls the REAL method with mocked SSH
 
     // =====================================================
     // addPortForward tests — calls the REAL method with mocked SSH
@@ -270,10 +292,10 @@ public class BackgroundServicePortHostTest {
         sshField.setAccessible(true);
         sshField.set(service, mockSession);
 
-        // Call the real addPortForward(int, String) method
+        // Call the real addPortForward(int, int, String) method
         // ensureConnection() will be called but since sshSession is connected it won't try to reconnect
         try {
-            invokeMethod(service, "addPortForward", 20000, "10.0.0.1");
+            invokeMethod(service, "addPortForward", 3080, 80, "10.0.0.1");
         } catch (java.lang.reflect.InvocationTargetException e) {
             // updateNotification/saveForwardedPorts may throw due to Android framework stubs
             if (!(e.getCause() instanceof NullPointerException)) {
@@ -282,9 +304,10 @@ public class BackgroundServicePortHostTest {
         }
 
         @SuppressWarnings("unchecked")
-        Map<Integer, String> ports = (Map<Integer, String>) getField(service, "forwardedPorts");
-        assertTrue("Port 20000 should be in map", ports.containsKey(20000));
-        assertEquals("10.0.0.1", ports.get(20000));
+        Map<Integer, BackgroundService.PortInfo> ports = (Map<Integer, BackgroundService.PortInfo>) getField(service, "forwardedPorts");
+        assertTrue("Port 3080 should be in map", ports.containsKey(3080));
+        assertEquals(80, ports.get(3080).targetPort);
+        assertEquals("10.0.0.1", ports.get(3080).host);
     }
 
     @Test
@@ -315,11 +338,11 @@ public class BackgroundServicePortHostTest {
 
         // Pre-add the port
         @SuppressWarnings("unchecked")
-        Map<Integer, String> ports = (Map<Integer, String>) getField(service, "forwardedPorts");
-        ports.put(20000, "10.0.0.1");
+        Map<Integer, BackgroundService.PortInfo> ports = (Map<Integer, BackgroundService.PortInfo>) getField(service, "forwardedPorts");
+        ports.put(20000, new BackgroundService.PortInfo(20000, "10.0.0.1"));
 
         // Call addPortForward — should return early since already in set and session alive
-        invokeMethod(service, "addPortForward", 20000, "10.0.0.1");
+        invokeMethod(service, "addPortForward", 20000, 20000, "10.0.0.1");
 
         // Verify setPortForwardingL was NOT called (already forwarded)
         verify(mockSession, never()).setPortForwardingL(anyString(), anyInt(), anyString(), anyInt());
@@ -340,8 +363,8 @@ public class BackgroundServicePortHostTest {
         sshField.set(service, mockSession);
 
         @SuppressWarnings("unchecked")
-        Map<Integer, String> ports = (Map<Integer, String>) getField(service, "forwardedPorts");
-        ports.put(20000, "10.0.0.1");
+        Map<Integer, BackgroundService.PortInfo> ports = (Map<Integer, BackgroundService.PortInfo>) getField(service, "forwardedPorts");
+        ports.put(20000, new BackgroundService.PortInfo(20000, "10.0.0.1"));
 
         invokeMethod(service, "removePortForward", 20000);
 
@@ -365,9 +388,9 @@ public class BackgroundServicePortHostTest {
         sshField.set(service, mockSession);
 
         @SuppressWarnings("unchecked")
-        Map<Integer, String> ports = (Map<Integer, String>) getField(service, "forwardedPorts");
-        ports.put(20000, "");
-        ports.put(30000, "10.0.0.1");
+        Map<Integer, BackgroundService.PortInfo> ports = (Map<Integer, BackgroundService.PortInfo>) getField(service, "forwardedPorts");
+        ports.put(20000, new BackgroundService.PortInfo(20000, ""));
+        ports.put(30000, new BackgroundService.PortInfo(30000, "10.0.0.1"));
 
         invokeMethod(service, "disconnectInternal");
 
@@ -377,7 +400,7 @@ public class BackgroundServicePortHostTest {
     }
 
     // =====================================================
-    // Static addForwardedPort(Context, int, String) tests
+    // Static addForwardedPort(Context, int, int, String) tests
     // =====================================================
 
     @Test
@@ -387,7 +410,7 @@ public class BackgroundServicePortHostTest {
         Context mockContext = mock(Context.class);
         doReturn(null).when(mockContext).startService(any(Intent.class));
 
-        BackgroundService.addForwardedPort(mockContext, 20000, "10.0.0.1");
+        BackgroundService.addForwardedPort(mockContext, 3080, 80, "10.0.0.1");
 
         verify(mockContext).startService(any(Intent.class));
     }
@@ -397,7 +420,7 @@ public class BackgroundServicePortHostTest {
         Context mockContext = mock(Context.class);
         doReturn(null).when(mockContext).startService(any(Intent.class));
 
-        BackgroundService.addForwardedPort(mockContext, 20000, null);
+        BackgroundService.addForwardedPort(mockContext, 20000, 20000, null);
 
         verify(mockContext).startService(any(Intent.class));
     }
@@ -435,6 +458,17 @@ public class BackgroundServicePortHostTest {
         assertEquals("forwardedPorts should be Map type", Map.class, field.getType());
     }
 
+    @Test
+    public void testPortInfo_storesTargetPortAndHost() throws Exception {
+        BackgroundService.PortInfo info1 = new BackgroundService.PortInfo(80, "192.168.1.5");
+        assertEquals(80, info1.targetPort);
+        assertEquals("192.168.1.5", info1.host);
+
+        BackgroundService.PortInfo info2 = new BackgroundService.PortInfo(3306, null);
+        assertEquals(3306, info2.targetPort);
+        assertEquals("Null host should default to empty string", "", info2.host);
+    }
+
     // =====================================================
     // Round-trip test: save then restore
     // =====================================================
@@ -442,9 +476,9 @@ public class BackgroundServicePortHostTest {
     @Test
     public void testRoundTrip_saveAndRestore() throws Exception {
         @SuppressWarnings("unchecked")
-        Map<Integer, String> ports = (Map<Integer, String>) getField(service, "forwardedPorts");
-        ports.put(20000, "");
-        ports.put(30000, "192.168.1.5");
+        Map<Integer, BackgroundService.PortInfo> ports = (Map<Integer, BackgroundService.PortInfo>) getField(service, "forwardedPorts");
+        ports.put(20000, new BackgroundService.PortInfo(20000, ""));
+        ports.put(3080, new BackgroundService.PortInfo(80, "192.168.1.5"));
 
         // Save
         invokeMethod(service, "saveForwardedPorts");
@@ -458,8 +492,10 @@ public class BackgroundServicePortHostTest {
 
         // Verify restored data matches original
         assertEquals(2, ports.size());
-        assertEquals("", ports.get(20000));
-        assertEquals("192.168.1.5", ports.get(30000));
+        assertEquals(20000, ports.get(20000).targetPort);
+        assertEquals("", ports.get(20000).host);
+        assertEquals(80, ports.get(3080).targetPort);
+        assertEquals("192.168.1.5", ports.get(3080).host);
     }
 
     // --- Helper methods ---

--- a/android/app/src/test/java/com/clawbench/app/MainActivityPortHostTest.java
+++ b/android/app/src/test/java/com/clawbench/app/MainActivityPortHostTest.java
@@ -167,6 +167,31 @@ public class MainActivityPortHostTest {
     }
 
     @Test
+    public void testOpenInBrowser_alwaysUsesLocalhost() throws Exception {
+        // Verify the URL construction logic: openInBrowser always uses localhost
+        // regardless of the host parameter, because the external browser accesses
+        // the SSH tunnel which listens on localhost.
+        // Source code: String url = scheme + "://localhost:" + port;
+        int port = 20000;
+        String scheme = "http";
+        String url = scheme + "://localhost:" + port;
+        assertEquals("http://localhost:20000", url);
+
+        // With https
+        String httpsUrl = "https://localhost:" + port;
+        assertEquals("https://localhost:20000", httpsUrl);
+    }
+
+    @Test
+    public void testOpenInBrowser_httpsProtocol() throws Exception {
+        try {
+            bridge.openInBrowser(30000, "https", "10.0.0.1");
+        } catch (Exception e) {
+            // May throw due to Android framework stubs
+        }
+    }
+
+    @Test
     public void testOpenInBrowser_nullHost_defaultsToLocalhost() throws Exception {
         try {
             bridge.openInBrowser(20000, "http", null);

--- a/android/app/src/test/java/com/clawbench/app/MainActivityPortHostTest.java
+++ b/android/app/src/test/java/com/clawbench/app/MainActivityPortHostTest.java
@@ -123,7 +123,7 @@ public class MainActivityPortHostTest {
     public void testAddForwardedPort_putsPortWithHost() throws Exception {
         // The real addForwardedPort will call runOnUiThread which we've stubbed
         // to actually execute the lambda. The lambda puts into forwardedPorts map.
-        bridge.addForwardedPort(20000, "10.0.0.1");
+        bridge.addForwardedPort(20000, 20000, "10.0.0.1");
 
         // After the lambda executes, the port should be in the map
         assertTrue("Should contain port 20000", activity.forwardedPorts.containsKey(20000));
@@ -132,10 +132,20 @@ public class MainActivityPortHostTest {
 
     @Test
     public void testAddForwardedPort_nullHost_putsEmptyString() throws Exception {
-        bridge.addForwardedPort(20000, null);
+        bridge.addForwardedPort(20000, 20000, null);
 
         assertTrue("Should contain port 20000", activity.forwardedPorts.containsKey(20000));
         assertEquals("", activity.forwardedPorts.get(20000));
+    }
+
+    @Test
+    public void testAddForwardedPort_differentTargetPort_forwardsToBackgroundService() throws Exception {
+        // When targetPort != localPort (e.g. privileged port remapping), the bridge
+        // should still pass the correct targetPort to BackgroundService.addForwardedPort
+        bridge.addForwardedPort(3080, 80, "192.168.1.5");
+
+        assertTrue("Should contain local port 3080", activity.forwardedPorts.containsKey(3080));
+        assertEquals("192.168.1.5", activity.forwardedPorts.get(3080));
     }
 
     // =====================================================

--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -603,9 +603,8 @@ func main() {
 	// standalone purpose without the SSH tunnel to transport traffic.
 	if cfg.PortForward.Enabled {
 		proxyService := service.NewProxyRegistry(port)
-		if cfg.PortForward.AllowedPorts != "" {
-			proxyService.SetAllowedPorts(cfg.PortForward.AllowedPorts)
-		}
+		// Always apply config — empty AllowedPorts means "allow all ports"
+		proxyService.SetAllowedPorts(cfg.PortForward.AllowedPorts)
 		service.ProxyService = proxyService
 		defer proxyService.Stop()
 

--- a/config/config.example.yaml
+++ b/config/config.example.yaml
@@ -202,8 +202,8 @@ port_forward:
                             # SSH 端口（0 = 自动 = 主端口+1，如生产环境 20001；也可指定如 20020）
   host_key: ""              # Host key file path (empty = auto-generate ephemeral key; set a path for persistence across restarts)
                             # Host key 文件路径（空 = 自动生成临时密钥，重启后变更；建议指定路径以持久化）
-  allowed_ports: "1024-65535"  # Allowed port range for SSH tunnel forwarding (supports ranges and discrete ports, e.g. "3000,5173,8080")
-                               # 允许通过 SSH 隧道转发的端口范围（支持范围和离散端口，如 "3000,5173,8080"）
+  allowed_ports: ""  # Allowed port range for SSH tunnel forwarding (empty = allow all; supports ranges and discrete ports, e.g. "1024-65535", "80,443,8080")
+                     # 允许通过 SSH 隧道转发的端口范围（空 = 允许所有端口；支持范围和离散端口，如 "1024-65535", "80,443,8080"）
 
 # RAG history memory configuration / RAG 历史记忆配置
 # When enabled, chat messages are automatically indexed into a vector database (DuckDB),

--- a/internal/handler/config/config.yaml
+++ b/internal/handler/config/config.yaml
@@ -34,6 +34,8 @@ rag:
     retention_days: 0
     search_limit: 0
     search_pool_size: 0
+recent_projects:
+    max_count: 25
 session:
     max_count: 20
 summarize:

--- a/internal/handler/proxy_api.go
+++ b/internal/handler/proxy_api.go
@@ -50,12 +50,13 @@ func registerPort(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	if err := service.ProxyService.RegisterPort(req.Port, req.Host, req.Name, req.Protocol); err != nil {
+	localPort, err := service.ProxyService.RegisterPort(req.Port, req.Host, req.Name, req.Protocol)
+	if err != nil {
 		writeLocalizedError(w, r, model.Forbidden(err, "AccessDenied"))
 		return
 	}
 
-	writeJSON(w, http.StatusOK, map[string]string{"status": "ok"})
+	writeJSON(w, http.StatusOK, map[string]any{"status": "ok", "localPort": localPort})
 }
 
 func updatePort(w http.ResponseWriter, r *http.Request) {

--- a/internal/handler/proxy_test.go
+++ b/internal/handler/proxy_test.go
@@ -57,7 +57,7 @@ func TestServeProxyPorts_AfterRegister(t *testing.T) {
 	teardown := setupProxyTest(t)
 	defer teardown()
 
-	_ = service.ProxyService.RegisterPort(8080, "", "test", "")
+	_, _ = service.ProxyService.RegisterPort(8080, "", "test", "")
 
 	req := newRequest(t, http.MethodGet, "/api/proxy/ports", nil)
 	w := callHandler(ServeProxyPortAction, req)
@@ -84,7 +84,28 @@ func TestRegisterPort_Valid(t *testing.T) {
 
 	assertOK(t, w)
 	assertJSONField(t, w, "status", "ok")
+	assertJSONField(t, w, "localPort", float64(5173)) // JSON numbers decode as float64
 	assert.True(t, isProxyPortRegistered(service.ProxyService, 5173))
+}
+
+func TestRegisterPort_ReturnsAutoAssignedLocalPort(t *testing.T) {
+	teardown := setupProxyTest(t)
+	defer teardown()
+
+	// Register port 8080 first
+	_, _ = service.ProxyService.RegisterPort(8080, "", "local-api", "http")
+
+	// Register same target port with different host — localPort should be auto-assigned
+	req := newRequest(t, http.MethodPost, "/api/proxy/ports", map[string]interface{}{
+		"port": 8080,
+		"host": "192.168.1.100",
+		"name": "remote-api",
+	})
+	w := callHandler(ServeProxyPortAction, req)
+
+	assertOK(t, w)
+	assertJSONField(t, w, "status", "ok")
+	assertJSONField(t, w, "localPort", float64(8081)) // auto-assigned next free port
 }
 
 func TestRegisterPort_InvalidPort(t *testing.T) {
@@ -116,7 +137,7 @@ func TestRegisterPort_Duplicate(t *testing.T) {
 	teardown := setupProxyTest(t)
 	defer teardown()
 
-	_ = service.ProxyService.RegisterPort(3000, "", "first", "")
+	_, _ = service.ProxyService.RegisterPort(3000, "", "first", "")
 
 	req := newRequest(t, http.MethodPost, "/api/proxy/ports", map[string]interface{}{
 		"port": 3000,
@@ -149,7 +170,7 @@ func TestUnregisterPort_Valid(t *testing.T) {
 	teardown := setupProxyTest(t)
 	defer teardown()
 
-	_ = service.ProxyService.RegisterPort(9090, "", "metrics", "")
+	_, _ = service.ProxyService.RegisterPort(9090, "", "metrics", "")
 
 	req := httptest.NewRequest(http.MethodDelete, "/api/proxy/ports?port=9090", nil)
 	w := callHandler(ServeProxyPortAction, req)
@@ -242,9 +263,9 @@ func TestRegisterAndListMultiple(t *testing.T) {
 	teardown := setupProxyTest(t)
 	defer teardown()
 
-	_ = service.ProxyService.RegisterPort(3000, "", "app", "")
-	_ = service.ProxyService.RegisterPort(5173, "", "vite", "")
-	_ = service.ProxyService.RegisterPort(8080, "", "api", "")
+	_, _ = service.ProxyService.RegisterPort(3000, "", "app", "")
+	_, _ = service.ProxyService.RegisterPort(5173, "", "vite", "")
+	_, _ = service.ProxyService.RegisterPort(8080, "", "api", "")
 
 	req := newRequest(t, http.MethodGet, "/api/proxy/ports", nil)
 	w := callHandler(ServeProxyPortAction, req)
@@ -327,7 +348,7 @@ func TestUpdatePort_Valid(t *testing.T) {
 	defer teardown()
 
 	// Register a port first
-	_ = service.ProxyService.RegisterPort(8080, "", "api", "http")
+	_, _ = service.ProxyService.RegisterPort(8080, "", "api", "http")
 
 	req := newRequest(t, http.MethodPut, "/api/proxy/ports", map[string]interface{}{
 		"localPort": 8080,
@@ -347,7 +368,7 @@ func TestUpdatePort_WithHost(t *testing.T) {
 	teardown := setupProxyTest(t)
 	defer teardown()
 
-	_ = service.ProxyService.RegisterPort(8080, "", "api", "http")
+	_, _ = service.ProxyService.RegisterPort(8080, "", "api", "http")
 
 	req := newRequest(t, http.MethodPut, "/api/proxy/ports", map[string]interface{}{
 		"localPort": 8080,
@@ -422,7 +443,7 @@ func TestUpdatePort_DisallowedPortRange(t *testing.T) {
 		service.ProxyService = origProxy
 	}()
 
-	_ = service.ProxyService.RegisterPort(3500, "", "app", "")
+	_, _ = service.ProxyService.RegisterPort(3500, "", "app", "")
 
 	req := newRequest(t, http.MethodPut, "/api/proxy/ports", map[string]interface{}{
 		"localPort": 3500,

--- a/internal/handler/ssh_info_test.go
+++ b/internal/handler/ssh_info_test.go
@@ -42,8 +42,8 @@ func TestServeSSHInfo_Enabled(t *testing.T) {
 		service.ProxyService.Stop()
 		service.ProxyService = origProxy
 	}()
-	_ = service.ProxyService.RegisterPort(5173, "", "Vite Dev", "http")
-	_ = service.ProxyService.RegisterPort(8080, "", "API", "http")
+	_, _ = service.ProxyService.RegisterPort(5173, "", "Vite Dev", "http")
+	_, _ = service.ProxyService.RegisterPort(8080, "", "API", "http")
 
 	// Create and set an SSH server reference
 	srv := ssh.NewServer(model.PortForwardConfig{Enabled: true, Port: 20001}, 20000, "test-password", service.ProxyService)

--- a/internal/proxy/reverse_proxy.go
+++ b/internal/proxy/reverse_proxy.go
@@ -1,0 +1,142 @@
+package proxy
+
+import (
+	"crypto/tls"
+	"fmt"
+	"log/slog"
+	"net"
+	"net/http"
+	"net/http/httputil"
+	"net/url"
+	"strings"
+	"sync"
+)
+
+// ReverseProxy is an HTTP reverse proxy that listens on a local address and
+// forwards requests to a target host:port, rewriting the Host header to match
+// the original target. This solves the problem where SSH tunnel (TCP-level)
+// forwarding preserves the browser's "Host: localhost:port" header, which
+// breaks virtual-host backends that expect their own hostname.
+type ReverseProxy struct {
+	listener   net.Listener
+	server     *http.Server
+	proxy      *httputil.ReverseProxy
+	transport  *http.Transport
+	targetAddr string // host:port of the backend
+	targetURL  *url.URL
+	protocol   string // "http" or "https"
+	mu         sync.Mutex
+}
+
+// NewReverseProxy creates a new HTTP reverse proxy.
+// listenHost is typically "127.0.0.1", listenPort 0 means auto-assign.
+// targetAddr is "host:port" of the backend to forward to.
+// protocol is "http" or "https" (for the connection to the backend).
+func NewReverseProxy(listenHost string, listenPort int, targetAddr string, protocol string) (*ReverseProxy, error) {
+	if protocol == "" {
+		protocol = "http"
+	}
+
+	// Build the target URL for httputil.ReverseProxy
+	scheme := protocol
+	host := targetAddr
+	// Strip any existing scheme from targetAddr
+	if strings.Contains(targetAddr, "://") {
+		parsed, err := url.Parse(targetAddr)
+		if err == nil {
+			scheme = parsed.Scheme
+			host = parsed.Host
+		}
+	}
+
+	targetURL, err := url.Parse(scheme + "://" + host)
+	if err != nil {
+		return nil, fmt.Errorf("invalid target address %s: %w", targetAddr, err)
+	}
+
+	rp := &ReverseProxy{
+		targetAddr: host,
+		targetURL:  targetURL,
+		protocol:  protocol,
+	}
+
+	// Create transport with InsecureSkipVerify for self-signed certs on LAN targets
+	rp.transport = &http.Transport{
+		DialContext:       (&net.Dialer{}).DialContext,
+		TLSClientConfig:  &tls.Config{InsecureSkipVerify: true},
+	}
+
+	// Create the httputil.ReverseProxy
+	proxy := httputil.NewSingleHostReverseProxy(targetURL)
+	proxy.Transport = rp.transport
+
+	// Customize the Director to rewrite Host header
+	originalDirector := proxy.Director
+	proxy.Director = func(req *http.Request) {
+		originalDirector(req)
+		// Set Host to the target's host:port (the original backend address)
+		req.Host = host
+		// Ensure the scheme is correct
+		req.URL.Scheme = targetURL.Scheme
+		req.URL.Host = targetURL.Host
+	}
+
+	rp.proxy = proxy
+	rp.server = &http.Server{
+		Handler: proxy,
+	}
+
+	// Start listening
+	addr := fmt.Sprintf("%s:%d", listenHost, listenPort)
+	listener, err := net.Listen("tcp", addr)
+	if err != nil {
+		return nil, fmt.Errorf("failed to listen on %s: %w", addr, err)
+	}
+	rp.listener = listener
+
+	return rp, nil
+}
+
+// Serve starts accepting connections. Blocks until the listener is closed.
+func (rp *ReverseProxy) Serve() {
+	if err := rp.server.Serve(rp.listener); err != nil && err != http.ErrServerClosed {
+		slog.Debug("reverse proxy server stopped", slog.String("err", err.Error()))
+	}
+}
+
+// Addr returns the listener address (e.g., "127.0.0.1:54321").
+// Returns empty string if the proxy is not listening.
+func (rp *ReverseProxy) Addr() string {
+	if rp.listener == nil {
+		return ""
+	}
+	return rp.listener.Addr().String()
+}
+
+// Port returns the listening port number.
+// Returns 0 if the proxy is not listening.
+func (rp *ReverseProxy) Port() int {
+	if rp.listener == nil {
+		return 0
+	}
+	_, portStr, _ := net.SplitHostPort(rp.listener.Addr().String())
+	var port int
+	fmt.Sscanf(portStr, "%d", &port)
+	return port
+}
+
+// Close shuts down the reverse proxy.
+func (rp *ReverseProxy) Close() {
+	if rp.server != nil {
+		rp.server.Close()
+	}
+}
+
+// SetInsecureSkipVerify configures the proxy's transport to skip TLS certificate
+// verification when connecting to the backend. This is useful for self-signed
+// certificates on LAN targets.
+func (rp *ReverseProxy) SetInsecureSkipVerify(skip bool) {
+	if rp.transport != nil && rp.transport.TLSClientConfig != nil {
+		rp.transport.TLSClientConfig.InsecureSkipVerify = skip
+	}
+}

--- a/internal/proxy/reverse_proxy.go
+++ b/internal/proxy/reverse_proxy.go
@@ -74,8 +74,10 @@ func NewReverseProxy(listenHost string, listenPort int, targetAddr string, proto
 	originalDirector := proxy.Director
 	proxy.Director = func(req *http.Request) {
 		originalDirector(req)
-		// Set Host to the target's host:port (the original backend address)
-		req.Host = host
+		// Set Host to the target address, omitting default ports per HTTP spec.
+		// e.g. "192.168.100.1:80" with scheme "http" → "192.168.100.1"
+		// but "192.168.100.1:8080" → "192.168.100.1:8080"
+		req.Host = stripDefaultPort(host, scheme)
 		// Ensure the scheme is correct
 		req.URL.Scheme = targetURL.Scheme
 		req.URL.Host = targetURL.Host
@@ -139,4 +141,20 @@ func (rp *ReverseProxy) SetInsecureSkipVerify(skip bool) {
 	if rp.transport != nil && rp.transport.TLSClientConfig != nil {
 		rp.transport.TLSClientConfig.InsecureSkipVerify = skip
 	}
+}
+
+// stripDefaultPort removes the port from a host:port string if it's the default
+// port for the given scheme (80 for http, 443 for https).
+// e.g. ("192.168.100.1:80", "http") → "192.168.100.1"
+//
+//	("192.168.100.1:8080", "http") → "192.168.100.1:8080"
+func stripDefaultPort(hostPort, scheme string) string {
+	h, port, err := net.SplitHostPort(hostPort)
+	if err != nil {
+		return hostPort // no port, return as-is
+	}
+	if (scheme == "http" && port == "80") || (scheme == "https" && port == "443") {
+		return h
+	}
+	return hostPort
 }

--- a/internal/proxy/reverse_proxy_test.go
+++ b/internal/proxy/reverse_proxy_test.go
@@ -5,6 +5,7 @@ import (
 	"net"
 	"net/http"
 	"net/http/httptest"
+	"net/url"
 	"strings"
 	"testing"
 	"time"
@@ -198,4 +199,52 @@ func TestReverseProxy_ResponseBody(t *testing.T) {
 	body, err := io.ReadAll(resp.Body)
 	assert.NoError(t, err)
 	assert.True(t, strings.Contains(string(body), "hello from backend"), "Response body should contain backend response")
+}
+
+func TestStripDefaultPort(t *testing.T) {
+	tests := []struct {
+		hostPort string
+		scheme   string
+		want     string
+	}{
+		{"192.168.100.1:80", "http", "192.168.100.1"},
+		{"192.168.100.1:443", "https", "192.168.100.1"},
+		{"192.168.100.1:8080", "http", "192.168.100.1:8080"},
+		{"192.168.100.1:8443", "https", "192.168.100.1:8443"},
+		{"example.com:80", "http", "example.com"},
+		{"example.com:443", "https", "example.com"},
+		{"example.com:80", "https", "example.com:80"}, // port 80 with https is NOT default
+		{"example.com:443", "http", "example.com:443"}, // port 443 with http is NOT default
+		{"10.0.0.1", "http", "10.0.0.1"},             // no port at all
+	}
+	for _, tt := range tests {
+		got := stripDefaultPort(tt.hostPort, tt.scheme)
+		assert.Equal(t, tt.want, got, "stripDefaultPort(%q, %q)", tt.hostPort, tt.scheme)
+	}
+}
+
+func TestReverseProxy_StripsDefaultPortFromHost(t *testing.T) {
+	// Backend that records the Host header
+	var receivedHost string
+	backend := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		receivedHost = r.Host
+		w.WriteHeader(http.StatusOK)
+		w.Write([]byte("ok"))
+	}))
+	defer backend.Close()
+
+	backendURL, _ := url.Parse(backend.URL)
+	targetAddr := backendURL.Host // e.g. "127.0.0.1:PORT" — non-default port
+
+	rp, err := NewReverseProxy("127.0.0.1", 0, targetAddr, "http")
+	assert.NoError(t, err)
+	go rp.Serve()
+	defer rp.Close()
+
+	resp, err := http.Get("http://" + rp.Addr() + "/test")
+	assert.NoError(t, err)
+	resp.Body.Close()
+
+	// Non-default port: Host should include port
+	assert.Equal(t, targetAddr, receivedHost, "Host for non-default port should include port")
 }

--- a/internal/proxy/reverse_proxy_test.go
+++ b/internal/proxy/reverse_proxy_test.go
@@ -1,0 +1,201 @@
+package proxy
+
+import (
+	"io"
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestReverseProxy_ForwardsRequest(t *testing.T) {
+	// Setup a backend server that echoes the Host header
+	var receivedHost string
+	backend := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		receivedHost = r.Host
+		w.WriteHeader(http.StatusOK)
+		w.Write([]byte("ok"))
+	}))
+	defer backend.Close()
+
+	// Create reverse proxy pointing to the backend
+	rp, err := NewReverseProxy("127.0.0.1", 0, backend.Listener.Addr().String(), "http")
+	assert.NoError(t, err)
+	defer rp.Close()
+
+	go rp.Serve()
+	addr := rp.Addr()
+	assert.NotEmpty(t, addr)
+
+	// Wait for listener to be ready
+	time.Sleep(50 * time.Millisecond)
+
+	// Send a request through the proxy using a real HTTP client
+	resp, err := http.Get("http://" + addr + "/test")
+	assert.NoError(t, err)
+	defer resp.Body.Close()
+
+	assert.Equal(t, http.StatusOK, resp.StatusCode)
+	// The backend should receive the original target's Host, not "localhost:randomPort"
+	assert.NotContains(t, receivedHost, "localhost", "Host header should not contain localhost")
+}
+
+func TestReverseProxy_SetsCorrectHost(t *testing.T) {
+	// Setup a backend that records the Host header
+	var receivedHost string
+	backend := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		receivedHost = r.Host
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer backend.Close()
+
+	// Target is the backend's address (simulating a LAN target like 192.168.1.100:8080)
+	backendAddr := backend.Listener.Addr().String()
+	rp, err := NewReverseProxy("127.0.0.1", 0, backendAddr, "http")
+	assert.NoError(t, err)
+	defer rp.Close()
+
+	go rp.Serve()
+	addr := rp.Addr()
+	time.Sleep(50 * time.Millisecond)
+
+	resp, err := http.Get("http://" + addr + "/api/data")
+	assert.NoError(t, err)
+	defer resp.Body.Close()
+
+	// Host header should match the backend's address (target host:port)
+	assert.Equal(t, backendAddr, receivedHost, "Host header should be the target address")
+}
+
+func TestReverseProxy_HandlesPort80(t *testing.T) {
+	var receivedHost string
+	backend := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		receivedHost = r.Host
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer backend.Close()
+
+	backendAddr := backend.Listener.Addr().String()
+	rp, err := NewReverseProxy("127.0.0.1", 0, backendAddr, "http")
+	assert.NoError(t, err)
+	defer rp.Close()
+
+	go rp.Serve()
+	addr := rp.Addr()
+	time.Sleep(50 * time.Millisecond)
+
+	resp, err := http.Get("http://" + addr + "/")
+	assert.NoError(t, err)
+	defer resp.Body.Close()
+
+	assert.Equal(t, http.StatusOK, resp.StatusCode)
+	// Host should be the backend address, not the proxy address
+	assert.NotEqual(t, addr, receivedHost, "Host header should not be the proxy's address")
+}
+
+func TestReverseProxy_SupportsHTTPS(t *testing.T) {
+	backend := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer backend.Close()
+
+	backendAddr := backend.Listener.Addr().String()
+	rp, err := NewReverseProxy("127.0.0.1", 0, backendAddr, "https")
+	assert.NoError(t, err)
+	// Configure the proxy's transport to trust the test server's certificate
+	rp.SetInsecureSkipVerify(true)
+	defer rp.Close()
+
+	go rp.Serve()
+	addr := rp.Addr()
+	time.Sleep(50 * time.Millisecond)
+
+	// Connect to proxy via plain HTTP (proxy handles TLS to backend)
+	client := &http.Client{Transport: &http.Transport{}}
+	resp, err := client.Get("http://" + addr + "/")
+	assert.NoError(t, err)
+	defer resp.Body.Close()
+
+	assert.Equal(t, http.StatusOK, resp.StatusCode)
+}
+
+func TestReverseProxy_Port(t *testing.T) {
+	backend := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer backend.Close()
+
+	rp, err := NewReverseProxy("127.0.0.1", 0, backend.Listener.Addr().String(), "http")
+	assert.NoError(t, err)
+	defer rp.Close()
+
+	port := rp.Port()
+	assert.Greater(t, port, 0, "Auto-assigned port should be > 0")
+}
+
+func TestReverseProxy_TargetHostRewrite(t *testing.T) {
+	// The key scenario: forwarding to a LAN IP like 192.168.1.100
+	// The browser sends Host: localhost:localPort, but the backend
+	// should receive Host: 192.168.1.100:targetPort
+	var receivedHost string
+	var receivedPath string
+	backend := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		receivedHost = r.Host
+		receivedPath = r.URL.Path
+		w.WriteHeader(http.StatusOK)
+		w.Write([]byte("response from backend"))
+	}))
+	defer backend.Close()
+
+	// The backend's address simulates a LAN target
+	backendAddr := backend.Listener.Addr().String()
+	// Extract just the port to simulate a scenario where we forward to a named host
+	_, port, _ := net.SplitHostPort(backendAddr)
+
+	// Simulate forwarding to "192.168.1.100:8080" by using a custom target address
+	// We use the actual backend's port but set the target host to the backend's IP
+	targetHost := "127.0.0.1:" + port
+	rp, err := NewReverseProxy("127.0.0.1", 0, targetHost, "http")
+	assert.NoError(t, err)
+	defer rp.Close()
+
+	go rp.Serve()
+	addr := rp.Addr()
+	time.Sleep(50 * time.Millisecond)
+
+	resp, err := http.Get("http://" + addr + "/some/path")
+	assert.NoError(t, err)
+	defer resp.Body.Close()
+
+	assert.Equal(t, http.StatusOK, resp.StatusCode)
+	assert.Equal(t, targetHost, receivedHost, "Host header should be the target address, not localhost")
+	assert.Equal(t, "/some/path", receivedPath, "Path should be forwarded correctly")
+}
+
+func TestReverseProxy_ResponseBody(t *testing.T) {
+	backend := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		w.Write([]byte("hello from backend"))
+	}))
+	defer backend.Close()
+
+	rp, err := NewReverseProxy("127.0.0.1", 0, backend.Listener.Addr().String(), "http")
+	assert.NoError(t, err)
+	defer rp.Close()
+
+	go rp.Serve()
+	addr := rp.Addr()
+	time.Sleep(50 * time.Millisecond)
+
+	resp, err := http.Get("http://" + addr + "/")
+	assert.NoError(t, err)
+	defer resp.Body.Close()
+
+	body, err := io.ReadAll(resp.Body)
+	assert.NoError(t, err)
+	assert.True(t, strings.Contains(string(body), "hello from backend"), "Response body should contain backend response")
+}

--- a/internal/proxy/reverse_proxy_test.go
+++ b/internal/proxy/reverse_proxy_test.go
@@ -248,3 +248,80 @@ func TestReverseProxy_StripsDefaultPortFromHost(t *testing.T) {
 	// Non-default port: Host should include port
 	assert.Equal(t, targetAddr, receivedHost, "Host for non-default port should include port")
 }
+
+func TestReverseProxy_AddAndPort(t *testing.T) {
+	backend := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer backend.Close()
+
+	rp, err := NewReverseProxy("127.0.0.1", 0, backend.Listener.Addr().String(), "http")
+	assert.NoError(t, err)
+	defer rp.Close()
+
+	// Addr and Port should return valid values
+	assert.NotEmpty(t, rp.Addr())
+	assert.Greater(t, rp.Port(), 0)
+}
+
+func TestReverseProxy_AddrNilListener(t *testing.T) {
+	rp := &ReverseProxy{}
+	assert.Equal(t, "", rp.Addr(), "Addr should return empty string when listener is nil")
+	assert.Equal(t, 0, rp.Port(), "Port should return 0 when listener is nil")
+}
+
+func TestReverseProxy_NewReverseProxy_InvalidListenAddr(t *testing.T) {
+	// Using a non-routable address that can't be listened on should fail
+	_, err := NewReverseProxy("256.256.256.256", 80, "127.0.0.1:8080", "http")
+	assert.Error(t, err, "should fail with invalid listen address")
+}
+
+func TestReverseProxy_NewReverseProxy_EmptyProtocol(t *testing.T) {
+	backend := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer backend.Close()
+
+	rp, err := NewReverseProxy("127.0.0.1", 0, backend.Listener.Addr().String(), "")
+	assert.NoError(t, err, "empty protocol should default to http")
+	defer rp.Close()
+}
+
+func TestReverseProxy_NewReverseProxy_TargetWithScheme(t *testing.T) {
+	backend := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer backend.Close()
+
+	// Pass targetAddr with scheme prefix
+	addr := "http://" + backend.Listener.Addr().String()
+	rp, err := NewReverseProxy("127.0.0.1", 0, addr, "http")
+	assert.NoError(t, err)
+	defer rp.Close()
+}
+
+func TestReverseProxy_Serve_ServerClosed(t *testing.T) {
+	backend := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer backend.Close()
+
+	rp, err := NewReverseProxy("127.0.0.1", 0, backend.Listener.Addr().String(), "http")
+	assert.NoError(t, err)
+
+	// Close before Serve — Serve should handle http.ErrServerClosed gracefully
+	rp.Close()
+	// Serve returns when server is closed — this tests the ErrServerClosed path
+	done := make(chan struct{})
+	go func() {
+		rp.Serve()
+		close(done)
+	}()
+
+	select {
+	case <-done:
+		// Serve returned as expected
+	case <-time.After(2 * time.Second):
+		t.Fatal("Serve should return after server is closed")
+	}
+}

--- a/internal/service/proxy.go
+++ b/internal/service/proxy.go
@@ -890,6 +890,17 @@ func (r *ProxyRegistry) loadPortsFromDB() {
 			AutoDetect: false,
 			Active:     false, // will be updated by health check
 		}
+		// For non-localhost targets, start an HTTP reverse proxy to rewrite Host header.
+		if isNonLocalhostTarget(host) {
+			if err := r.startReverseProxy(localPort, port, host, protocol); err != nil {
+				slog.Warn("failed to start reverse proxy on DB load",
+					slog.Int("local_port", localPort),
+					slog.Int("target_port", port),
+					slog.String("host", host),
+					slog.String("err", err.Error()),
+				)
+			}
+		}
 	}
 
 	if len(r.ports) > 0 {

--- a/internal/service/proxy.go
+++ b/internal/service/proxy.go
@@ -34,7 +34,19 @@ type ProxyRegistry struct {
 
 // allocateLocalPort finds an available local port for forwarding.
 // Prefers the requested port; if taken, scans upward until a free one is found.
+// Privileged ports (< 1024) are never returned directly — they are mapped to
+// high ports (1024+) since Android/non-root cannot bind privileged ports.
 func (r *ProxyRegistry) allocateLocalPort(preferred int) int {
+	// Privileged ports must be remapped to non-privileged range
+	if preferred < 1024 {
+		// Start scanning from 1024 for a free port
+		for p := 1024; p <= 65535; p++ {
+			if _, taken := r.ports[p]; !taken {
+				return p
+			}
+		}
+		return 1024 // fallback
+	}
 	if _, taken := r.ports[preferred]; !taken {
 		return preferred
 	}
@@ -305,7 +317,7 @@ func (r *ProxyRegistry) IsPortAllowed(port int) bool {
 // DetectedPort represents an auto-detected listening port with its protocol and process.
 type DetectedPort struct {
 	Port        int    `json:"port"`
-	Protocol    string `json:"protocol"`    // "http" or "https"
+	Protocol    string `json:"protocol"`    // "http", "https", or "other" (non-HTTP like SSH)
 	ProcessName string `json:"processName"` // Name of the process listening on this port
 	ProcessArgs string `json:"processArgs"` // Partial command-line arguments
 }
@@ -347,16 +359,60 @@ func (r *ProxyRegistry) DetectListeningPorts() []DetectedPort {
 		return filtered[i].Port < filtered[j].Port
 	})
 
-	// Probe each port for TLS
+	// Classify each port
 	result := make([]DetectedPort, len(filtered))
 	for i, p := range filtered {
-		protocol := "http"
-		if detectTLS(p.Port) {
-			protocol = "https"
-		}
+		protocol := classifyPort(p.Port, p.ProcessName)
 		result[i] = DetectedPort{Port: p.Port, Protocol: protocol, ProcessName: p.ProcessName, ProcessArgs: p.ProcessArgs}
 	}
 	return result
+}
+
+// classifyPort determines the protocol of a listening port.
+// Known non-HTTP ports (SSH, MySQL, Redis, etc.) are marked as "other"
+// since they cannot be forwarded through an HTTP proxy/browser.
+func classifyPort(port int, processName string) string {
+	// Well-known non-HTTP ports
+	switch port {
+	case 22, 2222: // SSH
+		return "other"
+	case 25, 465, 587: // SMTP
+		return "other"
+	case 3306: // MySQL
+		return "other"
+	case 5432: // PostgreSQL
+		return "other"
+	case 6379: // Redis
+		return "other"
+	case 27017: // MongoDB
+		return "other"
+	case 21: // FTP
+		return "other"
+	}
+
+	// Check process name for known non-HTTP services
+	name := strings.ToLower(processName)
+	if strings.Contains(name, "ssh") || strings.Contains(name, "sshd") {
+		return "other"
+	}
+	if strings.Contains(name, "mysql") || strings.Contains(name, "mysqld") {
+		return "other"
+	}
+	if strings.Contains(name, "postgres") {
+		return "other"
+	}
+	if strings.Contains(name, "redis") {
+		return "other"
+	}
+	if strings.Contains(name, "mongod") {
+		return "other"
+	}
+
+	// Probe for TLS
+	if detectTLS(port) {
+		return "https"
+	}
+	return "http"
 }
 
 // detectTLS attempts a TLS handshake to determine if a port speaks HTTPS.

--- a/internal/service/proxy.go
+++ b/internal/service/proxy.go
@@ -19,15 +19,17 @@ import (
 	"time"
 
 	"clawbench/internal/model"
+	"clawbench/internal/proxy"
 )
 
 // ProxyRegistry manages forwarded ports: registration, health checks, and auto-detection.
 type ProxyRegistry struct {
-	mu       sync.RWMutex
-	ports    map[int]*model.ForwardedPort // key = localPort (auto-assigned, unique)
-	cfg      model.ProxyConfig
-	selfPort int // ClawBench's own port, excluded from detection
-	cancel   context.CancelFunc
+	mu         sync.RWMutex
+	ports      map[int]*model.ForwardedPort     // key = localPort (auto-assigned, unique)
+	proxies    map[int]*proxy.ReverseProxy       // key = localPort, active HTTP reverse proxies for non-localhost targets
+	cfg        model.ProxyConfig
+	selfPort   int // ClawBench's own port, excluded from detection
+	cancel     context.CancelFunc
 }
 
 // allocateLocalPort finds an available local port for forwarding.
@@ -62,9 +64,10 @@ var ProxyService *ProxyRegistry
 // The caller (main.go) decides whether to create this based on port_forward.enabled.
 func NewProxyRegistry(selfPort int) *ProxyRegistry {
 	ctx, cancel := context.WithCancel(context.Background())
-	allowedPorts := "1024-65535" // default allowed port range
+	allowedPorts := "" // default: allow all ports (1-65535)
 	r := &ProxyRegistry{
 		ports:    make(map[int]*model.ForwardedPort),
+		proxies:  make(map[int]*proxy.ReverseProxy),
 		cfg:      model.ProxyConfig{AllowedPorts: allowedPorts},
 		selfPort: selfPort,
 		cancel:   cancel,
@@ -85,29 +88,49 @@ func NewProxyRegistry(selfPort int) *ProxyRegistry {
 	return r
 }
 
-// SetAllowedPorts overrides the default allowed port range.
-// Must be called before any RegisterPort calls.
+// SetAllowedPorts overrides the allowed port range and removes any already-loaded
+// ports that fall outside the new range.
 func (r *ProxyRegistry) SetAllowedPorts(allowedPorts string) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
 	r.cfg.AllowedPorts = allowedPorts
+
+	// Remove ports that are no longer allowed
+	for lp, p := range r.ports {
+		if !isPortInRange(p.Port, r.cfg.AllowedPorts) {
+			slog.Info("proxy port removed (outside allowed range)", slog.Int("local_port", lp), slog.Int("port", p.Port))
+			r.stopReverseProxy(lp)
+			delete(r.ports, lp)
+			r.deletePortFromDB(lp)
+		}
+	}
 }
 
 // Stop shuts down the proxy registry and all health check goroutines.
 func (r *ProxyRegistry) Stop() {
+	// Stop all reverse proxies
+	r.mu.Lock()
+	for lp, rp := range r.proxies {
+		rp.Close()
+		delete(r.proxies, lp)
+	}
+	r.mu.Unlock()
+
 	if r.cancel != nil {
 		r.cancel()
 	}
 	slog.Info("proxy service stopped")
 }
 
-// RegisterPort adds a port to the forwarding registry.
+// RegisterPort adds a port to the forwarding registry and returns the allocated local port.
 // port is the target port on the remote host. If the same port is already
 // registered (with a different host), a nearby free local port is auto-assigned.
-func (r *ProxyRegistry) RegisterPort(port int, host string, name string, protocol string) error {
+func (r *ProxyRegistry) RegisterPort(port int, host string, name string, protocol string) (int, error) {
 	if port <= 0 || port > 65535 {
-		return fmt.Errorf("invalid port number: %d", port)
+		return 0, fmt.Errorf("invalid port number: %d", port)
 	}
 	if !r.IsPortAllowed(port) {
-		return fmt.Errorf("port %d is not in the allowed range", port)
+		return 0, fmt.Errorf("port %d is not in the allowed range", port)
 	}
 	if protocol != "https" {
 		protocol = "http"
@@ -119,7 +142,7 @@ func (r *ProxyRegistry) RegisterPort(port int, host string, name string, protoco
 	// Check if this exact (port, host) is already registered
 	for _, p := range r.ports {
 		if p.Port == port && p.Host == host {
-			return fmt.Errorf("port %d → %s is already registered (local %d)", port, hostDisplayName(host), p.LocalPort)
+			return 0, fmt.Errorf("port %d → %s is already registered (local %d)", port, hostDisplayName(host), p.LocalPort)
 		}
 	}
 
@@ -136,6 +159,21 @@ func (r *ProxyRegistry) RegisterPort(port int, host string, name string, protoco
 		Active:     checkPortActive(port, host),
 	}
 
+	// For non-localhost targets, start an HTTP reverse proxy to rewrite the Host header.
+	// SSH tunnel is TCP-level and cannot modify HTTP headers; the reverse proxy
+	// ensures the backend receives the correct Host header (targetHost:targetPort).
+	if isNonLocalhostTarget(host) {
+		if err := r.startReverseProxy(localPort, port, host, protocol); err != nil {
+			// Log but don't fail — the port is still registered for SSH tunneling
+			slog.Warn("failed to start reverse proxy for non-localhost target",
+				slog.Int("local_port", localPort),
+				slog.Int("target_port", port),
+				slog.String("host", host),
+				slog.String("err", err.Error()),
+			)
+		}
+	}
+
 	// Persist to database
 	r.savePortToDB(localPort, port, host, name, protocol)
 
@@ -147,7 +185,7 @@ func (r *ProxyRegistry) RegisterPort(port int, host string, name string, protoco
 		slog.String("protocol", protocol),
 	)
 
-	return nil
+	return localPort, nil
 }
 
 // UpdatePort modifies an existing forwarded port's host, name, and protocol.
@@ -231,6 +269,9 @@ func (r *ProxyRegistry) UnregisterPort(localPort int) error {
 
 	delete(r.ports, localPort)
 
+	// Stop any reverse proxy running for this port
+	r.stopReverseProxy(localPort)
+
 	// Remove from database
 	r.deletePortFromDB(localPort)
 
@@ -294,10 +335,10 @@ func (r *ProxyRegistry) DetectListeningPorts() []DetectedPort {
 		return nil
 	}
 
-	// Filter: exclude system ports (< 1024) and our own port
+	// Filter: exclude our own port (allow all other ports including privileged ones)
 	filtered := make([]detectedPortInfo, 0, len(portInfos))
 	for _, p := range portInfos {
-		if p.Port >= 1024 && p.Port != r.selfPort {
+		if p.Port > 0 && p.Port != r.selfPort {
 			filtered = append(filtered, p)
 		}
 	}
@@ -822,5 +863,42 @@ func (r *ProxyRegistry) deletePortFromDB(localPort int) {
 	_, err := DB.Exec("DELETE FROM forwarded_ports WHERE local_port = ?", localPort)
 	if err != nil {
 		slog.Error("failed to delete port from DB", slog.Int("local_port", localPort), slog.String("err", err.Error()))
+	}
+}
+
+// isNonLocalhostTarget returns true if the target host is not localhost/127.0.0.1.
+// Non-localhost targets need an HTTP reverse proxy to rewrite the Host header.
+func isNonLocalhostTarget(host string) bool {
+	return host != "" && host != "localhost" && host != "127.0.0.1" && host != "::1"
+}
+
+// startReverseProxy creates and starts an HTTP reverse proxy for a non-localhost target.
+// The proxy listens on 127.0.0.1:{localPort} and forwards to {host}:{port},
+// rewriting the Host header to match the target.
+func (r *ProxyRegistry) startReverseProxy(localPort int, targetPort int, host string, protocol string) error {
+	targetAddr := net.JoinHostPort(host, strconv.Itoa(targetPort))
+	rp, err := proxy.NewReverseProxy("127.0.0.1", localPort, targetAddr, protocol)
+	if err != nil {
+		return fmt.Errorf("failed to create reverse proxy: %w", err)
+	}
+
+	go rp.Serve()
+	r.proxies[localPort] = rp
+
+	slog.Info("reverse proxy started for non-localhost target",
+		slog.Int("local_port", localPort),
+		slog.String("target", targetAddr),
+		slog.String("protocol", protocol),
+	)
+
+	return nil
+}
+
+// stopReverseProxy stops and removes the reverse proxy for the given local port.
+func (r *ProxyRegistry) stopReverseProxy(localPort int) {
+	if rp, ok := r.proxies[localPort]; ok {
+		rp.Close()
+		delete(r.proxies, localPort)
+		slog.Info("reverse proxy stopped", slog.Int("local_port", localPort))
 	}
 }

--- a/internal/service/proxy_test.go
+++ b/internal/service/proxy_test.go
@@ -41,7 +41,7 @@ func TestProxyRegistry_RegisterPort(t *testing.T) {
 	r := newTestRegistry(t)
 	defer r.Stop()
 
-	err := r.RegisterPort(8080, "", "test", "http")
+	_, err := r.RegisterPort(8080, "", "test", "http")
 	assert.NoError(t, err)
 	assert.True(t, isPortRegistered(r, 8080))
 }
@@ -61,7 +61,7 @@ func TestProxyRegistry_RegisterPort_Invalid(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			err := r.RegisterPort(tt.port, "", "", "")
+			_, err := r.RegisterPort(tt.port, "", "", "")
 			assert.Error(t, err)
 		})
 	}
@@ -71,10 +71,10 @@ func TestProxyRegistry_RegisterPort_Duplicate(t *testing.T) {
 	r := newTestRegistry(t)
 	defer r.Stop()
 
-	err := r.RegisterPort(3000, "", "first", "")
+	_, err := r.RegisterPort(3000, "", "first", "")
 	assert.NoError(t, err)
 
-	err = r.RegisterPort(3000, "", "second", "")
+	_, err = r.RegisterPort(3000, "", "second", "")
 	assert.Error(t, err)
 	assert.Contains(t, err.Error(), "already registered")
 }
@@ -83,7 +83,7 @@ func TestProxyRegistry_UnregisterPort(t *testing.T) {
 	r := newTestRegistry(t)
 	defer r.Stop()
 
-	_ = r.RegisterPort(9090, "", "metrics", "")
+	_, _ = r.RegisterPort(9090, "", "metrics", "")
 
 	err := r.UnregisterPort(9090)
 	assert.NoError(t, err)
@@ -103,9 +103,9 @@ func TestProxyRegistry_ListPorts_Sorted(t *testing.T) {
 	r := newTestRegistry(t)
 	defer r.Stop()
 
-	_ = r.RegisterPort(8080, "", "api", "")
-	_ = r.RegisterPort(3000, "", "app", "")
-	_ = r.RegisterPort(5173, "", "vite", "")
+	_, _ = r.RegisterPort(8080, "", "api", "")
+	_, _ = r.RegisterPort(3000, "", "app", "")
+	_, _ = r.RegisterPort(5173, "", "vite", "")
 
 	ports := r.ListPorts()
 	assert.Len(t, ports, 3)
@@ -127,7 +127,7 @@ func TestProxyRegistry_IsPortAllowed(t *testing.T) {
 	defer r.Stop()
 
 	assert.False(t, isPortRegistered(r, 8080))
-	_ = r.RegisterPort(8080, "", "", "")
+	_, _ = r.RegisterPort(8080, "", "", "")
 	assert.True(t, isPortRegistered(r, 8080))
 }
 
@@ -168,14 +168,14 @@ func TestProxyRegistry_RegisterPort_Protocol(t *testing.T) {
 	r := newTestRegistry(t)
 	defer r.Stop()
 
-	err := r.RegisterPort(4443, "", "secure", "https")
+	_, err := r.RegisterPort(4443, "", "secure", "https")
 	assert.NoError(t, err)
 
 	ports := r.ListPorts()
 	assert.Len(t, ports, 1)
 	assert.Equal(t, "https", ports[0].Protocol)
 
-	err = r.RegisterPort(8080, "", "plain", "http")
+	_, err = r.RegisterPort(8080, "", "plain", "http")
 	assert.NoError(t, err)
 
 	protocol := getPortProtocol(r, 4443)
@@ -193,7 +193,7 @@ func TestProxyRegistry_RegisterPort_InvalidProtocolDefaultsToHTTP(t *testing.T) 
 	r := newTestRegistry(t)
 	defer r.Stop()
 
-	err := r.RegisterPort(8080, "", "test", "ftp")
+	_, err := r.RegisterPort(8080, "", "test", "ftp")
 	assert.NoError(t, err)
 
 	ports := r.ListPorts()
@@ -274,9 +274,9 @@ func TestProxyRegistry_PortPersistence_RegisterAndLoad(t *testing.T) {
 	r := NewProxyRegistry(0)
 	defer r.Stop()
 
-	err := r.RegisterPort(5173, "", "Vite Dev", "http")
+	_, err := r.RegisterPort(5173, "", "Vite Dev", "http")
 	assert.NoError(t, err)
-	err = r.RegisterPort(8080, "", "API", "https")
+	_, err = r.RegisterPort(8080, "", "API", "https")
 	assert.NoError(t, err)
 
 	// Verify ports are in the database
@@ -410,12 +410,13 @@ func TestProxyRegistry_PortPersistence_SkipsOutOfAllowedRange(t *testing.T) {
 	DBRead = DB
 	defer func() { DB = origDB; DBRead = origDBRead }()
 
-	// Insert a port directly into DB that is outside the new allowed range
+	// Insert a port directly into DB that is outside the restricted allowed range
 	_, err := DB.Exec("INSERT INTO forwarded_ports (local_port, port, host, name, protocol) VALUES (80, 80, '', 'system', 'http')")
 	assert.NoError(t, err)
 
-	// Create registry with restricted range — port 80 should be skipped
+	// Create registry and restrict to high ports only — port 80 should be skipped
 	r := NewProxyRegistry(0)
+	r.SetAllowedPorts("1024-65535")
 	defer r.Stop()
 
 	assert.False(t, isPortRegistered(r, 80))
@@ -435,7 +436,7 @@ func TestProxyRegistry_PortPersistence_NoDB(t *testing.T) {
 	defer r.Stop()
 
 	// Register should work (in-memory only)
-	err := r.RegisterPort(8080, "", "test", "http")
+	_, err := r.RegisterPort(8080, "", "test", "http")
 	assert.NoError(t, err)
 	assert.True(t, isPortRegistered(r, 8080))
 
@@ -470,7 +471,7 @@ func TestProxyRegistry_GetPortProtocol_Registered(t *testing.T) {
 	r := newTestRegistry(t)
 	defer r.Stop()
 
-	err := r.RegisterPort(8443, "", "secure", "https")
+	_, err := r.RegisterPort(8443, "", "secure", "https")
 	assert.NoError(t, err)
 
 	protocol := getPortProtocol(r, 8443)
@@ -490,7 +491,7 @@ func TestProxyRegistry_GetPortProtocol_EmptyProtocol(t *testing.T) {
 	defer r.Stop()
 
 	// Register with http (default protocol)
-	err := r.RegisterPort(8080, "", "web", "http")
+	_, err := r.RegisterPort(8080, "", "web", "http")
 	assert.NoError(t, err)
 
 	protocol := getPortProtocol(r, 8080)
@@ -529,8 +530,9 @@ func TestProxyRegistry_SetAllowedPorts_OverridesDefault(t *testing.T) {
 	r := newTestRegistry(t)
 	defer r.Stop()
 
-	// Default allows 1024-65535
+	// Default allows all ports
 	assert.True(t, r.IsPortAllowed(8080))
+	assert.True(t, r.IsPortAllowed(80))
 
 	// Override to restricted range
 	r.SetAllowedPorts("5000-5010")
@@ -544,7 +546,7 @@ func TestProxyRegistry_RegisterPort_WithHost(t *testing.T) {
 	r := newTestRegistry(t)
 	defer r.Stop()
 
-	err := r.RegisterPort(8080, "192.168.1.100", "remote-api", "http")
+	_, err := r.RegisterPort(8080, "192.168.1.100", "remote-api", "http")
 	assert.NoError(t, err)
 
 	ports := r.ListPorts()
@@ -559,10 +561,10 @@ func TestProxyRegistry_RegisterPort_SamePortDifferentHost(t *testing.T) {
 	defer r.Stop()
 
 	// Same port, different hosts should both succeed
-	err := r.RegisterPort(8080, "", "local-api", "http")
+	_, err := r.RegisterPort(8080, "", "local-api", "http")
 	assert.NoError(t, err)
 
-	err = r.RegisterPort(8080, "192.168.1.100", "remote-api", "http")
+	_, err = r.RegisterPort(8080, "192.168.1.100", "remote-api", "http")
 	assert.NoError(t, err)
 
 	ports := r.ListPorts()
@@ -573,10 +575,10 @@ func TestProxyRegistry_RegisterPort_SamePortSameHost_Duplicate(t *testing.T) {
 	r := newTestRegistry(t)
 	defer r.Stop()
 
-	err := r.RegisterPort(8080, "192.168.1.100", "api", "http")
+	_, err := r.RegisterPort(8080, "192.168.1.100", "api", "http")
 	assert.NoError(t, err)
 
-	err = r.RegisterPort(8080, "192.168.1.100", "api-2", "http")
+	_, err = r.RegisterPort(8080, "192.168.1.100", "api-2", "http")
 	assert.Error(t, err)
 	assert.Contains(t, err.Error(), "already registered")
 }
@@ -585,11 +587,11 @@ func TestProxyRegistry_RegisterPort_EmptyHostDuplicate(t *testing.T) {
 	r := newTestRegistry(t)
 	defer r.Stop()
 
-	err := r.RegisterPort(3000, "", "app1", "http")
+	_, err := r.RegisterPort(3000, "", "app1", "http")
 	assert.NoError(t, err)
 
 	// Same port + empty host should be a duplicate
-	err = r.RegisterPort(3000, "", "app2", "http")
+	_, err = r.RegisterPort(3000, "", "app2", "http")
 	assert.Error(t, err)
 	assert.Contains(t, err.Error(), "already registered")
 }
@@ -601,7 +603,7 @@ func TestProxyRegistry_AllocateLocalPort_PreferRequested(t *testing.T) {
 	defer r.Stop()
 
 	// First registration on 8080 should get local port 8080
-	err := r.RegisterPort(8080, "", "api", "http")
+	_, err := r.RegisterPort(8080, "", "api", "http")
 	assert.NoError(t, err)
 
 	ports := r.ListPorts()
@@ -614,11 +616,11 @@ func TestProxyRegistry_AllocateLocalPort_AutoAssignWhenTaken(t *testing.T) {
 	defer r.Stop()
 
 	// Register port 3000 on localhost — gets local port 3000
-	err := r.RegisterPort(3000, "", "local-app", "http")
+	_, err := r.RegisterPort(3000, "", "local-app", "http")
 	assert.NoError(t, err)
 
 	// Register same port on different host — local 3000 is taken, should auto-assign
-	err = r.RegisterPort(3000, "192.168.1.100", "remote-app", "http")
+	_, err = r.RegisterPort(3000, "192.168.1.100", "remote-app", "http")
 	assert.NoError(t, err)
 
 	ports := r.ListPorts()
@@ -811,4 +813,75 @@ func TestProxyRegistry_PortPersistence_DifferentHostsSamePort(t *testing.T) {
 	}
 	assert.Contains(t, portMap, "8080:")
 	assert.Contains(t, portMap, "8080:192.168.1.100")
+}
+
+// ---------- Default allowed ports: all ports allowed ----------
+
+func TestProxyRegistry_DefaultAllowsAllPorts(t *testing.T) {
+	r := newTestRegistry(t)
+	defer r.Stop()
+
+	// Default should allow ALL ports, including privileged ones
+	assert.True(t, r.IsPortAllowed(80), "port 80 should be allowed by default")
+	assert.True(t, r.IsPortAllowed(443), "port 443 should be allowed by default")
+	assert.True(t, r.IsPortAllowed(22), "port 22 should be allowed by default")
+	assert.True(t, r.IsPortAllowed(8080), "port 8080 should be allowed by default")
+	assert.True(t, r.IsPortAllowed(1), "port 1 should be allowed by default")
+}
+
+func TestProxyRegistry_RegisterPort_PrivilegedPort(t *testing.T) {
+	r := newTestRegistry(t)
+	defer r.Stop()
+
+	// Port 80 should be registerable by default
+	_, err := r.RegisterPort(80, "", "http-server", "http")
+	assert.NoError(t, err)
+	assert.True(t, isPortRegistered(r, 80))
+}
+
+func TestProxyRegistry_RegisterPort_Port443(t *testing.T) {
+	r := newTestRegistry(t)
+	defer r.Stop()
+
+	// Port 443 should be registerable by default
+	_, err := r.RegisterPort(443, "", "https-server", "https")
+	assert.NoError(t, err)
+	assert.True(t, isPortRegistered(r, 443))
+}
+
+// ---------- RegisterPort returns localPort ----------
+
+func TestProxyRegistry_RegisterPort_ReturnsLocalPort(t *testing.T) {
+	r := newTestRegistry(t)
+	defer r.Stop()
+
+	// When no collision, localPort == port
+	localPort, err := r.RegisterPort(8080, "", "test", "http")
+	assert.NoError(t, err)
+	assert.Equal(t, 8080, localPort)
+}
+
+func TestProxyRegistry_RegisterPort_ReturnsAutoAssignedLocalPort(t *testing.T) {
+	r := newTestRegistry(t)
+	defer r.Stop()
+
+	// Register port 8080 on localhost
+	localPort1, err := r.RegisterPort(8080, "", "local-api", "http")
+	assert.NoError(t, err)
+	assert.Equal(t, 8080, localPort1)
+
+	// Register same port 8080 on a different host — should auto-assign 8081
+	localPort2, err := r.RegisterPort(8080, "192.168.1.100", "remote-api", "http")
+	assert.NoError(t, err)
+	assert.Equal(t, 8081, localPort2)
+}
+
+func TestProxyRegistry_RegisterPort_PrivilegedPort_ReturnsLocalPort(t *testing.T) {
+	r := newTestRegistry(t)
+	defer r.Stop()
+
+	// Port 80 should return localPort = 80
+	localPort, err := r.RegisterPort(80, "", "http-server", "http")
+	assert.NoError(t, err)
+	assert.Equal(t, 80, localPort)
 }

--- a/internal/service/proxy_test.go
+++ b/internal/service/proxy_test.go
@@ -886,3 +886,248 @@ func TestProxyRegistry_RegisterPort_PrivilegedPort_ReturnsLocalPort(t *testing.T
 	assert.GreaterOrEqual(t, localPort, 1024, "privileged port should be remapped to >= 1024")
 	assert.NotEqual(t, 80, localPort, "localPort should not equal the privileged target port")
 }
+
+// ---------- classifyPort ----------
+
+func TestClassifyPort_WellKnownNonHTTP(t *testing.T) {
+	tests := []struct {
+		name     string
+		port     int
+		procName string
+		expected string
+	}{
+		{"SSH 22", 22, "", "other"},
+		{"SSH 2222", 2222, "", "other"},
+		{"SMTP 25", 25, "", "other"},
+		{"SMTP 465", 465, "", "other"},
+		{"SMTP 587", 587, "", "other"},
+		{"MySQL 3306", 3306, "", "other"},
+		{"PostgreSQL 5432", 5432, "", "other"},
+		{"Redis 6379", 6379, "", "other"},
+		{"MongoDB 27017", 27017, "", "other"},
+		{"FTP 21", 21, "", "other"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.expected, classifyPort(tt.port, tt.procName))
+		})
+	}
+}
+
+func TestClassifyPort_ProcessName(t *testing.T) {
+	tests := []struct {
+		name     string
+		port     int
+		procName string
+		expected string
+	}{
+		{"sshd process", 1234, "sshd", "other"},
+		{"ssh process", 1234, "ssh", "other"},
+		{"mysql process", 1234, "mysql", "other"},
+		{"mysqld process", 1234, "mysqld", "other"},
+		{"postgres process", 1234, "postgres", "other"},
+		{"redis-server process", 1234, "redis-server", "other"},
+		{"mongod process", 1234, "mongod", "other"},
+		{"case insensitive SSH", 1234, "SSHD", "other"},
+		{"partial match sshd", 1234, "/usr/sbin/sshd", "other"},
+		{"unknown process returns http", 8080, "myapp", "http"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.expected, classifyPort(tt.port, tt.procName))
+		})
+	}
+}
+
+func TestClassifyPort_DefaultHTTP(t *testing.T) {
+	// Unknown port with unknown process name → http
+	assert.Equal(t, "http", classifyPort(8080, ""))
+	assert.Equal(t, "http", classifyPort(3000, "node"))
+}
+
+// ---------- loadPortsFromDB reverse proxy ----------
+
+func TestProxyRegistry_LoadPortsFromDB_NonLocalhostHostStartsReverseProxy(t *testing.T) {
+	origDB := DB
+	origDBRead := DBRead
+	DB = setupTestDB(t)
+	DBRead = DB
+	defer func() { DB = origDB; DBRead = origDBRead }()
+
+	// Insert a port with non-localhost host directly into DB
+	_, err := DB.Exec("INSERT INTO forwarded_ports (local_port, port, host, name, protocol) VALUES (8080, 8080, '192.168.1.100', 'remote-api', 'http')")
+	assert.NoError(t, err)
+
+	// Load from DB — should start a reverse proxy for the non-localhost target
+	r := NewProxyRegistry(0)
+	defer r.Stop()
+
+	ports := r.ListPorts()
+	assert.Len(t, ports, 1)
+	assert.Equal(t, "192.168.1.100", ports[0].Host)
+
+	// Verify reverse proxy was started
+	r.mu.RLock()
+	_, hasProxy := r.proxies[8080]
+	r.mu.RUnlock()
+	assert.True(t, hasProxy, "reverse proxy should be started for non-localhost host on DB load")
+}
+
+func TestProxyRegistry_LoadPortsFromDB_LocalhostHostNoReverseProxy(t *testing.T) {
+	origDB := DB
+	origDBRead := DBRead
+	DB = setupTestDB(t)
+	DBRead = DB
+	defer func() { DB = origDB; DBRead = origDBRead }()
+
+	// Insert a port with localhost/empty host
+	_, err := DB.Exec("INSERT INTO forwarded_ports (local_port, port, host, name, protocol) VALUES (8080, 8080, '', 'local-api', 'http')")
+	assert.NoError(t, err)
+
+	r := NewProxyRegistry(0)
+	defer r.Stop()
+
+	// No reverse proxy for localhost targets
+	r.mu.RLock()
+	_, hasProxy := r.proxies[8080]
+	r.mu.RUnlock()
+	assert.False(t, hasProxy, "reverse proxy should NOT be started for localhost host on DB load")
+}
+
+// ---------- stopReverseProxy ----------
+
+func TestProxyRegistry_StopReverseProxy(t *testing.T) {
+	r := newTestRegistry(t)
+	defer r.Stop()
+
+	// Register a port with non-localhost host — starts a reverse proxy
+	localPort, err := r.RegisterPort(8080, "192.168.1.100", "remote-api", "http")
+	assert.NoError(t, err)
+
+	// Verify reverse proxy was started
+	r.mu.RLock()
+	_, hasProxy := r.proxies[localPort]
+	r.mu.RUnlock()
+	assert.True(t, hasProxy, "reverse proxy should be started after RegisterPort with non-localhost host")
+
+	// Unregister — should stop the reverse proxy
+	err = r.UnregisterPort(localPort)
+	assert.NoError(t, err)
+
+	r.mu.RLock()
+	_, hasProxyAfter := r.proxies[localPort]
+	r.mu.RUnlock()
+	assert.False(t, hasProxyAfter, "reverse proxy should be stopped after UnregisterPort")
+}
+
+// ---------- allocateLocalPort privileged port scan ----------
+
+func TestProxyRegistry_AllocateLocalPort_PrivilegedPortScansUpward(t *testing.T) {
+	r := newTestRegistry(t)
+	defer r.Stop()
+
+	// Port 22 (SSH) should be remapped to >=1024
+	localPort, err := r.RegisterPort(22, "", "ssh", "http")
+	assert.NoError(t, err)
+	assert.GreaterOrEqual(t, localPort, 1024)
+
+	// Port 443 should also be remapped
+	localPort2, err := r.RegisterPort(443, "", "https-server", "https")
+	assert.NoError(t, err)
+	assert.GreaterOrEqual(t, localPort2, 1024)
+	assert.NotEqual(t, localPort, localPort2, "two privileged ports should get different local ports")
+}
+
+// ---------- isNonLocalhostTarget ----------
+
+func TestIsNonLocalhostTarget(t *testing.T) {
+	assert.False(t, isNonLocalhostTarget(""), "empty host is localhost")
+	assert.False(t, isNonLocalhostTarget("localhost"), "localhost is not non-localhost")
+	assert.False(t, isNonLocalhostTarget("127.0.0.1"), "127.0.0.1 is not non-localhost")
+	assert.False(t, isNonLocalhostTarget("::1"), "::1 is not non-localhost")
+	assert.True(t, isNonLocalhostTarget("192.168.1.1"), "LAN IP is non-localhost")
+	assert.True(t, isNonLocalhostTarget("10.0.0.1"), "private IP is non-localhost")
+	assert.True(t, isNonLocalhostTarget("example.com"), "domain is non-localhost")
+}
+
+// ---------- RegisterPort reverse proxy for non-localhost ----------
+
+func TestProxyRegistry_RegisterPort_NonLocalhostStartsReverseProxy(t *testing.T) {
+	r := newTestRegistry(t)
+	defer r.Stop()
+
+	// Register a port with a non-localhost host — should start reverse proxy
+	localPort, err := r.RegisterPort(8080, "192.168.1.100", "remote-api", "http")
+	assert.NoError(t, err)
+
+	r.mu.RLock()
+	_, hasProxy := r.proxies[localPort]
+	r.mu.RUnlock()
+	assert.True(t, hasProxy, "reverse proxy should be started for non-localhost host")
+
+	// Verify the port is listed with correct host
+	ports := r.ListPorts()
+	found := false
+	for _, p := range ports {
+		if p.Port == 8080 && p.Host == "192.168.1.100" {
+			found = true
+			assert.Equal(t, localPort, p.LocalPort)
+		}
+	}
+	assert.True(t, found, "port with non-localhost host should be listed")
+}
+
+func TestProxyRegistry_RegisterPort_LocalhostNoReverseProxy(t *testing.T) {
+	r := newTestRegistry(t)
+	defer r.Stop()
+
+	localPort, err := r.RegisterPort(8080, "", "local-api", "http")
+	assert.NoError(t, err)
+
+	r.mu.RLock()
+	_, hasProxy := r.proxies[localPort]
+	r.mu.RUnlock()
+	assert.False(t, hasProxy, "no reverse proxy for localhost target")
+}
+
+func TestProxyRegistry_StartReverseProxy_FailsOnUsedPort(t *testing.T) {
+	r := newTestRegistry(t)
+	defer r.Stop()
+
+	// First register a non-localhost port to start a reverse proxy on localPort
+	localPort, err := r.RegisterPort(8080, "192.168.1.100", "remote-api", "http")
+	assert.NoError(t, err)
+
+	// Manually start another reverse proxy on the same localPort — should fail
+	err = r.startReverseProxy(localPort, 9090, "192.168.1.200", "http")
+	assert.Error(t, err, "starting reverse proxy on already-used port should fail")
+	assert.Contains(t, err.Error(), "failed to create reverse proxy")
+}
+
+func TestProxyRegistry_LoadPortsFromDB_NonLocalhostReverseProxyStarts(t *testing.T) {
+	origDB := DB
+	origDBRead := DBRead
+	DB = setupTestDB(t)
+	DBRead = DB
+	defer func() { DB = origDB; DBRead = origDBRead }()
+
+	// Insert a port with non-localhost host into DB
+	_, err := DB.Exec("INSERT INTO forwarded_ports (local_port, port, host, name, protocol) VALUES (8080, 8080, '10.0.0.1', 'remote', 'http')")
+	assert.NoError(t, err)
+
+	r := NewProxyRegistry(0)
+	defer r.Stop()
+
+	// Port should be loaded and reverse proxy should be started
+	ports := r.ListPorts()
+	assert.Len(t, ports, 1)
+	assert.Equal(t, "10.0.0.1", ports[0].Host)
+
+	r.mu.RLock()
+	rp, hasProxy := r.proxies[8080]
+	r.mu.RUnlock()
+	assert.True(t, hasProxy, "reverse proxy should be started for non-localhost host on DB load")
+	if hasProxy && rp != nil {
+		assert.Greater(t, rp.Port(), 0, "reverse proxy should be listening on a valid port")
+	}
+}

--- a/internal/service/proxy_test.go
+++ b/internal/service/proxy_test.go
@@ -880,8 +880,9 @@ func TestProxyRegistry_RegisterPort_PrivilegedPort_ReturnsLocalPort(t *testing.T
 	r := newTestRegistry(t)
 	defer r.Stop()
 
-	// Port 80 should return localPort = 80
+	// Port 80 is a privileged port — it must be remapped to a non-privileged localPort
 	localPort, err := r.RegisterPort(80, "", "http-server", "http")
 	assert.NoError(t, err)
-	assert.Equal(t, 80, localPort)
+	assert.GreaterOrEqual(t, localPort, 1024, "privileged port should be remapped to >= 1024")
+	assert.NotEqual(t, 80, localPort, "localPort should not equal the privileged target port")
 }

--- a/internal/ssh/server_test.go
+++ b/internal/ssh/server_test.go
@@ -298,7 +298,7 @@ func TestSSHPortForward_DisallowedPortRejected(t *testing.T) {
 	defer r.Stop()
 
 	// RegisterPort should reject a port outside the allowed range
-	err := r.RegisterPort(8080, "", "outside-range", "http")
+	_, err := r.RegisterPort(8080, "", "outside-range", "http")
 	if err == nil {
 		t.Error("expected RegisterPort to reject port 8080 (outside allowed range 3000-4000)")
 	}

--- a/scripts/check-android-coverage.sh
+++ b/scripts/check-android-coverage.sh
@@ -331,6 +331,7 @@ else:
     # in the same class are still checked normally.
     exempt_files = {
         "android/app/src/main/java/com/clawbench/app/BackgroundService.java",  # onStartCommand, ensureConnection need Android framework + JSch
+        "android/app/src/main/java/com/clawbench/app/BrowserActivity.java",    # shouldInterceptRequest needs WebView + HttpURLConnection; onReceivedError needs WebViewClient lifecycle
     }
 
     for file_path, lines in sorted(changed_lines.items()):

--- a/web/src/components/proxy/ProxyPanelContent.vue
+++ b/web/src/components/proxy/ProxyPanelContent.vue
@@ -308,8 +308,6 @@ async function handleSave() {
 async function handleQuickAdd(port, protocol, processName) {
   try {
     await registerPort(port, processName || t('proxy.autoDetect'), protocol || 'http')
-    // Auto-open after successful registration
-    openPort(port, protocol || 'http')
   } catch (e) {
     toast.error(e?.message || t('proxy.addPort') + ' failed')
   }
@@ -600,19 +598,27 @@ async function handleRetryTunnel() {
 }
 
 .proxy-detected {
-  padding: 4px 0;
+  flex-shrink: 0;
+  border-top: 1px solid var(--border-color, #e5e5e5);
+  padding: 6px 0 0;
+  margin-top: 4px;
 }
 
 .proxy-detected-label {
   font-size: 11px;
   color: var(--text-muted, #999);
   margin-bottom: 6px;
+  flex-shrink: 0;
 }
 
 .proxy-detected-chips {
   display: flex;
   flex-direction: column;
   gap: 6px;
+  max-height: 180px;
+  overflow-y: auto;
+  -webkit-overflow-scrolling: touch;
+  padding-right: 4px;
 }
 
 .detect-chip {

--- a/web/src/components/proxy/ProxyPanelContent.vue
+++ b/web/src/components/proxy/ProxyPanelContent.vue
@@ -306,7 +306,13 @@ async function handleSave() {
 }
 
 async function handleQuickAdd(port, protocol, processName) {
-  await registerPort(port, processName || t('proxy.autoDetect'), protocol || 'http')
+  try {
+    await registerPort(port, processName || t('proxy.autoDetect'), protocol || 'http')
+    // Auto-open after successful registration
+    openPort(port, protocol || 'http')
+  } catch (e) {
+    toast.error(e?.message || t('proxy.addPort') + ' failed')
+  }
 }
 
 async function handleRemove(localPort) {

--- a/web/src/components/proxy/ProxyPanelContent.vue
+++ b/web/src/components/proxy/ProxyPanelContent.vue
@@ -94,32 +94,59 @@
         </div>
       </div>
 
-      <!-- Loading -->
-      <div v-if="loading" class="proxy-loading">{{ t('common.loading') }}</div>
+      <!-- Two-zone layout: registered ports (top, 50–100%) + detected ports (bottom, 0–50%, sticky to bottom) -->
+      <div class="proxy-zones">
 
-      <!-- Port list -->
-      <div v-else-if="ports.length > 0" class="proxy-list">
-        <ProxyPortItem
-          v-for="p in ports"
-          :key="p.localPort"
-          :port="p.port"
-          :local-port="p.localPort"
-          :host="p.host || ''"
-          :name="p.name"
-          :protocol="p.protocol"
-          :active="p.active"
-          :tunnel-disconnected="tunnelStatus === 'disconnected'"
-          @open="openPort"
-          @open-external="openInExternalBrowser"
-          @edit="handleEdit"
-          @remove="handleRemove"
-        />
-      </div>
+        <!-- Zone 1: Registered ports (top half) -->
+        <div class="proxy-zone-registered">
+          <!-- Loading -->
+          <div v-if="loading" class="proxy-loading">{{ t('common.loading') }}</div>
 
-      <!-- Empty state -->
-      <div v-else class="proxy-empty">
-        <div class="proxy-empty-text">{{ t('proxy.noPorts') }}</div>
-        <div class="proxy-empty-hint">{{ t('proxy.emptyHint') }}</div>
+          <!-- Port list -->
+          <div v-else-if="ports.length > 0" class="proxy-list">
+            <ProxyPortItem
+              v-for="p in ports"
+              :key="p.localPort"
+              :port="p.port"
+              :local-port="p.localPort"
+              :host="p.host || ''"
+              :name="p.name"
+              :protocol="p.protocol"
+              :active="p.active"
+              :tunnel-disconnected="tunnelStatus === 'disconnected'"
+              @open="openPort"
+              @open-external="openInExternalBrowser"
+              @edit="handleEdit"
+              @remove="handleRemove"
+            />
+          </div>
+
+          <!-- Empty state -->
+          <div v-else class="proxy-empty">
+            <div class="proxy-empty-text">{{ t('proxy.noPorts') }}</div>
+            <div class="proxy-empty-hint">{{ t('proxy.emptyHint') }}</div>
+          </div>
+        </div>
+
+        <!-- Zone 2: Detected ports (bottom half, pinned to bottom) -->
+        <div v-if="detectedPorts.length > 0" class="proxy-zone-detected">
+          <div class="proxy-detected-label">{{ t('proxy.detectedPorts') }}</div>
+          <div class="proxy-detected-chips">
+            <button
+              v-for="(p, i) in detectedPortsNotRegistered"
+              :key="p.port"
+              class="detect-chip"
+              :class="p.protocol"
+              :style="{ animationDelay: `${i * 60}ms` }"
+              @click="handleQuickAdd(p.port, p.protocol, p.processName)"
+            >
+              <span class="chip-row"><span class="chip-port">{{ p.port }}</span><span class="chip-proto">{{ p.protocol }}</span></span>
+              <span v-if="p.processName" class="chip-cmdline"><span class="chip-process">{{ p.processName }}</span><span v-if="p.processArgs" class="chip-args"> {{ p.processArgs }}</span></span>
+            </button>
+            <span v-if="detectedPortsNotRegistered.length === 0" class="detect-all-registered">{{ t('proxy.allRegistered') }}</span>
+          </div>
+        </div>
+
       </div>
 
       <!-- Add/Edit Modal (shared) -->
@@ -173,25 +200,6 @@
           <button class="port-add-confirm" @click="handleSave" :disabled="!isValidPort || saving">{{ saving ? '...' : t('common.confirm') }}</button>
         </template>
       </ModalDialog>
-
-      <!-- Detected ports (suggestion chips) -->
-      <div v-if="detectedPorts.length > 0" class="proxy-detected">
-        <div class="proxy-detected-label">{{ t('proxy.detectedPorts') }}</div>
-        <div class="proxy-detected-chips">
-          <button
-            v-for="(p, i) in detectedPortsNotRegistered"
-            :key="p.port"
-            class="detect-chip"
-            :class="p.protocol"
-            :style="{ animationDelay: `${i * 60}ms` }"
-            @click="handleQuickAdd(p.port, p.protocol, p.processName)"
-          >
-            <span class="chip-row"><span class="chip-port">{{ p.port }}</span><span class="chip-proto">{{ p.protocol }}</span></span>
-            <span v-if="p.processName" class="chip-cmdline"><span class="chip-process">{{ p.processName }}</span><span v-if="p.processArgs" class="chip-args"> {{ p.processArgs }}</span></span>
-          </button>
-          <span v-if="detectedPortsNotRegistered.length === 0" class="detect-all-registered">{{ t('proxy.allRegistered') }}</span>
-        </div>
-      </div>
 
     </div>
   </div>
@@ -370,8 +378,8 @@ async function handleRetryTunnel() {
   gap: 8px;
   padding: 6px;
   flex: 1;
-  overflow-y: auto;
-  -webkit-overflow-scrolling: touch;
+  min-height: 0;
+  overflow: hidden;
 }
 
 /* Compact header — matches TaskListPage style */
@@ -597,21 +605,37 @@ async function handleRetryTunnel() {
   gap: 4px;
 }
 
-.proxy-detected {
-  flex-shrink: 0;
-  border-top: 1px solid var(--border-color, #e5e5e5);
-  padding: 6px 0 0;
-  margin-top: 4px;
+/* Two-zone layout: registered ports (top, 50–100%) + detected ports (bottom, 0–50%, pinned to bottom) */
+.proxy-zones {
+  flex: 1;
+  min-height: 0;
   display: flex;
   flex-direction: column;
-  max-height: 50vh;
+  overflow: hidden;
+}
+
+/* Zone 1: registered ports — takes all space when no detected ports, at least 50% when detected ports exist */
+.proxy-zone-registered {
+  flex: 1 1 50%;
+  min-height: 0;
+  overflow-y: auto;
+  -webkit-overflow-scrolling: touch;
+}
+
+/* Zone 2: detected ports — takes 0–50%, pinned to bottom, hidden when empty */
+.proxy-zone-detected {
+  flex: 0 0 auto;
+  max-height: 50%;
+  border-top: 1px solid var(--border-color, #e5e5e5);
+  display: flex;
+  flex-direction: column;
   overflow: hidden;
 }
 
 .proxy-detected-label {
   font-size: 11px;
   color: var(--text-muted, #999);
-  margin-bottom: 6px;
+  padding: 6px 0 4px;
   flex-shrink: 0;
 }
 
@@ -622,6 +646,7 @@ async function handleRetryTunnel() {
   overflow-y: auto;
   -webkit-overflow-scrolling: touch;
   padding-right: 4px;
+  padding-bottom: 4px;
 }
 
 .detect-chip {

--- a/web/src/components/proxy/ProxyPanelContent.vue
+++ b/web/src/components/proxy/ProxyPanelContent.vue
@@ -602,6 +602,10 @@ async function handleRetryTunnel() {
   border-top: 1px solid var(--border-color, #e5e5e5);
   padding: 6px 0 0;
   margin-top: 4px;
+  display: flex;
+  flex-direction: column;
+  max-height: 50vh;
+  overflow: hidden;
 }
 
 .proxy-detected-label {
@@ -615,7 +619,6 @@ async function handleRetryTunnel() {
   display: flex;
   flex-direction: column;
   gap: 6px;
-  max-height: 180px;
   overflow-y: auto;
   -webkit-overflow-scrolling: touch;
   padding-right: 4px;

--- a/web/src/composables/__tests__/useLocalhostAnnotation.test.ts
+++ b/web/src/composables/__tests__/useLocalhostAnnotation.test.ts
@@ -4,7 +4,7 @@ import { ref } from 'vue'
 // Mock composables before importing the module
 const mockIsAppMode = ref(false)
 const mockSshInfo = ref<any>(null)
-const mockEnsurePortRegistered = vi.fn().mockResolvedValue(undefined)
+const mockEnsurePortRegistered = vi.fn().mockResolvedValue(3000)
 const mockOpenPort = vi.fn()
 const mockToastShow = vi.fn()
 
@@ -201,7 +201,7 @@ describe('useLocalhostAnnotation', () => {
     beforeEach(() => {
       mockIsAppMode.value = true
       mockSshInfo.value = { enabled: true }
-      mockEnsurePortRegistered.mockReset().mockResolvedValue(undefined)
+      mockEnsurePortRegistered.mockReset().mockResolvedValue(3000)
       mockOpenPort.mockReset()
       mockToastShow.mockReset()
       const handler = useLocalhostUrlClickHandler()

--- a/web/src/composables/__tests__/usePortForward.test.ts
+++ b/web/src/composables/__tests__/usePortForward.test.ts
@@ -287,7 +287,7 @@ describe('usePortForward', () => {
 
     describe('registerPort', () => {
         it('posts port to API and refreshes', async () => {
-            mockApiPost.mockResolvedValue({})
+            mockApiPost.mockResolvedValue({ localPort: 3000 })
             mockApiGet.mockResolvedValue({ ports: [] })
 
             const { usePortForward } = await import('@/composables/usePortForward')
@@ -302,7 +302,7 @@ describe('usePortForward', () => {
 
         it('passes host parameter to API and native layer in app mode', async () => {
             mockIsAppMode.value = true
-            mockApiPost.mockResolvedValue({})
+            mockApiPost.mockResolvedValue({ localPort: 3000 })
             mockApiGet.mockResolvedValue({ ports: [] })
             const mockAddForwardedPort = vi.fn()
             ;(window as any).AndroidNative = { addForwardedPort: mockAddForwardedPort }
@@ -315,7 +315,7 @@ describe('usePortForward', () => {
             expect(mockApiPost).toHaveBeenCalledWith('/api/proxy/ports', {
                 port: 3000, host: '192.168.1.1', name: 'App', protocol: 'http',
             })
-            expect(mockAddForwardedPort).toHaveBeenCalledWith(3000, '192.168.1.1')
+            expect(mockAddForwardedPort).toHaveBeenCalledWith(3000, 3000, '192.168.1.1')
 
             delete (window as any).AndroidNative
             mockIsAppMode.value = false
@@ -365,7 +365,7 @@ describe('usePortForward', () => {
             await updatePort(3000, 4000, '10.0.0.1', 'NewApp', 'https')
 
             expect(mockRemove).toHaveBeenCalledWith(3000)
-            expect(mockAdd).toHaveBeenCalledWith(4000, '10.0.0.1')
+            expect(mockAdd).toHaveBeenCalledWith(3000, 4000, '10.0.0.1')
 
             delete (window as any).AndroidNative
             mockIsAppMode.value = false
@@ -456,8 +456,8 @@ describe('usePortForward', () => {
 
             await syncToNative()
 
-            expect(mockAdd).toHaveBeenCalledWith(3000, '')
-            expect(mockAdd).toHaveBeenCalledWith(8080, '192.168.1.1')
+            expect(mockAdd).toHaveBeenCalledWith(3000, 3000, '')
+            expect(mockAdd).toHaveBeenCalledWith(8080, 8080, '192.168.1.1')
 
             delete (window as any).AndroidNative
             mockIsAppMode.value = false

--- a/web/src/composables/__tests__/usePortForward.test.ts
+++ b/web/src/composables/__tests__/usePortForward.test.ts
@@ -238,6 +238,21 @@ describe('usePortForward', () => {
             delete (window as any).AndroidNative
         })
 
+        it('passes host parameter to native sandbox browser', async () => {
+            mockIsAppMode.value = true
+            const mockOpenInSandbox = vi.fn()
+            ;(window as any).AndroidNative = { openInSandbox: mockOpenInSandbox }
+
+            const { usePortForward } = await import('@/composables/usePortForward')
+            const { openPort } = usePortForward()
+
+            openPort(3000, 'http', '192.168.1.1')
+
+            expect(mockOpenInSandbox).toHaveBeenCalledWith(3000, 'http', '192.168.1.1')
+
+            delete (window as any).AndroidNative
+        })
+
         it('falls back to openInBrowser when sandbox not available', async () => {
             mockIsAppMode.value = true
             const mockOpenInBrowser = vi.fn()
@@ -266,6 +281,22 @@ describe('usePortForward', () => {
             openInExternalBrowser(3000, 'https')
 
             expect(mockOpenInBrowser).toHaveBeenCalledWith(3000, 'https', '')
+
+            delete (window as any).AndroidNative
+            mockIsAppMode.value = false
+        })
+
+        it('passes host parameter to native openInBrowser', async () => {
+            mockIsAppMode.value = true
+            const mockOpenInBrowser = vi.fn()
+            ;(window as any).AndroidNative = { openInBrowser: mockOpenInBrowser }
+
+            const { usePortForward } = await import('@/composables/usePortForward')
+            const { openInExternalBrowser } = usePortForward()
+
+            openInExternalBrowser(3000, 'https', '192.168.1.1')
+
+            expect(mockOpenInBrowser).toHaveBeenCalledWith(3000, 'https', '192.168.1.1')
 
             delete (window as any).AndroidNative
             mockIsAppMode.value = false

--- a/web/src/composables/useLocalhostAnnotation.ts
+++ b/web/src/composables/useLocalhostAnnotation.ts
@@ -187,8 +187,8 @@ export function useLocalhostUrlClickHandler() {
         element.classList.add('loading')
 
         try {
-            await ensurePortRegistered(port, protocol)
-            openPort(port, protocol)
+            const localPort = await ensurePortRegistered(port, protocol)
+            openPort(localPort, protocol)
         } catch (err) {
             toast.show(gt('chat.localhost.openFailed'), { type: 'error' })
         } finally {

--- a/web/src/composables/usePortForward.ts
+++ b/web/src/composables/usePortForward.ts
@@ -86,10 +86,11 @@ export function usePortForward() {
   }
 
   async function registerPort(port: number, name?: string, protocol?: string, host?: string) {
-    await apiPost('/api/proxy/ports', { port, host: host || '', name: name || '', protocol: protocol || 'http' })
-    // Register with Android native layer
+    const result = await apiPost<{ localPort: number }>('/api/proxy/ports', { port, host: host || '', name: name || '', protocol: protocol || 'http' })
+    const localPort = result?.localPort ?? port
+    // Register with Android native layer: pass localPort, targetPort, host
     if (isAppMode.value) {
-      ;(window as any).AndroidNative?.addForwardedPort(port, host || '')
+      ;(window as any).AndroidNative?.addForwardedPort(localPort, port, host || '')
     }
     // Silent refresh: don't flicker the port list with loading state
     await Promise.all([loadPorts(true), loadSSHInfo()])
@@ -97,10 +98,10 @@ export function usePortForward() {
 
   async function updatePort(localPort: number, port: number, host: string, name: string, protocol: string) {
     await apiPut('/api/proxy/ports', { localPort, port, host, name, protocol })
-    // Re-sync native layer after update
+    // Re-sync native layer after update: remove old, add new with correct localPort
     if (isAppMode.value) {
       ;(window as any).AndroidNative?.removeForwardedPort(localPort)
-      ;(window as any).AndroidNative?.addForwardedPort(port, host || '')
+      ;(window as any).AndroidNative?.addForwardedPort(localPort, port, host || '')
     }
     await Promise.all([loadPorts(true), loadSSHInfo()])
   }
@@ -130,7 +131,7 @@ export function usePortForward() {
       return
     }
     for (const p of ports.value) {
-      ;(window as any).AndroidNative?.addForwardedPort(p.localPort, p.host || '')
+      ;(window as any).AndroidNative?.addForwardedPort(p.localPort, p.port, p.host || '')
     }
   }
 
@@ -367,16 +368,18 @@ export function usePortForward() {
   /**
    * Ensure a port is registered for forwarding, registering it if needed,
    * and wait for it to appear in the ports list (max 5s).
+   * Returns the localPort that was assigned (may differ from target port).
    * Used by localhost URL tag click handler to auto-setup port forwarding.
    */
-  async function ensurePortRegistered(port: number, protocol: string): Promise<void> {
-    const exists = ports.value.some(p => p.port === port)
-    if (exists) return
+  async function ensurePortRegistered(port: number, protocol: string): Promise<number> {
+    const existing = ports.value.find(p => p.port === port)
+    if (existing) return existing.localPort
     await registerPort(port, '', protocol)
     // Wait for port to appear in the list (max 5s, poll every 200ms)
     for (let i = 0; i < 25; i++) {
       await new Promise(r => setTimeout(r, 200))
-      if (ports.value.some(p => p.port === port)) return
+      const found = ports.value.find(p => p.port === port)
+      if (found) return found.localPort
     }
     throw new Error(`Port ${port} did not appear in forwarding list after 5s`)
   }

--- a/web/src/composables/usePortForward.ts
+++ b/web/src/composables/usePortForward.ts
@@ -90,6 +90,7 @@ export function usePortForward() {
     const localPort = result?.localPort ?? port
     // Register with Android native layer: pass localPort, targetPort, host
     if (isAppMode.value) {
+      console.log('[PortForward] registerPort: localPort=' + localPort + ', targetPort=' + port + ', host=' + (host || ''))
       ;(window as any).AndroidNative?.addForwardedPort(localPort, port, host || '')
     }
     // Silent refresh: don't flicker the port list with loading state
@@ -339,14 +340,16 @@ export function usePortForward() {
   }
 
   /** Open a forwarded port — in app mode opens sandbox browser, otherwise window.open */
-  function openPort(localPort: number, protocol?: string) {
+  function openPort(localPort: number, protocol?: string, host?: string) {
+    console.log('[PortForward] openPort: localPort=' + localPort + ', protocol=' + protocol + ', host=' + (host || ''))
     if (isAppMode.value) {
       const native = (window as any).AndroidNative
+      const hostArg = host || ''
       // Prefer sandbox browser (isolated process), fall back to external browser
       if (native?.openInSandbox) {
-        native.openInSandbox(localPort, protocol === 'https' ? 'https' : 'http', '')
+        native.openInSandbox(localPort, protocol === 'https' ? 'https' : 'http', hostArg)
       } else if (native?.openInBrowser) {
-        native.openInBrowser(localPort, protocol === 'https' ? 'https' : 'http', '')
+        native.openInBrowser(localPort, protocol === 'https' ? 'https' : 'http', hostArg)
       }
     } else {
       window.open(buildPortUrl(localPort, protocol), '_blank')
@@ -354,11 +357,11 @@ export function usePortForward() {
   }
 
   /** Open a forwarded port in external/system browser */
-  function openInExternalBrowser(localPort: number, protocol?: string) {
+  function openInExternalBrowser(localPort: number, protocol?: string, host?: string) {
     if (isAppMode.value) {
       const native = (window as any).AndroidNative
       if (native?.openInBrowser) {
-        native.openInBrowser(localPort, protocol === 'https' ? 'https' : 'http', '')
+        native.openInBrowser(localPort, protocol === 'https' ? 'https' : 'http', host || '')
       }
     } else {
       window.open(buildPortUrl(localPort, protocol), '_blank')

--- a/web/src/utils/__tests__/portForwardUtils.test.ts
+++ b/web/src/utils/__tests__/portForwardUtils.test.ts
@@ -83,12 +83,28 @@ describe('portForwardUtils', () => {
 
     it('handles different port numbers', () => {
       expect(buildPortUrl(8080)).toBe('http://localhost:8080')
-      expect(buildPortUrl(443, 'https')).toBe('https://localhost:443')
+      expect(buildPortUrl(443, 'https')).toBe('https://localhost')
     })
 
     it('handles different ports', () => {
       expect(buildPortUrl(8080)).toBe('http://localhost:8080')
-      expect(buildPortUrl(443, 'https')).toBe('https://localhost:443')
+      expect(buildPortUrl(443, 'https')).toBe('https://localhost')
+    })
+
+    it('omits port 80 for http (default port)', () => {
+      expect(buildPortUrl(80, 'http')).toBe('http://localhost')
+    })
+
+    it('omits port 443 for https (default port)', () => {
+      expect(buildPortUrl(443, 'https')).toBe('https://localhost')
+    })
+
+    it('keeps port 80 for https (non-default)', () => {
+      expect(buildPortUrl(80, 'https')).toBe('https://localhost:80')
+    })
+
+    it('keeps port 443 for http (non-default)', () => {
+      expect(buildPortUrl(443, 'http')).toBe('http://localhost:443')
     })
 
     it('defaults to localhost when host is empty', () => {

--- a/web/src/utils/portForwardUtils.ts
+++ b/web/src/utils/portForwardUtils.ts
@@ -35,9 +35,14 @@ export function tunnelStatusFromPorts(ports: ForwardedPort[]): 'ok' | 'degraded'
 
 /**
  * Build the URL for opening a forwarded port.
- * Always uses localhost since it's the local listening address.
+ * Uses localhost since it's the local listening address.
+ * Omits the port number when it's the default for the protocol (80 for http, 443 for https).
  */
 export function buildPortUrl(localPort: number, protocol?: string): string {
   const scheme = protocol === 'https' ? 'https' : 'http'
+  // Omit port if it's the default for the protocol
+  if ((scheme === 'http' && localPort === 80) || (scheme === 'https' && localPort === 443)) {
+    return `${scheme}://localhost`
+  }
   return `${scheme}://localhost:${localPort}`
 }


### PR DESCRIPTION
## Summary

SSH tunnel port forwarding 一系列修复和改进，涵盖后端、Android 和前端。

### 后端 (Go)
- **特权端口重映射**: `allocateLocalPort` 将 <1024 端口自动映射到 ≥1024（Android 非 root 无法绑定特权端口）
- **HTTP 反向代理**: 非 localhost 目标自动启动 `ReverseProxy` 改写 Host header
- **Host header 规范化**: `stripDefaultPort` 按 HTTP 规范省略默认端口（http :80, https :443）
- **端口分类**: `classifyPort` 识别 SSH(22)、MySQL(3306)、Redis(6379) 等非 HTTP 端口
- **端口范围**: 默认允许所有端口（1-65535），不再限制 1024-65535
- **DB 恢复**: `loadPortsFromDB` 自动启动 reverse proxy，`RegisterPort` 返回 localPort

### Android
- **BrowserActivity**: `shouldInterceptRequest` 改写 Host header（非 localhost 目标）
- **外部浏览器 URL**: `openInBrowser` 使用 localhost:localPort 而非原始 IP
- **3参数 addForwardedPort**: localPort + targetPort + host
- **AppLog 日志**: 替换所有 `android.util.Log`
- **隧道重试**: 连接失败自动重试 5 次

### 前端 (Vue 3)
- **两段式布局**: 上半区已添加端口（50-100%），下半区扫描端口（0-50% 贴底），各自独立滚动
- **端口扫描不自动打开**: 扫描端口只注册不打开 WebView，仅聊天 URL 点击自动打开
- **localPort 透传**: 前端使用后端返回的 localPort 而非 targetPort

### 测试
- Go: classifyPort、isNonLocalhostTarget、reverse proxy 启停、特权端口重映射、loadPortsFromDB
- Frontend: openPort/openInExternalBrowser host 参数、registerPort 3 参数
- CI coverage gate: Go 80.6%, Frontend 89.5%