### PR TITLE
feat(chat): add swipe session toggle setting (default off)

### DIFF
--- a/web/src/components/settings/__tests__/SettingsCategory.test.ts
+++ b/web/src/components/settings/__tests__/SettingsCategory.test.ts
@@ -24,6 +24,7 @@ const localConfig = reactive<Record<string, any>>({
   fileView: 'list',
   terminalFontSize: 12,
   androidLogCapture: false,
+  swipeSession: false,
 })
 
 const serverConfig = ref<Record<string, any>>({
@@ -101,6 +102,7 @@ const i18n = createI18n({
         items: {
           defaultAgent: '默认智能体',
           autoSpeech: '自动语音',
+          swipeSession: '滑动切换会话',
           chatInitialMessages: '初始消息数',
           chatPageSize: '每页消息数',
           chatCollapsedHeight: '折叠高度',
@@ -234,6 +236,26 @@ describe('SettingsCategory', () => {
       await wrapper.vm.$nextTick()
 
       expect(mockSetLocalConfig).toHaveBeenCalledWith('autoSpeech', true)
+    })
+
+    it('renders swipeSession as switch item', () => {
+      const wrapper = mountCategory('chat')
+      const allItems = wrapper.findAllComponents({ name: 'SettingsItem' })
+      const swipeSessionItem = allItems.find(i => i.props().label === '滑动切换会话')
+      expect(swipeSessionItem).toBeTruthy()
+      expect(swipeSessionItem!.props().type).toBe('switch')
+    })
+
+    it('saves swipeSession locally when toggled', async () => {
+      const wrapper = mountCategory('chat')
+      const allItems = wrapper.findAllComponents({ name: 'SettingsItem' })
+      const swipeSessionItem = allItems.find(i => i.props().label === '滑动切换会话')
+      expect(swipeSessionItem).toBeTruthy()
+
+      await swipeSessionItem!.vm.$emit('update:modelValue', true)
+      await wrapper.vm.$nextTick()
+
+      expect(mockSetLocalConfig).toHaveBeenCalledWith('swipeSession', true)
     })
 
     it('PATCHes chat.initial_messages when number changed', async () => {

--- a/web/src/components/settings/__tests__/settingsFieldMap.test.ts
+++ b/web/src/components/settings/__tests__/settingsFieldMap.test.ts
@@ -31,6 +31,7 @@ describe('settingsFieldMap', () => {
     expect(map['theme']).toBeUndefined()
     expect(map['locale']).toBeUndefined()
     expect(map['autoSpeech']).toBeUndefined()
+    expect(map['swipeSession']).toBeUndefined()
   })
 
   it('includes TTS sub-config keys', () => {

--- a/web/src/components/settings/settingsFieldMap.ts
+++ b/web/src/components/settings/settingsFieldMap.ts
@@ -49,6 +49,7 @@ export const categoryItems: Record<string, ItemSpec[]> = {
   chat: [
     { labelKey: 'settings.items.defaultAgent', descriptionKey: 'settings.items.defaultAgentDesc', key: 'default_agent', type: 'select', source: 'server', needsRestart: true },
     { labelKey: 'settings.items.autoSpeech', descriptionKey: 'settings.items.autoSpeechDesc', key: 'autoSpeech', type: 'switch', source: 'local' },
+    { labelKey: 'settings.items.swipeSession', descriptionKey: 'settings.items.swipeSessionDesc', key: 'swipeSession', type: 'switch', source: 'local' },
     { labelKey: 'settings.items.chatInitialMessages', descriptionKey: 'settings.items.chatInitialMessagesDesc', key: 'chat.initial_messages', type: 'number', source: 'server' },
     { labelKey: 'settings.items.chatPageSize', descriptionKey: 'settings.items.chatPageSizeDesc', key: 'chat.page_size', type: 'number', source: 'server' },
     { labelKey: 'settings.items.chatCollapsedHeight', descriptionKey: 'settings.items.chatCollapsedHeightDesc', key: 'chat.collapsed_height', type: 'number', source: 'server' },

--- a/web/src/composables/__tests__/useSettingsConfig.test.ts
+++ b/web/src/composables/__tests__/useSettingsConfig.test.ts
@@ -125,6 +125,7 @@ describe('useSettingsConfig', () => {
     expect('fileView' in localConfig).toBe(true)
     expect('terminalFontSize' in localConfig).toBe(true)
     expect('androidLogCapture' in localConfig).toBe(true)
+    expect('swipeSession' in localConfig).toBe(true)
   })
 
   it('reads persisted localStorage value via setLocalConfig', () => {

--- a/web/src/composables/__tests__/useSwipeSession.test.ts
+++ b/web/src/composables/__tests__/useSwipeSession.test.ts
@@ -1,4 +1,102 @@
-import { describe, expect, it } from 'vitest'
+import { describe, expect, it, vi, beforeEach, afterEach } from 'vitest'
+import { reactive, ref } from 'vue'
+
+// ── swipeSession disabled guard ──
+// Tests that the composable's touch handlers respect the swipeSession local setting.
+
+// We must import localConfig and the composable after setting up the mock,
+// so we use dynamic import inside the describe block.
+
+describe('useSwipeSession disabled guard', () => {
+  let localConfig: Record<string, any>
+  let useSwipeSession: typeof import('@/composables/useSwipeSession')['useSwipeSession']
+
+  beforeEach(async () => {
+    // Reset module cache so we get fresh localConfig state
+    vi.resetModules()
+    // Clear localStorage to ensure predictable defaults
+    localStorage.clear()
+    const mod = await import('@/composables/useSwipeSession')
+    useSwipeSession = mod.useSwipeSession
+    const configMod = await import('@/composables/useSettingsConfig')
+    localConfig = configMod.localConfig
+  })
+
+  afterEach(() => {
+    localStorage.clear()
+  })
+
+  function createTouchEvent(type: 'touchstart' | 'touchend', clientX: number, clientY: number): TouchEvent {
+    const touch = { clientX, clientY } as Touch
+    const event = {
+      touches: type === 'touchstart' ? [touch] : [],
+      changedTouches: type === 'touchend' ? [touch] : [],
+      target: document.createElement('div'),
+      currentTarget: document.createElement('div'),
+    } as unknown as TouchEvent
+    return event
+  }
+
+  it('does not trigger session switch when swipeSession is false (default)', async () => {
+    // Default is false
+    expect(localConfig.swipeSession).toBe(false)
+
+    const switchSession = vi.fn().mockResolvedValue(undefined)
+    const currentSessionId = ref('session-1')
+
+    const { onTouchStart, onTouchEnd, indicatorText } = useSwipeSession({
+      currentSessionId,
+      switchSession,
+    })
+
+    // Simulate a left swipe that would normally switch sessions
+    const startEvent = createTouchEvent('touchstart', 200, 100)
+    onTouchStart(startEvent)
+
+    const endEvent = createTouchEvent('touchend', 50, 100)
+    onTouchEnd(endEvent)
+
+    // switchSession should NOT have been called because swipeSession is disabled
+    expect(switchSession).not.toHaveBeenCalled()
+    // indicator should remain empty
+    expect(indicatorText.value).toBe('')
+  })
+
+  it('triggers session switch when swipeSession is true', async () => {
+    localConfig.swipeSession = true
+
+    // Mock the sessions API
+    const fetchSpy = vi.spyOn(globalThis, 'fetch').mockResolvedValue({
+      ok: true,
+      json: () => Promise.resolve({ sessions: [{ id: 'session-1', title: 'S1' }, { id: 'session-2', title: 'S2' }] }),
+    } as Response)
+
+    const switchSession = vi.fn().mockResolvedValue(undefined)
+    const currentSessionId = ref('session-2')
+
+    const { onTouchStart, onTouchEnd, indicatorText } = useSwipeSession({
+      currentSessionId,
+      switchSession,
+    })
+
+    // Simulate a left swipe (next session)
+    const startEvent = createTouchEvent('touchstart', 200, 100)
+    onTouchStart(startEvent)
+
+    const endEvent = createTouchEvent('touchend', 50, 100)
+    onTouchEnd(endEvent)
+
+    // Wait for async operations
+    await vi.waitFor(() => {
+      expect(switchSession).toHaveBeenCalled()
+    })
+
+    // Indicator should show the target session title
+    expect(indicatorText.value).toBeTruthy()
+
+    fetchSpy.mockRestore()
+  })
+})
 
 /**
  * Pure swipe classification logic — extracted for testability.

--- a/web/src/composables/useSettingsConfig.ts
+++ b/web/src/composables/useSettingsConfig.ts
@@ -124,6 +124,9 @@ const legacyKeys: Record<string, {
   androidLogCapture: {
     // No legacy key — this is a new setting
   },
+  swipeSession: {
+    // No legacy key — this is a new setting
+  },
 }
 
 /** Read initial value from prefixed key (falls back to legacy key, then default) */
@@ -167,6 +170,7 @@ const localDefaults: Record<string, any> = {
   fileView: 'list',
   terminalFontSize: 12,
   androidLogCapture: false,
+  swipeSession: false,
 }
 
 // Build reactive local config from legacy localStorage + defaults

--- a/web/src/composables/useSwipeSession.ts
+++ b/web/src/composables/useSwipeSession.ts
@@ -1,5 +1,6 @@
 import { ref, type Ref } from 'vue'
 import { gt } from '@/composables/useLocale'
+import { localConfig } from '@/composables/useSettingsConfig'
 
 export interface UseSwipeSessionOptions {
   currentSessionId: Ref<string>
@@ -112,6 +113,7 @@ export function useSwipeSession(options: UseSwipeSessionOptions) {
   }
 
   function onTouchStart(e: TouchEvent) {
+    if (!localConfig.swipeSession) return
     const touch = e.touches[0]
     touchStartX = touch.clientX
     touchStartY = touch.clientY
@@ -120,6 +122,7 @@ export function useSwipeSession(options: UseSwipeSessionOptions) {
   }
 
   function onTouchEnd(e: TouchEvent) {
+    if (!localConfig.swipeSession) return
     if (touchInsideScrollable) return
 
     const touch = e.changedTouches[0]

--- a/web/src/i18n/locales/en.ts
+++ b/web/src/i18n/locales/en.ts
@@ -792,6 +792,8 @@ export default {
       localeEn: 'English',
       autoSpeech: 'Auto Speech',
       autoSpeechDesc: 'Automatically read aloud AI responses',
+      swipeSession: 'Swipe to Switch Session',
+      swipeSessionDesc: 'Swipe left/right in the chat area to switch to the previous/next session',
       defaultAgent: 'Default Agent',
       defaultAgentDesc: 'AI agent used by default when starting a new chat',
       agentModel: 'Preferred Model',

--- a/web/src/i18n/locales/zh.ts
+++ b/web/src/i18n/locales/zh.ts
@@ -792,6 +792,8 @@ export default {
       localeEn: 'English',
       autoSpeech: '自动语音',
       autoSpeechDesc: 'AI 回复完成后自动朗读',
+      swipeSession: '滑动切换会话',
+      swipeSessionDesc: '在聊天区域左右滑动切换到上/下一个会话',
       defaultAgent: '默认智能体',
       defaultAgentDesc: '新建聊天时默认使用的 AI 智能体',
       agentModel: '首选模型',


### PR DESCRIPTION
## Summary

Closes #54

Add a "Swipe to Switch Session" toggle in **Settings → Chat**, defaulting to **disabled**. When off, left/right swipe gestures in the chat area no longer trigger session switching, fixing accidental switches when scrolling wide content (code blocks, tables).

## Changes

- Add `swipeSession` local config (default: `false`) in `useSettingsConfig`
- Add `swipeSession` switch item in chat settings category (`settingsFieldMap`)
- Guard `onTouchStart`/`onTouchEnd` with `localConfig.swipeSession` check in `useSwipeSession`
- Add i18n labels for zh/en
- Add integration tests for disabled/enabled behavior
- Add SettingsCategory tests for swipeSession toggle

## Testing

- All 2972 frontend tests pass
- Coverage gate: Tier 1 PASS, Tier 2 Diff 100% (7/7)
- `useSwipeSession` disabled guard verified: touch handlers skip when setting is off
- Settings UI: toggle renders and persists correctly via localStorage