### PR TITLE
fix: 快捷发送/快捷命令编辑弹窗消息内容改为多行文本框

### DIFF
--- a/web/src/components/__tests__/quickSendEditModal.test.ts
+++ b/web/src/components/__tests__/quickSendEditModal.test.ts
@@ -1,0 +1,200 @@
+import { describe, expect, it, vi, beforeEach } from 'vitest'
+import { mount } from '@vue/test-utils'
+import { nextTick } from 'vue'
+import { createI18n } from 'vue-i18n'
+import QuickSendEditModal from '@/components/chat/QuickSendEditModal.vue'
+
+// ── Mocks ────────────────────────────────────────────────────
+const mockAddItem = vi.fn()
+const mockUpdateItem = vi.fn()
+const mockToastShow = vi.fn()
+
+vi.mock('@/composables/useQuickSend', () => ({
+  useQuickSend: () => ({
+    addItem: mockAddItem,
+    updateItem: mockUpdateItem,
+  }),
+}))
+
+vi.mock('@/composables/useToast', () => ({
+  useToast: () => ({ show: mockToastShow }),
+}))
+
+vi.mock('@/utils/quickSendValidation', () => ({
+  validateQuickSendForm: (form: { label: string; command: string }) => {
+    if (!form.label.trim() || !form.command.trim()) return 'chat.quickSend.itemRequired'
+    return ''
+  },
+}))
+
+// ── i18n ─────────────────────────────────────────────────────
+const i18n = createI18n({
+  legacy: false,
+  locale: 'zh',
+  messages: {
+    zh: {
+      chat: {
+        quickSend: {
+          addItem: '添加',
+          editItem: '编辑',
+          itemLabel: '标签',
+          itemCommand: '命令',
+          itemRequired: '必填',
+          itemSaved: '已保存',
+          saveFailed: '保存失败',
+        },
+      },
+      common: { cancel: '取消', save: '保存' },
+    },
+  },
+})
+
+beforeEach(() => {
+  mockAddItem.mockReset()
+  mockUpdateItem.mockReset()
+  mockToastShow.mockReset()
+})
+
+function mountModal(props = {}) {
+  return mount(QuickSendEditModal, {
+    props: {
+      open: true,
+      editingItem: null,
+      ...props,
+    },
+    global: {
+      stubs: { teleport: true },
+      plugins: [i18n],
+    },
+  })
+}
+
+// ── Tests ─────────────────────────────────────────────────────
+
+describe('QuickSendEditModal', () => {
+  describe('rendering', () => {
+    it('renders label input and command textarea when open', () => {
+      const wrapper = mountModal()
+
+      expect(wrapper.find('input.form-input').exists()).toBe(true)
+      expect(wrapper.find('textarea.form-input.form-textarea').exists()).toBe(true)
+    })
+
+    it('renders textarea with rows=4 for command field', () => {
+      const wrapper = mountModal()
+
+      const textarea = wrapper.find('textarea.form-textarea')
+      expect(textarea.exists()).toBe(true)
+      expect(textarea.attributes('rows')).toBe('4')
+    })
+
+    it('shows add title when no editingItem', () => {
+      const wrapper = mountModal()
+
+      expect(wrapper.find('.modal-title').text()).toBeTruthy()
+    })
+
+    it('shows edit title when editingItem is provided', async () => {
+      const wrapper = mountModal({
+        editingItem: { id: 1, label: '继续', command: '请继续', sort_order: 0 },
+      })
+      await nextTick()
+
+      expect(wrapper.find('.modal-title').text()).toBeTruthy()
+    })
+  })
+
+  describe('form behavior', () => {
+    it('pre-fills form when editingItem is provided', async () => {
+      // Mount closed, then open — watch triggers on open change
+      const wrapper = mount(QuickSendEditModal, {
+        props: { open: false, editingItem: null },
+        global: { stubs: { teleport: true }, plugins: [i18n] },
+      })
+      await wrapper.setProps({ open: true, editingItem: { id: 1, label: '继续', command: '请继续', sort_order: 0 } })
+      await nextTick()
+
+      expect(wrapper.find('input.form-input').element.value).toBe('继续')
+      expect(wrapper.find('textarea.form-textarea').element.value).toBe('请继续')
+    })
+
+    it('resets form when dialog opens with no editingItem', async () => {
+      const wrapper = mountModal()
+      await nextTick()
+
+      expect(wrapper.find('input.form-input').element.value).toBe('')
+      expect(wrapper.find('textarea.form-textarea').element.value).toBe('')
+    })
+
+    it('shows validation error when saving with empty fields', async () => {
+      const wrapper = mountModal()
+
+      await wrapper.find('.modal-btn.primary').trigger('click')
+      await nextTick()
+
+      expect(wrapper.find('.form-error').exists()).toBe(true)
+    })
+
+    it('calls addItem when saving new item', async () => {
+      mockAddItem.mockResolvedValue(true)
+      const wrapper = mountModal()
+
+      await wrapper.find('input.form-input').setValue('继续')
+      await wrapper.find('textarea.form-textarea').setValue('请继续执行')
+      await wrapper.find('.modal-btn.primary').trigger('click')
+      await nextTick()
+
+      expect(mockAddItem).toHaveBeenCalledWith({ label: '继续', command: '请继续执行' })
+    })
+
+    it('calls updateItem when saving edited item', async () => {
+      mockUpdateItem.mockResolvedValue(true)
+      // Mount closed, then open with editingItem
+      const wrapper = mount(QuickSendEditModal, {
+        props: { open: false, editingItem: null },
+        global: { stubs: { teleport: true }, plugins: [i18n] },
+      })
+      await wrapper.setProps({ open: true, editingItem: { id: 5, label: '继续', command: '继续', sort_order: 0 } })
+      await nextTick()
+
+      await wrapper.find('textarea.form-textarea').setValue('请继续')
+      await wrapper.find('.modal-btn.primary').trigger('click')
+      await nextTick()
+
+      expect(mockUpdateItem).toHaveBeenCalledWith(5, expect.objectContaining({ command: '请继续' }))
+    })
+
+    it('emits saved on successful save', async () => {
+      mockAddItem.mockResolvedValue(true)
+      const wrapper = mountModal()
+
+      await wrapper.find('input.form-input').setValue('继续')
+      await wrapper.find('textarea.form-textarea').setValue('继续')
+      await wrapper.find('.modal-btn.primary').trigger('click')
+      await nextTick()
+
+      expect(wrapper.emitted('saved')).toBeTruthy()
+    })
+
+    it('shows error when save API fails', async () => {
+      mockAddItem.mockResolvedValue(false)
+      const wrapper = mountModal()
+
+      await wrapper.find('input.form-input').setValue('继续')
+      await wrapper.find('textarea.form-textarea').setValue('继续')
+      await wrapper.find('.modal-btn.primary').trigger('click')
+      await nextTick()
+
+      expect(wrapper.find('.form-error').exists()).toBe(true)
+      expect(wrapper.emitted('saved')).toBeFalsy()
+    })
+
+    it('emits close when cancel button is clicked', async () => {
+      const wrapper = mountModal()
+
+      await wrapper.find('.modal-btn:not(.primary)').trigger('click')
+
+      expect(wrapper.emitted('close')).toBeTruthy()
+    })
+  })
+})

--- a/web/src/components/chat/QuickSendEditModal.vue
+++ b/web/src/components/chat/QuickSendEditModal.vue
@@ -15,7 +15,7 @@
       </div>
       <div class="form-group">
         <label class="form-label">{{ t('chat.quickSend.itemCommand') }} <span class="required">*</span></label>
-        <input type="text" class="form-input" v-model="form.command" :placeholder="t('chat.quickSend.itemCommand')" />
+        <textarea class="form-input form-textarea" v-model="form.command" :placeholder="t('chat.quickSend.itemCommand')" rows="4" />
       </div>
       <div v-if="formError" class="form-error">{{ formError }}</div>
     </div>
@@ -134,6 +134,13 @@ async function saveItem() {
 
 .form-input:focus {
   border-color: var(--accent-color, #0066cc);
+}
+
+.form-textarea {
+  resize: vertical;
+  min-height: 80px;
+  line-height: 1.5;
+  font-family: inherit;
 }
 
 .form-error {

--- a/web/src/components/terminal/QuickCommandEditModal.vue
+++ b/web/src/components/terminal/QuickCommandEditModal.vue
@@ -15,7 +15,7 @@
       </div>
       <div class="form-group">
         <label class="form-label">{{ t('terminal.commandText') }} <span class="required">*</span></label>
-        <input type="text" class="form-input" v-model="form.command" :placeholder="t('terminal.commandText')" />
+        <textarea class="form-input form-textarea" v-model="form.command" :placeholder="t('terminal.commandText')" rows="4" />
       </div>
       <div v-if="formError" class="form-error">{{ formError }}</div>
 
@@ -155,6 +155,13 @@ async function saveCommand() {
 
 .form-input:focus {
   border-color: var(--accent-color, #0066cc);
+}
+
+.form-textarea {
+  resize: vertical;
+  min-height: 80px;
+  line-height: 1.5;
+  font-family: inherit;
 }
 
 .form-error {

--- a/web/src/components/terminal/__tests__/QuickCommandEditModal.test.ts
+++ b/web/src/components/terminal/__tests__/QuickCommandEditModal.test.ts
@@ -1,0 +1,223 @@
+import { describe, expect, it, vi, beforeEach } from 'vitest'
+import { mount } from '@vue/test-utils'
+import { nextTick, ref } from 'vue'
+import { createI18n } from 'vue-i18n'
+import QuickCommandEditModal from '@/components/terminal/QuickCommandEditModal.vue'
+
+// ── Mocks ────────────────────────────────────────────────────
+const mockAddCommand = vi.fn()
+const mockUpdateCommand = vi.fn()
+const mockToastShow = vi.fn()
+
+// Module-level ref shared across instances
+const mockCommandsRef = ref<any[]>([])
+
+vi.mock('@/composables/useQuickCommands', () => ({
+  useQuickCommands: () => ({
+    commands: mockCommandsRef,
+    addCommand: mockAddCommand,
+    updateCommand: mockUpdateCommand,
+  }),
+}))
+
+vi.mock('@/composables/useToast', () => ({
+  useToast: () => ({ show: mockToastShow }),
+}))
+
+// ── i18n ─────────────────────────────────────────────────────
+const i18n = createI18n({
+  legacy: false,
+  locale: 'zh',
+  messages: {
+    zh: {
+      terminal: {
+        addCommand: '添加命令',
+        editCommand: '编辑命令',
+        commandLabel: '标签',
+        commandText: '命令',
+        commandHidden: '隐藏',
+        commandAutoExecute: '自动执行',
+        commandRequired: '必填',
+        commandSaved: '已保存',
+        saveFailed: '保存失败',
+        autoExecuteWarning: '已有自动执行命令',
+      },
+      common: { cancel: '取消', save: '保存' },
+    },
+  },
+})
+
+beforeEach(() => {
+  mockAddCommand.mockReset()
+  mockUpdateCommand.mockReset()
+  mockToastShow.mockReset()
+  mockCommandsRef.value = []
+})
+
+function mountModal(props = {}) {
+  return mount(QuickCommandEditModal, {
+    props: {
+      open: true,
+      editingCommand: null,
+      ...props,
+    },
+    global: {
+      stubs: { teleport: true },
+      plugins: [i18n],
+    },
+  })
+}
+
+// ── Tests ─────────────────────────────────────────────────────
+
+describe('QuickCommandEditModal', () => {
+  describe('rendering', () => {
+    it('renders label input and command textarea when open', () => {
+      const wrapper = mountModal()
+
+      expect(wrapper.find('input.form-input').exists()).toBe(true)
+      expect(wrapper.find('textarea.form-input.form-textarea').exists()).toBe(true)
+    })
+
+    it('renders textarea with rows=4 for command field', () => {
+      const wrapper = mountModal()
+
+      const textarea = wrapper.find('textarea.form-textarea')
+      expect(textarea.exists()).toBe(true)
+      expect(textarea.attributes('rows')).toBe('4')
+    })
+
+    it('renders hidden and auto_execute checkboxes', () => {
+      const wrapper = mountModal()
+
+      const checkboxes = wrapper.findAll('input[type="checkbox"]')
+      expect(checkboxes).toHaveLength(2)
+    })
+
+    it('does not show auto-execute warning when no existing auto-exec command', () => {
+      const wrapper = mountModal()
+
+      expect(wrapper.find('.form-hint').exists()).toBe(false)
+    })
+  })
+
+  describe('form behavior', () => {
+    it('pre-fills form when editingCommand is provided', async () => {
+      // Mount closed, then open — watch triggers on open change
+      const wrapper = mount(QuickCommandEditModal, {
+        props: { open: false, editingCommand: null },
+        global: { stubs: { teleport: true }, plugins: [i18n] },
+      })
+      await wrapper.setProps({
+        open: true,
+        editingCommand: {
+          id: 1, label: 'ls', command: 'ls -la', hidden: true, auto_execute: false, sort_order: 0,
+        },
+      })
+      await nextTick()
+
+      expect(wrapper.find('input.form-input').element.value).toBe('ls')
+      expect(wrapper.find('textarea.form-textarea').element.value).toBe('ls -la')
+    })
+
+    it('resets form when dialog opens with no editingCommand', async () => {
+      const wrapper = mountModal()
+      await nextTick()
+
+      expect(wrapper.find('input.form-input').element.value).toBe('')
+      expect(wrapper.find('textarea.form-textarea').element.value).toBe('')
+    })
+
+    it('shows validation error when saving with empty fields', async () => {
+      const wrapper = mountModal()
+
+      await wrapper.find('.modal-btn.primary').trigger('click')
+      await nextTick()
+
+      expect(wrapper.find('.form-error').exists()).toBe(true)
+    })
+
+    it('calls addCommand when saving new command', async () => {
+      mockAddCommand.mockResolvedValue(true)
+      const wrapper = mountModal()
+
+      await wrapper.find('input.form-input').setValue('grep')
+      await wrapper.find('textarea.form-textarea').setValue('grep -r "test" .')
+      await wrapper.find('.modal-btn.primary').trigger('click')
+      await nextTick()
+
+      expect(mockAddCommand).toHaveBeenCalledWith(
+        expect.objectContaining({ label: 'grep', command: 'grep -r "test" .' }),
+      )
+    })
+
+    it('calls updateCommand when saving edited command', async () => {
+      mockUpdateCommand.mockResolvedValue(true)
+      // Mount closed, then open with editingCommand
+      const wrapper = mount(QuickCommandEditModal, {
+        props: { open: false, editingCommand: null },
+        global: { stubs: { teleport: true }, plugins: [i18n] },
+      })
+      await wrapper.setProps({
+        open: true,
+        editingCommand: {
+          id: 3, label: 'ls', command: 'ls', hidden: false, auto_execute: false, sort_order: 0,
+        },
+      })
+      await nextTick()
+
+      await wrapper.find('textarea.form-textarea').setValue('ls -la')
+      await wrapper.find('.modal-btn.primary').trigger('click')
+      await nextTick()
+
+      expect(mockUpdateCommand).toHaveBeenCalledWith(3, expect.objectContaining({ command: 'ls -la' }))
+    })
+
+    it('emits saved on successful save', async () => {
+      mockAddCommand.mockResolvedValue(true)
+      const wrapper = mountModal()
+
+      await wrapper.find('input.form-input').setValue('ls')
+      await wrapper.find('textarea.form-textarea').setValue('ls')
+      await wrapper.find('.modal-btn.primary').trigger('click')
+      await nextTick()
+
+      expect(wrapper.emitted('saved')).toBeTruthy()
+    })
+
+    it('shows error when save API fails', async () => {
+      mockAddCommand.mockResolvedValue(false)
+      const wrapper = mountModal()
+
+      await wrapper.find('input.form-input').setValue('ls')
+      await wrapper.find('textarea.form-textarea').setValue('ls')
+      await wrapper.find('.modal-btn.primary').trigger('click')
+      await nextTick()
+
+      expect(wrapper.find('.form-error').exists()).toBe(true)
+      expect(wrapper.emitted('saved')).toBeFalsy()
+    })
+
+    it('emits close when cancel button is clicked', async () => {
+      const wrapper = mountModal()
+
+      await wrapper.find('.modal-btn:not(.primary)').trigger('click')
+
+      expect(wrapper.emitted('close')).toBeTruthy()
+    })
+
+    it('shows auto-execute warning when another command has auto_execute', async () => {
+      mockCommandsRef.value = [
+        { id: 1, label: 'cd', command: 'cd ~', hidden: false, auto_execute: true, sort_order: 0 },
+      ]
+      const wrapper = mountModal()
+
+      // Check the auto_execute checkbox (second checkbox)
+      const checkboxes = wrapper.findAll('input[type="checkbox"]')
+      await checkboxes[1].setValue(true)
+      await nextTick()
+
+      expect(wrapper.find('.form-hint').exists()).toBe(true)
+    })
+  })
+})


### PR DESCRIPTION
## 变更

将快捷发送和终端快捷命令的编辑弹窗中「消息/命令内容」字段从单行 `<input>` 改为多行 `<textarea rows=4>`。

### 改动
- `QuickSendEditModal.vue`: command 字段 → textarea (rows=4)，新增 form-textarea 样式
- `QuickCommandEditModal.vue`: command 字段 → textarea (rows=4)，新增 form-textarea 样式
- 新增两个组件的渲染测试（quickSendEditModal.test.ts, QuickCommandEditModal.test.ts）

### 效果
- 多行内容可以完整显示，不再被截断
- textarea 支持上下拖动调整高度（resize: vertical, min-height: 80px）