### PR TITLE
fix: annotation false positives + code block annotations (Issue #50)

### DIFF
--- a/Dockerfile.build
+++ b/Dockerfile.build
@@ -1,0 +1,17 @@
+# Ubuntu 22.04 builder — produces GLIBC 2.35 compatible binary
+# (Ubuntu apt mirrors are fast in China; Rocky Linux dnf is very slow)
+# Usage:
+#   docker build -t clawbench-builder -f Dockerfile.build .
+#   docker run --rm -v $(pwd):/src -w /src clawbench-builder ./build.sh --linux
+FROM ubuntu:22.04
+
+ENV DEBIAN_FRONTEND=noninteractive
+
+# Install build tools (cached layer)
+RUN apt-get update && apt-get install -y gcc g++ make git curl && rm -rf /var/lib/apt/lists/*
+
+# Install Go (cached layer)
+RUN curl -sL https://go.dev/dl/go1.26.1.linux-amd64.tar.gz | tar -C /usr/local -xz
+ENV PATH=$PATH:/usr/local/go/bin
+
+WORKDIR /src

--- a/internal/handler/file.go
+++ b/internal/handler/file.go
@@ -368,6 +368,74 @@ func ServeProjects(w http.ResponseWriter, r *http.Request) {
 	})
 }
 
+// containsGlobChars returns true if the path contains characters that are
+// invalid in filesystem paths (glob wildcards, angle brackets, double-star).
+// These characters indicate the string is a glob pattern or template variable,
+// not a real file path.
+func containsGlobChars(path string) bool {
+	return strings.ContainsAny(path, "*?[]<>") || strings.Contains(path, "**")
+}
+
+// ServeFileBatchExists handles POST /api/file/batch-exists
+// Body:   { "paths": ["src/main.go", "lib/", "**/*.class"] }
+// Response: { "results": { "src/main.go": "file", "lib": "dir", "**/*.class": "none" } }
+// Each path is checked against the project directory. Paths containing glob
+// characters are short-circuited to "none" without touching the filesystem.
+func ServeFileBatchExists(w http.ResponseWriter, r *http.Request) {
+	if !requireMethod(w, r, http.MethodPost) {
+		return
+	}
+
+	var req struct {
+		Paths []string `json:"paths"`
+	}
+	if !decodeJSON(w, r, &req) {
+		return
+	}
+	if len(req.Paths) == 0 {
+		writeLocalizedErrorf(w, r, http.StatusBadRequest, "MissingPath")
+		return
+	}
+	if len(req.Paths) > 100 {
+		writeLocalizedErrorf(w, r, http.StatusBadRequest, "TooManyPaths")
+		return
+	}
+
+	projectPath, ok := requireProject(w, r)
+	if !ok {
+		return
+	}
+	baseAbs, err := filepath.Abs(projectPath)
+	if err != nil {
+		model.WriteError(w, model.Internal(err))
+		return
+	}
+
+	results := make(map[string]string, len(req.Paths))
+	for _, p := range req.Paths {
+		// Short-circuit glob patterns and template variables
+		if containsGlobChars(p) {
+			results[p] = "none"
+			continue
+		}
+		absPath, ok := model.ValidatePath(baseAbs, p)
+		if !ok {
+			results[p] = "none"
+			continue
+		}
+		info, err := os.Stat(absPath)
+		if err != nil {
+			results[p] = "none"
+		} else if info.IsDir() {
+			results[p] = "dir"
+		} else {
+			results[p] = "file"
+		}
+	}
+
+	writeJSON(w, http.StatusOK, map[string]interface{}{"results": results})
+}
+
 // ── File-related DTOs ──────────────────────────────────────────────────────────
 
 // DirEntry represents a directory entry in API responses

--- a/internal/handler/file_test.go
+++ b/internal/handler/file_test.go
@@ -549,4 +549,51 @@ func TestServeFileBatchExists(t *testing.T) {
 		w := callHandler(ServeFileBatchExists, req)
 		assertStatus(t, w, http.StatusBadRequest)
 	})
+
+	t.Run("WrongMethod_GET_Returns405", func(t *testing.T) {
+		env, teardown := setupTestEnv(t)
+		defer teardown()
+
+		req := newRequest(t, http.MethodGet, "/api/file/batch-exists", nil)
+		withProjectCookie(req, env.ProjectDir)
+
+		w := callHandler(ServeFileBatchExists, req)
+		assertStatus(t, w, http.StatusMethodNotAllowed)
+	})
+
+	t.Run("InvalidJSON_Returns400", func(t *testing.T) {
+		env, teardown := setupTestEnv(t)
+		defer teardown()
+
+		req := newRequest(t, http.MethodPost, "/api/file/batch-exists", "not-json")
+		withProjectCookie(req, env.ProjectDir)
+
+		w := callHandler(ServeFileBatchExists, req)
+		assertStatus(t, w, http.StatusBadRequest)
+	})
+
+	t.Run("ContainsGlobChars_ShortCircuit", func(t *testing.T) {
+		env, teardown := setupTestEnv(t)
+		defer teardown()
+
+		// Create a file that would match if glob chars weren't filtered
+		createTestFile(t, env.ProjectDir, "test.class", "class data")
+
+		req := newRequest(t, http.MethodPost, "/api/file/batch-exists", map[string]interface{}{
+			"paths": []string{"*.class", "test.class"},
+		})
+		withProjectCookie(req, env.ProjectDir)
+
+		w := callHandler(ServeFileBatchExists, req)
+		assertOK(t, w)
+
+		var result map[string]interface{}
+		err := json.Unmarshal(w.Body.Bytes(), &result)
+		assert.NoError(t, err)
+
+		results, ok := result["results"].(map[string]interface{})
+		assert.True(t, ok)
+		assert.Equal(t, "none", results["*.class"])   // glob → none (no os.Stat)
+		assert.Equal(t, "file", results["test.class"]) // real path → file
+	})
 }

--- a/internal/handler/file_test.go
+++ b/internal/handler/file_test.go
@@ -366,3 +366,187 @@ func TestServeProjects(t *testing.T) {
 		assert.Equal(t, "dir", entry["type"])
 	})
 }
+
+func TestServeFileBatchExists(t *testing.T) {
+	t.Run("ExistingFile_ReturnsFile", func(t *testing.T) {
+		env, teardown := setupTestEnv(t)
+		defer teardown()
+
+		createTestFile(t, env.ProjectDir, "src/main.go", "package main")
+
+		req := newRequest(t, http.MethodPost, "/api/file/batch-exists", map[string]interface{}{
+			"paths": []string{"src/main.go"},
+		})
+		withProjectCookie(req, env.ProjectDir)
+
+		w := callHandler(ServeFileBatchExists, req)
+		assertOK(t, w)
+
+		var result map[string]interface{}
+		err := json.Unmarshal(w.Body.Bytes(), &result)
+		assert.NoError(t, err)
+
+		results, ok := result["results"].(map[string]interface{})
+		assert.True(t, ok)
+		assert.Equal(t, "file", results["src/main.go"])
+	})
+
+	t.Run("ExistingDirectory_ReturnsDir", func(t *testing.T) {
+		env, teardown := setupTestEnv(t)
+		defer teardown()
+
+		os.MkdirAll(filepath.Join(env.ProjectDir, "src"), 0755)
+
+		req := newRequest(t, http.MethodPost, "/api/file/batch-exists", map[string]interface{}{
+			"paths": []string{"src"},
+		})
+		withProjectCookie(req, env.ProjectDir)
+
+		w := callHandler(ServeFileBatchExists, req)
+		assertOK(t, w)
+
+		var result map[string]interface{}
+		err := json.Unmarshal(w.Body.Bytes(), &result)
+		assert.NoError(t, err)
+
+		results, ok := result["results"].(map[string]interface{})
+		assert.True(t, ok)
+		assert.Equal(t, "dir", results["src"])
+	})
+
+	t.Run("NonExistentPath_ReturnsNone", func(t *testing.T) {
+		env, teardown := setupTestEnv(t)
+		defer teardown()
+
+		req := newRequest(t, http.MethodPost, "/api/file/batch-exists", map[string]interface{}{
+			"paths": []string{"nonexistent.go"},
+		})
+		withProjectCookie(req, env.ProjectDir)
+
+		w := callHandler(ServeFileBatchExists, req)
+		assertOK(t, w)
+
+		var result map[string]interface{}
+		err := json.Unmarshal(w.Body.Bytes(), &result)
+		assert.NoError(t, err)
+
+		results, ok := result["results"].(map[string]interface{})
+		assert.True(t, ok)
+		assert.Equal(t, "none", results["nonexistent.go"])
+	})
+
+	t.Run("GlobChars_ReturnsNone", func(t *testing.T) {
+		env, teardown := setupTestEnv(t)
+		defer teardown()
+
+		req := newRequest(t, http.MethodPost, "/api/file/batch-exists", map[string]interface{}{
+			"paths": []string{"**/*.class", "*.java", "src/[test]/file.go", "<sourcefile>"},
+		})
+		withProjectCookie(req, env.ProjectDir)
+
+		w := callHandler(ServeFileBatchExists, req)
+		assertOK(t, w)
+
+		var result map[string]interface{}
+		err := json.Unmarshal(w.Body.Bytes(), &result)
+		assert.NoError(t, err)
+
+		results, ok := result["results"].(map[string]interface{})
+		assert.True(t, ok)
+		assert.Equal(t, "none", results["**/*.class"])
+		assert.Equal(t, "none", results["*.java"])
+		assert.Equal(t, "none", results["src/[test]/file.go"])
+		assert.Equal(t, "none", results["<sourcefile>"])
+	})
+
+	t.Run("PathTraversal_ReturnsNone", func(t *testing.T) {
+		env, teardown := setupTestEnv(t)
+		defer teardown()
+
+		req := newRequest(t, http.MethodPost, "/api/file/batch-exists", map[string]interface{}{
+			"paths": []string{"../../../etc/passwd"},
+		})
+		withProjectCookie(req, env.ProjectDir)
+
+		w := callHandler(ServeFileBatchExists, req)
+		assertOK(t, w)
+
+		var result map[string]interface{}
+		err := json.Unmarshal(w.Body.Bytes(), &result)
+		assert.NoError(t, err)
+
+		results, ok := result["results"].(map[string]interface{})
+		assert.True(t, ok)
+		assert.Equal(t, "none", results["../../../etc/passwd"])
+	})
+
+	t.Run("MixedPaths_CorrectResults", func(t *testing.T) {
+		env, teardown := setupTestEnv(t)
+		defer teardown()
+
+		createTestFile(t, env.ProjectDir, "exists.txt", "hello")
+		os.MkdirAll(filepath.Join(env.ProjectDir, "subdir"), 0755)
+
+		req := newRequest(t, http.MethodPost, "/api/file/batch-exists", map[string]interface{}{
+			"paths": []string{"exists.txt", "subdir", "missing.go", "**/*.class"},
+		})
+		withProjectCookie(req, env.ProjectDir)
+
+		w := callHandler(ServeFileBatchExists, req)
+		assertOK(t, w)
+
+		var result map[string]interface{}
+		err := json.Unmarshal(w.Body.Bytes(), &result)
+		assert.NoError(t, err)
+
+		results, ok := result["results"].(map[string]interface{})
+		assert.True(t, ok)
+		assert.Equal(t, "file", results["exists.txt"])
+		assert.Equal(t, "dir", results["subdir"])
+		assert.Equal(t, "none", results["missing.go"])
+		assert.Equal(t, "none", results["**/*.class"])
+	})
+
+	t.Run("EmptyPaths_Returns400", func(t *testing.T) {
+		env, teardown := setupTestEnv(t)
+		defer teardown()
+
+		req := newRequest(t, http.MethodPost, "/api/file/batch-exists", map[string]interface{}{
+			"paths": []string{},
+		})
+		withProjectCookie(req, env.ProjectDir)
+
+		w := callHandler(ServeFileBatchExists, req)
+		assertStatus(t, w, http.StatusBadRequest)
+	})
+
+	t.Run("NoProjectCookie_Returns403", func(t *testing.T) {
+		_, teardown := setupTestEnv(t)
+		defer teardown()
+
+		req := newRequest(t, http.MethodPost, "/api/file/batch-exists", map[string]interface{}{
+			"paths": []string{"test.txt"},
+		})
+
+		w := callHandler(ServeFileBatchExists, req)
+		assertStatus(t, w, http.StatusForbidden)
+	})
+
+	t.Run("TooManyPaths_Returns400", func(t *testing.T) {
+		env, teardown := setupTestEnv(t)
+		defer teardown()
+
+		paths := make([]string, 101)
+		for i := range paths {
+			paths[i] = "file.txt"
+		}
+
+		req := newRequest(t, http.MethodPost, "/api/file/batch-exists", map[string]interface{}{
+			"paths": paths,
+		})
+		withProjectCookie(req, env.ProjectDir)
+
+		w := callHandler(ServeFileBatchExists, req)
+		assertStatus(t, w, http.StatusBadRequest)
+	})
+}

--- a/internal/handler/handler.go
+++ b/internal/handler/handler.go
@@ -257,6 +257,7 @@ func RegisterRoutes(mux *http.ServeMux) {
 	register("/api/file/edit-line", middleware.Auth(ServeFileEditLine))
 	register("/api/file/delete", middleware.Auth(ServeFileDelete))
 	register("/api/file/batch-delete", middleware.Auth(ServeFileBatchDelete))
+	register("/api/file/batch-exists", middleware.Auth(ServeFileBatchExists))
 	register("/api/file/create", middleware.Auth(ServeFileCreate))
 	register("/api/file/copy", middleware.Auth(ServeFileCopy))
 	register("/api/dir/create", middleware.Auth(ServeDirCreate))

--- a/web/src/components/chat/ChatMessageList.vue
+++ b/web/src/components/chat/ChatMessageList.vue
@@ -84,6 +84,7 @@ import PendingMessageItem from './PendingMessageItem.vue'
 import { useDoubleClickCopy } from '@/composables/useDoubleClickCopy.ts'
 import { useFilePathAnnotation } from '@/composables/useFilePathAnnotation.ts'
 import { useLocalhostUrlClickHandler } from '@/composables/useLocalhostAnnotation.ts'
+import { useDialog } from '@/composables/useDialog'
 import { store } from '@/stores/app.ts'
 import { computeRemainingCount, computeLastRoundIndices, isCollapsed as isCollapsedUtil } from '@/utils/messageListUtils.ts'
 
@@ -110,6 +111,7 @@ const emit = defineEmits(['toggle-tool', 'show-tool-detail', 'show-thinking-deta
 const messagesRef = ref(null)
 const { handleDblClick } = useDoubleClickCopy()
 const { openFilePath } = useFilePathAnnotation()
+const dialog = useDialog()
 const { handleLocalhostUrlClick } = useLocalhostUrlClickHandler()
 
 // How many older messages are not yet loaded
@@ -181,17 +183,37 @@ async function handleChatClick(event) {
   // 1. Handle localhost URL clicks (icon button or <a> tag) — App mode only
   if (handleLocalhostUrlClick(event)) return
 
-  // 2. Worktree switch button (before file-path to avoid .worktrees paths being treated as files)
-  const wtBtn = (event.target).closest('.chat-worktree-switch-btn')
+  // 2. Worktree action button — show modal with "Switch" or "Open directory"
+  const wtBtn = (event.target).closest('.chat-worktree-btn')
   if (wtBtn) {
     event.preventDefault()
     event.stopPropagation()
     const wtPath = wtBtn.getAttribute('data-worktree-path')
+    const filePath = wtBtn.getAttribute('data-file-path')
     if (wtPath) {
-      if (hotSwitchProject) {
-        await hotSwitchProject(wtPath)
-      } else {
-        await store.setProject(wtPath)
+      const switchLabel = t('chat.attach.switchWorktree')
+      const openLabel = t('chat.attach.openDirectory')
+      // Use prompt dialog as a two-option chooser:
+      // confirm → switch to worktree, cancel → open directory (if available)
+      const result = await dialog.confirm(
+        filePath ? `${switchLabel}\n${openLabel}` : switchLabel,
+        {
+          title: t('chat.attach.openWorktree'),
+          confirmText: switchLabel,
+          cancelText: filePath ? openLabel : t('common.cancel'),
+        }
+      )
+      if (result) {
+        // Switch to worktree
+        if (hotSwitchProject) {
+          await hotSwitchProject(wtPath)
+        } else {
+          await store.setProject(wtPath)
+        }
+      } else if (filePath) {
+        // Open directory
+        openFilePath(filePath)
+        chatUI.navigateToFileViewer?.()
       }
     }
     return

--- a/web/src/components/chat/ContentBlocks.vue
+++ b/web/src/components/chat/ContentBlocks.vue
@@ -199,7 +199,7 @@ function handleToolDetailClick(event) {
   const toolName = event.currentTarget.dataset?.toolName
   if (toolName && handleToolAction(toolName, event, emit)) return
   // Allow file-open buttons and commit-hash elements to bubble
-  if (event.target.closest('.chat-file-open-btn') || event.target.closest('.chat-commit-hash, .chat-commit-open-btn') || event.target.closest('.chat-worktree-switch-btn')) {
+  if (event.target.closest('.chat-file-open-btn') || event.target.closest('.chat-commit-hash, .chat-commit-open-btn') || event.target.closest('.chat-worktree-btn')) {
     return
   }
   event.stopPropagation()
@@ -691,7 +691,7 @@ onUnmounted(() => {
   background: var(--bg-tertiary, #f0f0f0);
 }
 
-.content-blocks .chat-worktree-switch-btn {
+.content-blocks .chat-worktree-btn {
   background: none;
   border: none;
   padding: 2px;

--- a/web/src/components/chat/ToolDetailOverlay.vue
+++ b/web/src/components/chat/ToolDetailOverlay.vue
@@ -75,8 +75,8 @@ function handleBodyClick(event) {
     if (filePath) emit('file-open', filePath)
     return
   }
-  // Handle worktree switch buttons
-  const wtBtn = event.target.closest('.chat-worktree-switch-btn')
+  // Handle worktree action buttons
+  const wtBtn = event.target.closest('.chat-worktree-btn')
   if (wtBtn) {
     const wtPath = wtBtn.getAttribute('data-worktree-path')
     if (wtPath) store.setProject(wtPath)
@@ -911,7 +911,7 @@ function handleBodyClick(event) {
   background: var(--bg-tertiary, #f0f0f0);
 }
 
-.tool-detail-body .chat-worktree-switch-btn {
+.tool-detail-body .chat-worktree-btn {
   background: none;
   border: none;
   padding: 2px;

--- a/web/src/components/task/TaskExecDetail.vue
+++ b/web/src/components/task/TaskExecDetail.vue
@@ -256,8 +256,8 @@ function handleContentClick(event) {
     return
   }
 
-  // 3. Handle worktree switch buttons
-  const wtBtn = event.target.closest('.chat-worktree-switch-btn')
+  // 3. Handle worktree action buttons
+  const wtBtn = event.target.closest('.chat-worktree-btn')
   if (wtBtn) {
     event.preventDefault()
     event.stopPropagation()

--- a/web/src/composables/__tests__/useCommitHashAnnotation.test.ts
+++ b/web/src/composables/__tests__/useCommitHashAnnotation.test.ts
@@ -114,11 +114,11 @@ describe('annotateCommitHashes', () => {
         expect(result.html).toContain('data-commit-sha="abc1234"')
     })
 
-    it('does NOT annotate commit hash inside <pre> block', () => {
+    it('annotates commit hash inside <pre> block', () => {
         const html = '<pre><code>abc1234</code></pre>'
         const result = annotateCommitHashes(html)
-        expect(result.detectedSHAs).toEqual([])
-        expect(result.html).not.toContain('chat-commit-hash')
+        expect(result.detectedSHAs).toContain('abc1234')
+        expect(result.html).toContain('chat-commit-hash')
     })
 
     it('does NOT annotate <code> with chat-file-path class', () => {
@@ -144,10 +144,10 @@ describe('annotateCommitHashes', () => {
         expect(result.detectedSHAs).toEqual([])
     })
 
-    it('does NOT annotate commit hash inside <pre> without code', () => {
+    it('annotates commit hash inside <pre> without code', () => {
         const html = '<pre>abc1234</pre>'
         const result = annotateCommitHashes(html)
-        expect(result.detectedSHAs).toEqual([])
+        expect(result.detectedSHAs).toEqual(['abc1234'])
     })
 
     it('detects multiple commit hashes in same text', () => {

--- a/web/src/composables/__tests__/useFilePathAnnotation.test.ts
+++ b/web/src/composables/__tests__/useFilePathAnnotation.test.ts
@@ -96,6 +96,30 @@ describe('resolveFilePath', () => {
       expect(resolveFilePath('../src/main.go', '')).toBeNull()
     })
   })
+
+  describe('illegal characters (glob patterns, template vars)', () => {
+    it('returns null for paths with * wildcard', () => {
+      expect(resolveFilePath('*.class', projectRoot)).toBeNull()
+      expect(resolveFilePath('src/*.go', projectRoot)).toBeNull()
+    })
+
+    it('returns null for paths with ** double-star', () => {
+      expect(resolveFilePath('**/*.class', projectRoot)).toBeNull()
+      expect(resolveFilePath('src/**/*.ts', projectRoot)).toBeNull()
+    })
+
+    it('returns null for paths with ? wildcard', () => {
+      expect(resolveFilePath('src/test?.go', projectRoot)).toBeNull()
+    })
+
+    it('returns null for paths with [ ] brackets', () => {
+      expect(resolveFilePath('src/[test]/file.go', projectRoot)).toBeNull()
+    })
+
+    it('returns null for paths with < > angle brackets', () => {
+      expect(resolveFilePath('<sourcefile>/<line>', projectRoot)).toBeNull()
+    })
+  })
 })
 
 // --- resolveRelativePath ---
@@ -516,6 +540,34 @@ describe('annotateFilePaths', () => {
   it('skips <code> elements already annotated as worktree', () => {
     // <code> with chat-worktree-path class should be skipped in step 2
     const input = '<code class="chat-worktree-path" data-worktree-path="/home/user/project/.worktrees/fix">.worktrees/fix</code>'
+    const result = annotateFilePaths(input, { projectRoot })
+    expect(result.detectedPaths).toHaveLength(0)
+  })
+
+  // ── Glob / illegal character rejection tests ──
+
+  it('does not annotate glob patterns in <code> tags', () => {
+    const input = '<code>**/*.class</code>'
+    const result = annotateFilePaths(input, { projectRoot })
+    expect(result.detectedPaths).toHaveLength(0)
+    expect(result.html).not.toContain('chat-file-path')
+  })
+
+  it('does not annotate paths with * wildcard in <code> tags', () => {
+    const input = '<code>*Test.java</code>'
+    const result = annotateFilePaths(input, { projectRoot })
+    expect(result.detectedPaths).toHaveLength(0)
+  })
+
+  it('does not annotate paths with angle brackets (template vars)', () => {
+    const input = '<code><sourcefile>/<line></code>'
+    const result = annotateFilePaths(input, { projectRoot })
+    expect(result.detectedPaths).toHaveLength(0)
+  })
+
+  it('does not annotate ProGuard-style glob patterns in text', () => {
+    // These are common in Android/Java projects — not real file paths
+    const input = '<p>**/R.class and **/R$*.class and **/Manifest*.*</p>'
     const result = annotateFilePaths(input, { projectRoot })
     expect(result.detectedPaths).toHaveLength(0)
   })

--- a/web/src/composables/__tests__/useFilePathAnnotation.test.ts
+++ b/web/src/composables/__tests__/useFilePathAnnotation.test.ts
@@ -120,6 +120,15 @@ describe('resolveFilePath', () => {
     it('returns null for paths with < > angle brackets', () => {
       expect(resolveFilePath('<sourcefile>/<line>', projectRoot)).toBeNull()
     })
+
+    it('returns null for http:// URLs', () => {
+      expect(resolveFilePath('http://localhost:20003', projectRoot)).toBeNull()
+      expect(resolveFilePath('http://example.com/page.html', projectRoot)).toBeNull()
+    })
+
+    it('returns null for https:// URLs', () => {
+      expect(resolveFilePath('https://example.com/page.html', projectRoot)).toBeNull()
+    })
   })
 })
 
@@ -494,6 +503,16 @@ describe('annotateFilePaths', () => {
     // https:// URLs should not be treated as file paths
     // (the regex does not match strings starting with http/https)
     expect(result.detectedPaths).toHaveLength(0)
+  })
+
+  it('does not annotate localhost URLs in <code> elements', () => {
+    const input = '<code>http://localhost:20003</code>'
+    const result = annotateFilePaths(input, { projectRoot })
+    // localhost URLs should not get file-path annotations
+    // (they are handled by localhost annotation instead)
+    expect(result.detectedPaths).toHaveLength(0)
+    expect(result.html).not.toContain('chat-file-path')
+    expect(result.html).not.toContain('chat-file-open-btn')
   })
 
   it('annotates <a> with relative href and baseDir', () => {

--- a/web/src/composables/__tests__/useFilePathAnnotation.test.ts
+++ b/web/src/composables/__tests__/useFilePathAnnotation.test.ts
@@ -1,10 +1,11 @@
-import { describe, expect, it, vi, beforeEach } from 'vitest'
+import { describe, expect, it, vi, beforeEach, afterEach } from 'vitest'
 import {
   resolveFilePath,
   resolveRelativePath,
   fileOpenButtonHtml,
   FILE_OPEN_ICON_SVG,
   annotateFilePaths,
+  verifyFilePaths,
   clearVerifiedCache,
 } from '@/composables/useFilePathAnnotation'
 
@@ -578,5 +579,177 @@ describe('annotateFilePaths', () => {
 describe('clearVerifiedCache', () => {
   it('does not throw when called', () => {
     expect(() => clearVerifiedCache()).not.toThrow()
+  })
+})
+
+// --- verifyFilePaths ---
+
+describe('verifyFilePaths', () => {
+  beforeEach(() => {
+    clearVerifiedCache()
+  })
+
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  // Ensure CSS.escape is available in jsdom
+  if (typeof (globalThis as any).CSS === 'undefined') {
+    ;(globalThis as any).CSS = {}
+  }
+  if (typeof (globalThis as any).CSS.escape === 'undefined') {
+    ;(globalThis as any).CSS.escape = (s: string) => s.replace(/[!"#$%&'()*+,.\/:;<=>?@[\\\]^`{|}~]/g, '\\$&')
+  }
+
+  it('removes buttons for non-existent paths (batch API returns none)', async () => {
+    const mockFetch = vi.fn().mockResolvedValue({
+      ok: true,
+      json: () => Promise.resolve({ results: { 'missing.go': 'none' } }),
+    })
+    vi.stubGlobal('fetch', mockFetch)
+
+    const container = document.createElement('div')
+    container.innerHTML = '<button class="chat-file-open-btn" data-file-path="missing.go">open</button><span class="chat-file-path" data-file-path="missing.go">missing.go</span>'
+
+    await verifyFilePaths(['missing.go'], container)
+
+    // Button should be removed
+    expect(container.querySelector('.chat-file-open-btn')).toBeNull()
+    // Span should be unwrapped (plain text remains)
+    expect(container.textContent).toContain('missing.go')
+    expect(container.querySelector('.chat-file-path')).toBeNull()
+
+    // Verify batch API was called
+    expect(mockFetch).toHaveBeenCalledTimes(1)
+    const callArgs = mockFetch.mock.calls[0]
+    expect(callArgs[0]).toBe('/api/file/batch-exists')
+    expect(callArgs[1].method).toBe('POST')
+
+    vi.unstubAllGlobals()
+  })
+
+  it('keeps annotations for existing paths (batch API returns file)', async () => {
+    const mockFetch = vi.fn().mockResolvedValue({
+      ok: true,
+      json: () => Promise.resolve({ results: { 'src/main.go': 'file' } }),
+    })
+    vi.stubGlobal('fetch', mockFetch)
+
+    const container = document.createElement('div')
+    container.innerHTML = '<button class="chat-file-open-btn" data-file-path="src/main.go">open</button><span class="chat-file-path" data-file-path="src/main.go">src/main.go</span>'
+
+    await verifyFilePaths(['src/main.go'], container)
+
+    // Button and span should remain
+    expect(container.querySelector('.chat-file-open-btn')).not.toBeNull()
+    expect(container.querySelector('.chat-file-path')).not.toBeNull()
+
+    vi.unstubAllGlobals()
+  })
+
+  it('keeps annotations for existing directories (batch API returns dir)', async () => {
+    const mockFetch = vi.fn().mockResolvedValue({
+      ok: true,
+      json: () => Promise.resolve({ results: { 'src': 'dir' } }),
+    })
+    vi.stubGlobal('fetch', mockFetch)
+
+    const container = document.createElement('div')
+    container.innerHTML = '<button class="chat-file-open-btn" data-file-path="src">open</button>'
+
+    await verifyFilePaths(['src'], container)
+
+    expect(container.querySelector('.chat-file-open-btn')).not.toBeNull()
+
+    vi.unstubAllGlobals()
+  })
+
+  it('handles mixed existing and non-existing paths', async () => {
+    const mockFetch = vi.fn().mockResolvedValue({
+      ok: true,
+      json: () => Promise.resolve({ results: { 'exists.go': 'file', 'missing.go': 'none' } }),
+    })
+    vi.stubGlobal('fetch', mockFetch)
+
+    const container = document.createElement('div')
+    container.innerHTML = '<button class="chat-file-open-btn" data-file-path="exists.go">open</button><button class="chat-file-open-btn" data-file-path="missing.go">open</button>'
+
+    await verifyFilePaths(['exists.go', 'missing.go'], container)
+
+    expect(container.querySelector('[data-file-path="exists.go"]')).not.toBeNull()
+    expect(container.querySelector('[data-file-path="missing.go"]')).toBeNull()
+
+    vi.unstubAllGlobals()
+  })
+
+  it('handles network error gracefully (assumes exists)', async () => {
+    const mockFetch = vi.fn().mockRejectedValue(new Error('Network error'))
+    vi.stubGlobal('fetch', mockFetch)
+
+    const container = document.createElement('div')
+    container.innerHTML = '<button class="chat-file-open-btn" data-file-path="test.go">open</button>'
+
+    await verifyFilePaths(['test.go'], container)
+
+    // On network error, assumes exists — button stays
+    expect(container.querySelector('.chat-file-open-btn')).not.toBeNull()
+
+    vi.unstubAllGlobals()
+  })
+
+  it('skips API call when all paths are cached', async () => {
+    const mockFetch = vi.fn().mockResolvedValue({
+      ok: true,
+      json: () => Promise.resolve({ results: { 'cached.go': 'file' } }),
+    })
+    vi.stubGlobal('fetch', mockFetch)
+
+    // First call populates cache
+    const container1 = document.createElement('div')
+    await verifyFilePaths(['cached.go'], container1)
+
+    // Second call should use cache — no fetch
+    const mockFetch2 = vi.fn()
+    vi.stubGlobal('fetch', mockFetch2)
+
+    const container2 = document.createElement('div')
+    container2.innerHTML = '<button class="chat-file-open-btn" data-file-path="cached.go">open</button>'
+    await verifyFilePaths(['cached.go'], container2)
+
+    expect(mockFetch2).not.toHaveBeenCalled()
+    expect(container2.querySelector('.chat-file-open-btn')).not.toBeNull()
+
+    vi.unstubAllGlobals()
+  })
+
+  it('does nothing for empty paths array', async () => {
+    const mockFetch = vi.fn()
+    vi.stubGlobal('fetch', mockFetch)
+
+    const container = document.createElement('div')
+    await verifyFilePaths([], container)
+
+    expect(mockFetch).not.toHaveBeenCalled()
+
+    vi.unstubAllGlobals()
+  })
+
+  it('deduplicates paths before making API call', async () => {
+    const mockFetch = vi.fn().mockResolvedValue({
+      ok: true,
+      json: () => Promise.resolve({ results: { 'dup.go': 'file' } }),
+    })
+    vi.stubGlobal('fetch', mockFetch)
+
+    const container = document.createElement('div')
+    await verifyFilePaths(['dup.go', 'dup.go', 'dup.go'], container)
+
+    // Should only call API once
+    expect(mockFetch).toHaveBeenCalledTimes(1)
+    // The body should contain deduplicated paths
+    const body = JSON.parse(mockFetch.mock.calls[0][1].body)
+    expect(body.paths).toEqual(['dup.go'])
+
+    vi.unstubAllGlobals()
   })
 })

--- a/web/src/composables/__tests__/useFilePathAnnotation.test.ts
+++ b/web/src/composables/__tests__/useFilePathAnnotation.test.ts
@@ -226,10 +226,10 @@ describe('annotateFilePaths', () => {
     expect(result.detectedPaths).toHaveLength(0)
   })
 
-  it('preserves pre blocks without annotation', () => {
+  it('annotates file paths inside <pre> blocks', () => {
     const input = '<pre>some /home/user/project/src/main.go code</pre>'
     const result = annotateFilePaths(input, { projectRoot })
-    expect(result.detectedPaths).toHaveLength(0)
+    expect(result.detectedPaths).toContain('src/main.go')
   })
 
   it('annotates file paths inside inline code elements', () => {
@@ -352,12 +352,13 @@ describe('annotateFilePaths', () => {
     expect(btnCount).toBe(1)
   })
 
-  it('does not annotate code inside <pre> blocks', () => {
-    // <pre><code> is a multi-line code block — paths inside should NOT be annotated
+  it('annotates code inside <pre> blocks', () => {
+    // <pre><code> is a multi-line code block — paths inside are now also annotated
     const input = '<pre><code>import "/home/user/project/src/main.go"</code></pre>'
     const result = annotateFilePaths(input, { projectRoot })
-    expect(result.detectedPaths).toHaveLength(0)
-    expect(result.html).not.toContain('chat-file-path')
+    expect(result.detectedPaths).toContain('src/main.go')
+    // Path is inside <code> content but not the entire content, so only a button is appended
+    expect(result.html).toContain('chat-file-open-btn')
   })
 
   it('annotates absolute path immediately followed by CJK characters', () => {

--- a/web/src/composables/__tests__/useLocalhostAnnotation.test.ts
+++ b/web/src/composables/__tests__/useLocalhostAnnotation.test.ts
@@ -165,12 +165,12 @@ describe('useLocalhostAnnotation', () => {
       expect(result).toContain('data-port="8080"')
     })
 
-    it('does not annotate inside <pre> blocks', () => {
+    it('annotates inside <pre> blocks', () => {
       mockIsAppMode.value = true
       mockSshInfo.value = { enabled: true }
       const html = '<pre>http://localhost:3000</pre>'
       const result = annotateLocalhostUrls(html)
-      expect(result).not.toContain('chat-url-open-btn')
+      expect(result).toContain('chat-url-open-btn')
     })
 
     it('annotates 127.0.0.1 URLs', () => {

--- a/web/src/composables/__tests__/useWorktreeAnnotation.test.ts
+++ b/web/src/composables/__tests__/useWorktreeAnnotation.test.ts
@@ -1,8 +1,9 @@
 import { describe, expect, it, vi, beforeEach } from 'vitest'
 import {
     worktreeButtonHtml,
+    buildSearchEntries,
     annotateWorktreePaths,
-    verifyWorktreePaths,
+    warmWorktreeCache,
     clearWorktreeCache,
     useWorktreeAnnotation,
 } from '@/composables/useWorktreeAnnotation'
@@ -25,6 +26,91 @@ if (typeof (globalThis as any).CSS.escape === 'undefined') {
 }
 
 const PROJECT_ROOT = '/home/user/project'
+
+const MOCK_WORKTREES = [
+    {
+        path: '/home/user/project',
+        displayPath: '.',
+        branch: 'main',
+        isCurrent: true,
+        dirty: false,
+        changeCount: 0,
+        untrackedCount: 0,
+        locked: false,
+        missing: false,
+    },
+    {
+        path: '/home/user/project/.worktrees/feature-x',
+        displayPath: './.worktrees/feature-x',
+        branch: 'feature-x',
+        isCurrent: false,
+        dirty: false,
+        changeCount: 0,
+        untrackedCount: 0,
+        locked: false,
+        missing: false,
+    },
+    {
+        path: '/home/user/project/.worktrees/bugfix-y',
+        displayPath: './.worktrees/bugfix-y',
+        branch: 'bugfix-y',
+        isCurrent: false,
+        dirty: true,
+        changeCount: 3,
+        untrackedCount: 1,
+        locked: false,
+        missing: false,
+    },
+]
+
+/**
+ * Helper: seed the worktree list cache so annotateWorktreePaths can use it.
+ */
+async function seedCache(projectRoot: string, worktrees: any[]) {
+    const mockFetch = vi.fn().mockResolvedValue({
+        ok: true,
+        json: () => Promise.resolve({ worktrees }),
+    })
+    vi.stubGlobal('fetch', mockFetch)
+    await warmWorktreeCache(projectRoot)
+    vi.unstubAllGlobals()
+}
+
+// ── buildSearchEntries ──
+
+describe('buildSearchEntries', () => {
+    it('excludes isCurrent worktree', () => {
+        const entries = buildSearchEntries(MOCK_WORKTREES)
+        expect(entries.every(e => e.absPath !== '/home/user/project')).toBe(true)
+    })
+
+    it('generates absolute path entries', () => {
+        const entries = buildSearchEntries(MOCK_WORKTREES)
+        expect(entries.some(e => e.keyword === '/home/user/project/.worktrees/feature-x')).toBe(true)
+    })
+
+    it('generates displayPath entries', () => {
+        const entries = buildSearchEntries(MOCK_WORKTREES)
+        expect(entries.some(e => e.keyword === './.worktrees/feature-x')).toBe(true)
+    })
+
+    it('generates displayPath without ./ prefix entries', () => {
+        const entries = buildSearchEntries(MOCK_WORKTREES)
+        expect(entries.some(e => e.keyword === '.worktrees/feature-x')).toBe(true)
+    })
+
+    it('sorts entries by keyword length descending', () => {
+        const entries = buildSearchEntries(MOCK_WORKTREES)
+        for (let i = 1; i < entries.length; i++) {
+            expect(entries[i - 1].keyword.length).toBeGreaterThanOrEqual(entries[i].keyword.length)
+        }
+    })
+
+    it('returns empty for empty worktree list', () => {
+        const entries = buildSearchEntries([])
+        expect(entries).toEqual([])
+    })
+})
 
 // ── worktreeButtonHtml ──
 
@@ -54,10 +140,42 @@ describe('worktreeButtonHtml', () => {
         const html = worktreeButtonHtml('/home/user/project/.worktrees/feature-x')
         expect(html).toContain('<svg')
     })
+})
 
-    it('contains title attribute', () => {
-        const html = worktreeButtonHtml('/home/user/project/.worktrees/feature-x')
-        expect(html).toContain('title=')
+// ── warmWorktreeCache ──
+
+describe('warmWorktreeCache', () => {
+    beforeEach(() => {
+        clearWorktreeCache()
+    })
+
+    it('populates cache from API', async () => {
+        const mockFetch = vi.fn().mockResolvedValue({
+            ok: true,
+            json: () => Promise.resolve({ worktrees: MOCK_WORKTREES }),
+        })
+        vi.stubGlobal('fetch', mockFetch)
+
+        await warmWorktreeCache(PROJECT_ROOT)
+
+        // Second call should use cache (no fetch)
+        const mockFetch2 = vi.fn()
+        vi.stubGlobal('fetch', mockFetch2)
+        await warmWorktreeCache(PROJECT_ROOT)
+        expect(mockFetch2).not.toHaveBeenCalled()
+
+        vi.unstubAllGlobals()
+    })
+
+    it('does nothing when projectRoot is empty', async () => {
+        const mockFetch = vi.fn()
+        vi.stubGlobal('fetch', mockFetch)
+
+        await warmWorktreeCache('')
+
+        expect(mockFetch).not.toHaveBeenCalled()
+
+        vi.unstubAllGlobals()
     })
 })
 
@@ -68,162 +186,132 @@ describe('annotateWorktreePaths', () => {
         clearWorktreeCache()
     })
 
-    it('annotates .worktrees/ path in text node (regex-first, no cache needed)', () => {
+    it('annotates .worktrees/ path in text node (via worktree list)', async () => {
+        await seedCache(PROJECT_ROOT, MOCK_WORKTREES)
         const result = annotateWorktreePaths('<p>.worktrees/feature-x</p>', { projectRoot: PROJECT_ROOT })
         expect(result.detectedWorktreePaths).toContain('/home/user/project/.worktrees/feature-x')
         expect(result.html).toContain('chat-worktree-path')
         expect(result.html).toContain('chat-worktree-btn')
     })
 
-    it('annotates ./.worktrees/ path in text node', () => {
+    it('annotates ./.worktrees/ path in text node', async () => {
+        await seedCache(PROJECT_ROOT, MOCK_WORKTREES)
         const result = annotateWorktreePaths('<p>./.worktrees/feature-x</p>', { projectRoot: PROJECT_ROOT })
         expect(result.detectedWorktreePaths).toContain('/home/user/project/.worktrees/feature-x')
         expect(result.html).toContain('chat-worktree-path')
     })
 
-    it('annotates absolute path in text node', () => {
+    it('annotates absolute path in text node', async () => {
+        await seedCache(PROJECT_ROOT, MOCK_WORKTREES)
         const absPath = '/home/user/project/.worktrees/feature-x'
         const result = annotateWorktreePaths(`<p>${absPath}</p>`, { projectRoot: PROJECT_ROOT })
         expect(result.detectedWorktreePaths).toContain(absPath)
         expect(result.html).toContain('chat-worktree-path')
     })
 
-    it('appends button after <a> tag with worktree href', () => {
+    it('annotates external worktree path (not under .worktrees/)', async () => {
+        const externalWorktrees = [
+            { ...MOCK_WORKTREES[0] },
+            { path: '/tmp/my-worktree', displayPath: './my-worktree', branch: 'my-worktree', isCurrent: false, dirty: false, changeCount: 0, untrackedCount: 0, locked: false, missing: false },
+        ]
+        await seedCache(PROJECT_ROOT, externalWorktrees)
+        const result = annotateWorktreePaths('<p>/tmp/my-worktree</p>', { projectRoot: PROJECT_ROOT })
+        expect(result.detectedWorktreePaths).toContain('/tmp/my-worktree')
+        expect(result.html).toContain('chat-worktree-path')
+    })
+
+    it('appends button after <a> tag with worktree href', async () => {
+        await seedCache(PROJECT_ROOT, MOCK_WORKTREES)
         const result = annotateWorktreePaths('<a href=".worktrees/feature-x">link</a>', { projectRoot: PROJECT_ROOT })
         expect(result.detectedWorktreePaths).toContain('/home/user/project/.worktrees/feature-x')
         expect(result.html).toContain('chat-worktree-btn')
     })
 
-    it('adds class + button to <code> tag with worktree content', () => {
+    it('adds class + button to <code> tag with worktree content', async () => {
+        await seedCache(PROJECT_ROOT, MOCK_WORKTREES)
         const result = annotateWorktreePaths('<code>.worktrees/feature-x</code>', { projectRoot: PROJECT_ROOT })
         expect(result.detectedWorktreePaths).toContain('/home/user/project/.worktrees/feature-x')
         expect(result.html).toContain('chat-worktree-path')
         expect(result.html).toContain('chat-worktree-btn')
     })
 
-    it('does NOT annotate paths inside <pre> blocks', () => {
+    it('does NOT annotate paths inside <pre> blocks', async () => {
+        await seedCache(PROJECT_ROOT, MOCK_WORKTREES)
         const result = annotateWorktreePaths('<pre><code>.worktrees/feature-x</code></pre>', { projectRoot: PROJECT_ROOT })
         expect(result.detectedWorktreePaths).toEqual([])
         expect(result.html).not.toContain('chat-worktree-path')
     })
 
-    it('does NOT double-annotate paths inside <a> tags in text node step', () => {
+    it('does NOT double-annotate paths inside <a> tags in text node step', async () => {
+        await seedCache(PROJECT_ROOT, MOCK_WORKTREES)
         const result = annotateWorktreePaths('<a href=".worktrees/feature-x">.worktrees/feature-x</a>', { projectRoot: PROJECT_ROOT })
         const path = '/home/user/project/.worktrees/feature-x'
-        // Should have exactly one detected path (from the <a> tag step, text inside <a> skipped)
         const count = result.detectedWorktreePaths.filter(p => p === path).length
         expect(count).toBe(1)
     })
 
-    it('does NOT annotate non-worktree paths', () => {
+    it('does NOT annotate non-worktree paths', async () => {
+        await seedCache(PROJECT_ROOT, MOCK_WORKTREES)
         const result = annotateWorktreePaths('<p>src/main.go</p>', { projectRoot: PROJECT_ROOT })
         expect(result.detectedWorktreePaths).toEqual([])
         expect(result.html).not.toContain('chat-worktree-path')
     })
 
-    it('annotates multiple worktree paths in one text node', () => {
+    it('annotates multiple worktree paths in one text node', async () => {
+        await seedCache(PROJECT_ROOT, MOCK_WORKTREES)
         const result = annotateWorktreePaths('<p>.worktrees/feature-x and .worktrees/bugfix-y</p>', { projectRoot: PROJECT_ROOT })
         expect(result.detectedWorktreePaths).toContain('/home/user/project/.worktrees/feature-x')
         expect(result.detectedWorktreePaths).toContain('/home/user/project/.worktrees/bugfix-y')
     })
 
-    it('returns empty result for empty input', () => {
+    it('returns empty result for empty input', async () => {
+        await seedCache(PROJECT_ROOT, MOCK_WORKTREES)
         const result = annotateWorktreePaths('', { projectRoot: PROJECT_ROOT })
         expect(result.html).toBe('')
         expect(result.detectedWorktreePaths).toEqual([])
     })
 
-    it('sets data-worktree-path attribute with absolute path', () => {
+    it('sets data-worktree-path attribute with absolute path', async () => {
+        await seedCache(PROJECT_ROOT, MOCK_WORKTREES)
         const result = annotateWorktreePaths('<code>.worktrees/feature-x</code>', { projectRoot: PROJECT_ROOT })
         expect(result.html).toContain('data-worktree-path="/home/user/project/.worktrees/feature-x"')
     })
 
-    it('skips <a> tags with non-worktree href', () => {
+    it('skips <a> tags with non-worktree href', async () => {
+        await seedCache(PROJECT_ROOT, MOCK_WORKTREES)
         const result = annotateWorktreePaths('<a href="https://example.com">link</a>', { projectRoot: PROJECT_ROOT })
         expect(result.detectedWorktreePaths).toEqual([])
         expect(result.html).not.toContain('chat-worktree-btn')
     })
 
-    it('skips <code> with chat-commit-hash class', () => {
+    it('skips <code> with chat-commit-hash class', async () => {
+        await seedCache(PROJECT_ROOT, MOCK_WORKTREES)
         const result = annotateWorktreePaths('<code class="chat-commit-hash">.worktrees/feature-x</code>', { projectRoot: PROJECT_ROOT })
         expect(result.detectedWorktreePaths).toEqual([])
     })
 
-    it('skips <code> with non-worktree text content', () => {
-        const result = annotateWorktreePaths('<code>src/main.go</code>', { projectRoot: PROJECT_ROOT })
-        expect(result.detectedWorktreePaths).toEqual([])
-    })
-
-    it('preserves text before and after worktree path in text node', () => {
-        const result = annotateWorktreePaths('<p>Check .worktrees/feature-x for details</p>', { projectRoot: PROJECT_ROOT })
-        expect(result.html).toContain('Check')
-        expect(result.html).toContain('for details')
-        expect(result.detectedWorktreePaths).toContain('/home/user/project/.worktrees/feature-x')
-    })
-
-    it('handles mixed absolute and relative paths in same text node', () => {
-        const absPath = '/home/user/project/.worktrees/feature-x'
-        const result = annotateWorktreePaths(`<p>${absPath} and .worktrees/bugfix-y</p>`, { projectRoot: PROJECT_ROOT })
-        expect(result.detectedWorktreePaths).toContain(absPath)
-        expect(result.detectedWorktreePaths).toContain('/home/user/project/.worktrees/bugfix-y')
-    })
-
-    it('skips text nodes inside elements with chat-commit-hash class', () => {
-        const result = annotateWorktreePaths('<span class="chat-commit-hash">.worktrees/feature-x</span>', { projectRoot: PROJECT_ROOT })
-        expect(result.detectedWorktreePaths).toEqual([])
-    })
-
-    it('skips text nodes inside elements with chat-worktree-path class', () => {
-        const result = annotateWorktreePaths('<span class="chat-worktree-path">.worktrees/feature-x</span>', { projectRoot: PROJECT_ROOT })
-        expect(result.detectedWorktreePaths).toEqual([])
-    })
-
-    it('APPENDS worktree annotation to .chat-file-path elements (coexistence)', () => {
-        const result = annotateWorktreePaths('<span class="chat-file-path" data-file-path=".worktrees/feature-x">.worktrees/feature-x</span>', { projectRoot: PROJECT_ROOT })
-        expect(result.detectedWorktreePaths).toContain('/home/user/project/.worktrees/feature-x')
-        expect(result.html).toContain('chat-worktree-path')
-        expect(result.html).toContain('chat-worktree-btn')
-        expect(result.html).toContain('chat-file-path')
-    })
-
-    it('annotates without cache (regex-first design — works on first render)', () => {
-        // No cache seeding needed — regex matches .worktrees/ pattern directly
+    it('does NOT annotate when cache is empty (triggers background fetch)', () => {
         const result = annotateWorktreePaths('<p>.worktrees/feature-x</p>', { projectRoot: PROJECT_ROOT })
-        expect(result.detectedWorktreePaths.length).toBeGreaterThan(0)
-        expect(result.html).toContain('chat-worktree-path')
-        expect(result.html).toContain('chat-worktree-btn')
+        expect(result.detectedWorktreePaths).toEqual([])
+        expect(result.html).not.toContain('chat-worktree-path')
     })
 
-    it('skips <code> that already has chat-worktree-path class (already annotated)', () => {
-        const result = annotateWorktreePaths('<code class="chat-worktree-path" data-worktree-path="/home/user/project/.worktrees/feature-x">.worktrees/feature-x</code>', { projectRoot: PROJECT_ROOT })
-        // Should not add another button (no double annotation)
-        const btnCount = (result.html.match(/chat-worktree-btn/g) || []).length
-        expect(btnCount).toBe(0)
+    it('does NOT annotate paths not in the worktree list', async () => {
+        await seedCache(PROJECT_ROOT, MOCK_WORKTREES)
+        const result = annotateWorktreePaths('<p>.worktrees/nonexistent-wt</p>', { projectRoot: PROJECT_ROOT })
+        expect(result.detectedWorktreePaths).toEqual([])
+        expect(result.html).not.toContain('chat-worktree-path')
     })
 
-    it('skips <code> inside <pre> with chat-file-path (worktree coexistence in pre)', () => {
-        const result = annotateWorktreePaths('<pre><code class="chat-file-path">.worktrees/feature-x</code></pre>', { projectRoot: PROJECT_ROOT })
+    it('does NOT annotate when all worktrees are current (no search entries)', async () => {
+        const onlyCurrent = [{ ...MOCK_WORKTREES[0] }]
+        await seedCache(PROJECT_ROOT, onlyCurrent)
+        const result = annotateWorktreePaths('<p>.worktrees/feature-x</p>', { projectRoot: PROJECT_ROOT })
         expect(result.detectedWorktreePaths).toEqual([])
     })
 
-    it('annotates full absolute worktree path in text node', () => {
-        const absPath = '/home/user/project/.worktrees/feature-x'
-        const result = annotateWorktreePaths(`<p>${absPath}</p>`, { projectRoot: PROJECT_ROOT })
-        expect(result.detectedWorktreePaths).toContain(absPath)
-        expect(result.html).toContain('chat-worktree-path')
-        expect(result.html).toContain('chat-worktree-btn')
-        expect(result.html).toContain('data-worktree-path="/home/user/project/.worktrees/feature-x"')
-    })
-
-    it('annotates full absolute worktree path in <code> tag', () => {
-        const absPath = '/home/user/project/.worktrees/feature-x'
-        const result = annotateWorktreePaths(`<code>${absPath}</code>`, { projectRoot: PROJECT_ROOT })
-        expect(result.detectedWorktreePaths).toContain(absPath)
-        expect(result.html).toContain('chat-worktree-path')
-        expect(result.html).toContain('chat-worktree-btn')
-    })
-
-    it('single button with data-worktree-path and data-file-path for path under projectRoot', () => {
+    it('single button with data-worktree-path and data-file-path for path under projectRoot', async () => {
+        await seedCache(PROJECT_ROOT, MOCK_WORKTREES)
         const absPath = '/home/user/project/.worktrees/feature-x'
         const result = annotateWorktreePaths(`<p>${absPath}</p>`, { projectRoot: PROJECT_ROOT })
         expect(result.html).toContain('chat-worktree-btn')
@@ -231,81 +319,34 @@ describe('annotateWorktreePaths', () => {
         expect(result.html).toContain('data-file-path=".worktrees/feature-x"')
     })
 
-    it('does NOT add data-file-path for path outside projectRoot', () => {
-        // Absolute path that is not under projectRoot won't match regex
+    it('does NOT add data-file-path for worktree path outside projectRoot', async () => {
+        const externalWorktrees = [
+            { ...MOCK_WORKTREES[0] },
+            { path: '/other/location/worktree-x', displayPath: './worktree-x', branch: 'worktree-x', isCurrent: false, dirty: false, changeCount: 0, untrackedCount: 0, locked: false, missing: false },
+        ]
+        await seedCache(PROJECT_ROOT, externalWorktrees)
         const result = annotateWorktreePaths('<p>/other/location/worktree-x</p>', { projectRoot: PROJECT_ROOT })
-        expect(result.detectedWorktreePaths).toEqual([])
+        expect(result.html).toContain('chat-worktree-btn')
+        expect(result.html).toContain('data-worktree-path="/other/location/worktree-x"')
+        // No data-file-path because /other/location is outside projectRoot
+        expect(result.html).not.toContain('data-file-path')
     })
 
-    it('does NOT annotate worktree-like path not under projectRoot', () => {
-        // .worktrees/ path always resolves under projectRoot, so this always works
-        // But /other/.worktrees/x won't match because it's not under projectRoot
-        const result = annotateWorktreePaths('<p>/other/path/.worktrees/x</p>', { projectRoot: PROJECT_ROOT })
-        expect(result.detectedWorktreePaths).toEqual([])
-    })
-})
-
-// ── verifyWorktreePaths ──
-
-describe('verifyWorktreePaths', () => {
-    beforeEach(() => {
-        clearWorktreeCache()
-    })
-
-    it('removes annotations for paths not in worktree list', async () => {
-        const mockFetch = vi.fn().mockResolvedValue({
-            ok: true,
-            json: () => Promise.resolve({ worktrees: [
-                { path: '/home/user/project/.worktrees/real-wt', displayPath: './.worktrees/real-wt', branch: 'real-wt', isCurrent: false, dirty: false, changeCount: 0, untrackedCount: 0, locked: false, missing: false },
-                { path: '/home/user/project', displayPath: '.', branch: 'main', isCurrent: true, dirty: false, changeCount: 0, untrackedCount: 0, locked: false, missing: false },
-            ] }),
-        })
-        vi.stubGlobal('fetch', mockFetch)
-
-        const container = document.createElement('div')
-        container.innerHTML = '<span class="chat-worktree-path" data-worktree-path="/home/user/project/.worktrees/fake-wt">.worktrees/fake-wt</span><button class="chat-worktree-btn" data-worktree-path="/home/user/project/.worktrees/fake-wt"></button>'
-
-        await verifyWorktreePaths(['/home/user/project/.worktrees/fake-wt'], container, PROJECT_ROOT)
-
-        // The fake worktree's span and button should be removed
-        expect(container.querySelector('.chat-worktree-btn')).toBeNull()
-        expect(container.querySelector('.chat-worktree-path')).toBeNull()
-        // The text content should remain (unwrapped from span)
-        expect(container.textContent).toContain('.worktrees/fake-wt')
-
-        vi.unstubAllGlobals()
-    })
-
-    it('keeps annotations for paths in worktree list', async () => {
-        const mockFetch = vi.fn().mockResolvedValue({
-            ok: true,
-            json: () => Promise.resolve({ worktrees: [
-                { path: '/home/user/project/.worktrees/real-wt', displayPath: './.worktrees/real-wt', branch: 'real-wt', isCurrent: false, dirty: false, changeCount: 0, untrackedCount: 0, locked: false, missing: false },
-                { path: '/home/user/project', displayPath: '.', branch: 'main', isCurrent: true, dirty: false, changeCount: 0, untrackedCount: 0, locked: false, missing: false },
-            ] }),
-        })
-        vi.stubGlobal('fetch', mockFetch)
-
-        const container = document.createElement('div')
-        container.innerHTML = '<span class="chat-worktree-path" data-worktree-path="/home/user/project/.worktrees/real-wt">.worktrees/real-wt</span><button class="chat-worktree-btn" data-worktree-path="/home/user/project/.worktrees/real-wt"></button>'
-
-        await verifyWorktreePaths(['/home/user/project/.worktrees/real-wt'], container, PROJECT_ROOT)
-
-        // The real worktree's span and button should remain
-        expect(container.querySelector('.chat-worktree-btn')).not.toBeNull()
-        expect(container.querySelector('.chat-worktree-path')).not.toBeNull()
-
-        vi.unstubAllGlobals()
+    it('skips <code> that already has chat-worktree-path class (already annotated)', async () => {
+        await seedCache(PROJECT_ROOT, MOCK_WORKTREES)
+        const result = annotateWorktreePaths('<code class="chat-worktree-path" data-worktree-path="/home/user/project/.worktrees/feature-x">.worktrees/feature-x</code>', { projectRoot: PROJECT_ROOT })
+        const btnCount = (result.html.match(/chat-worktree-btn/g) || []).length
+        expect(btnCount).toBe(0)
     })
 })
 
 // ── useWorktreeAnnotation composable ──
 
 describe('useWorktreeAnnotation', () => {
-    it('returns annotateWorktreePaths, verifyWorktreePaths and clearWorktreeCache', () => {
-        const { annotateWorktreePaths: annotate, verifyWorktreePaths: verify, clearWorktreeCache: clear } = useWorktreeAnnotation()
+    it('returns annotateWorktreePaths, warmWorktreeCache and clearWorktreeCache', () => {
+        const { annotateWorktreePaths: annotate, warmWorktreeCache: warm, clearWorktreeCache: clear } = useWorktreeAnnotation()
         expect(typeof annotate).toBe('function')
-        expect(typeof verify).toBe('function')
+        expect(typeof warm).toBe('function')
         expect(typeof clear).toBe('function')
     })
 })

--- a/web/src/composables/__tests__/useWorktreeAnnotation.test.ts
+++ b/web/src/composables/__tests__/useWorktreeAnnotation.test.ts
@@ -235,11 +235,11 @@ describe('annotateWorktreePaths', () => {
         expect(result.html).toContain('chat-worktree-btn')
     })
 
-    it('does NOT annotate paths inside <pre> blocks', async () => {
+    it('annotates paths inside <pre> blocks', async () => {
         await seedCache(PROJECT_ROOT, MOCK_WORKTREES)
         const result = annotateWorktreePaths('<pre><code>.worktrees/feature-x</code></pre>', { projectRoot: PROJECT_ROOT })
-        expect(result.detectedWorktreePaths).toEqual([])
-        expect(result.html).not.toContain('chat-worktree-path')
+        expect(result.detectedWorktreePaths).toContain('/home/user/project/.worktrees/feature-x')
+        expect(result.html).toContain('chat-worktree-path')
     })
 
     it('does NOT double-annotate paths inside <a> tags in text node step', async () => {

--- a/web/src/composables/__tests__/useWorktreeAnnotation.test.ts
+++ b/web/src/composables/__tests__/useWorktreeAnnotation.test.ts
@@ -1,8 +1,8 @@
 import { describe, expect, it, vi, beforeEach } from 'vitest'
 import {
-    worktreeSwitchButtonHtml,
-    buildSearchEntries,
+    worktreeButtonHtml,
     annotateWorktreePaths,
+    verifyWorktreePaths,
     clearWorktreeCache,
     useWorktreeAnnotation,
 } from '@/composables/useWorktreeAnnotation'
@@ -26,129 +26,37 @@ if (typeof (globalThis as any).CSS.escape === 'undefined') {
 
 const PROJECT_ROOT = '/home/user/project'
 
-const MOCK_WORKTREES = [
-    {
-        path: '/home/user/project',
-        displayPath: '.',
-        branch: 'main',
-        isCurrent: true,
-        dirty: false,
-        changeCount: 0,
-        untrackedCount: 0,
-        locked: false,
-        missing: false,
-    },
-    {
-        path: '/home/user/project/.worktrees/feature-x',
-        displayPath: './.worktrees/feature-x',
-        branch: 'feature-x',
-        isCurrent: false,
-        dirty: false,
-        changeCount: 0,
-        untrackedCount: 0,
-        locked: false,
-        missing: false,
-    },
-    {
-        path: '/home/user/project/.worktrees/bugfix-y',
-        displayPath: './.worktrees/bugfix-y',
-        branch: 'bugfix-y',
-        isCurrent: false,
-        dirty: true,
-        changeCount: 3,
-        untrackedCount: 1,
-        locked: false,
-        missing: false,
-    },
-]
+// ── worktreeButtonHtml ──
 
-/**
- * Helper: seed the worktree list cache so annotateWorktreePaths can use it.
- * We mock fetch to populate the cache, then call annotateWorktreePaths
- * which will find the cached data.
- */
-async function seedCache(projectRoot: string, worktrees: any[]) {
-    const mockFetch = vi.fn().mockResolvedValue({
-        ok: true,
-        json: () => Promise.resolve({ worktrees }),
-    })
-    vi.stubGlobal('fetch', mockFetch)
-    // First call triggers fetch and caches; annotateWorktreePaths returns empty
-    annotateWorktreePaths('<p>test</p>', { projectRoot })
-    // Wait for async fetch to complete
-    await vi.waitFor(() => expect(mockFetch).toHaveBeenCalled())
-    vi.unstubAllGlobals()
-}
-
-// ── buildSearchEntries ──
-
-describe('buildSearchEntries', () => {
-    it('excludes isCurrent worktree', () => {
-        const entries = buildSearchEntries(MOCK_WORKTREES)
-        expect(entries.every(e => e.absPath !== '/home/user/project')).toBe(true)
-    })
-
-    it('generates absolute path entries', () => {
-        const entries = buildSearchEntries(MOCK_WORKTREES)
-        expect(entries.some(e => e.keyword === '/home/user/project/.worktrees/feature-x')).toBe(true)
-    })
-
-    it('generates displayPath entries', () => {
-        const entries = buildSearchEntries(MOCK_WORKTREES)
-        expect(entries.some(e => e.keyword === './.worktrees/feature-x')).toBe(true)
-    })
-
-    it('generates displayPath without ./ prefix entries', () => {
-        const entries = buildSearchEntries(MOCK_WORKTREES)
-        expect(entries.some(e => e.keyword === '.worktrees/feature-x')).toBe(true)
-    })
-
-    it('sorts entries by keyword length descending', () => {
-        const entries = buildSearchEntries(MOCK_WORKTREES)
-        for (let i = 1; i < entries.length; i++) {
-            expect(entries[i - 1].keyword.length).toBeGreaterThanOrEqual(entries[i].keyword.length)
-        }
-    })
-
-    it('skips displayPath that is just "."', () => {
-        const entries = buildSearchEntries(MOCK_WORKTREES)
-        expect(entries.some(e => e.keyword === '.')).toBe(false)
-    })
-
-    it('returns empty for empty worktree list', () => {
-        const entries = buildSearchEntries([])
-        expect(entries).toEqual([])
-    })
-
-    it('all entries have correct absPath', () => {
-        const entries = buildSearchEntries(MOCK_WORKTREES)
-        for (const entry of entries) {
-            expect(entry.absPath).toMatch(/^\/home\/user\/project\/\.worktrees\//)
-        }
-    })
-})
-
-// ── worktreeSwitchButtonHtml ──
-
-describe('worktreeSwitchButtonHtml', () => {
-    it('contains chat-worktree-switch-btn class', () => {
-        const html = worktreeSwitchButtonHtml('/home/user/project/.worktrees/feature-x')
-        expect(html).toContain('chat-worktree-switch-btn')
+describe('worktreeButtonHtml', () => {
+    it('contains chat-worktree-btn class', () => {
+        const html = worktreeButtonHtml('/home/user/project/.worktrees/feature-x')
+        expect(html).toContain('chat-worktree-btn')
     })
 
     it('contains data-worktree-path with the absolute path', () => {
         const path = '/home/user/project/.worktrees/feature-x'
-        const html = worktreeSwitchButtonHtml(path)
+        const html = worktreeButtonHtml(path)
         expect(html).toContain(`data-worktree-path="${path}"`)
     })
 
+    it('contains data-file-path when resolvedPath is provided', () => {
+        const html = worktreeButtonHtml('/home/user/project/.worktrees/feature-x', '.worktrees/feature-x')
+        expect(html).toContain('data-file-path=".worktrees/feature-x"')
+    })
+
+    it('does NOT contain data-file-path when resolvedPath is omitted', () => {
+        const html = worktreeButtonHtml('/home/user/project/.worktrees/feature-x')
+        expect(html).not.toContain('data-file-path')
+    })
+
     it('contains the SVG icon', () => {
-        const html = worktreeSwitchButtonHtml('/home/user/project/.worktrees/feature-x')
+        const html = worktreeButtonHtml('/home/user/project/.worktrees/feature-x')
         expect(html).toContain('<svg')
     })
 
     it('contains title attribute', () => {
-        const html = worktreeSwitchButtonHtml('/home/user/project/.worktrees/feature-x')
+        const html = worktreeButtonHtml('/home/user/project/.worktrees/feature-x')
         expect(html).toContain('title=')
     })
 })
@@ -160,53 +68,46 @@ describe('annotateWorktreePaths', () => {
         clearWorktreeCache()
     })
 
-    it('annotates .worktrees/ path in text node (via worktree list)', async () => {
-        await seedCache(PROJECT_ROOT, MOCK_WORKTREES)
+    it('annotates .worktrees/ path in text node (regex-first, no cache needed)', () => {
         const result = annotateWorktreePaths('<p>.worktrees/feature-x</p>', { projectRoot: PROJECT_ROOT })
         expect(result.detectedWorktreePaths).toContain('/home/user/project/.worktrees/feature-x')
         expect(result.html).toContain('chat-worktree-path')
-        expect(result.html).toContain('chat-worktree-switch-btn')
+        expect(result.html).toContain('chat-worktree-btn')
     })
 
-    it('annotates ./.worktrees/ path in text node', async () => {
-        await seedCache(PROJECT_ROOT, MOCK_WORKTREES)
+    it('annotates ./.worktrees/ path in text node', () => {
         const result = annotateWorktreePaths('<p>./.worktrees/feature-x</p>', { projectRoot: PROJECT_ROOT })
         expect(result.detectedWorktreePaths).toContain('/home/user/project/.worktrees/feature-x')
         expect(result.html).toContain('chat-worktree-path')
     })
 
-    it('annotates absolute path in text node', async () => {
-        await seedCache(PROJECT_ROOT, MOCK_WORKTREES)
+    it('annotates absolute path in text node', () => {
         const absPath = '/home/user/project/.worktrees/feature-x'
         const result = annotateWorktreePaths(`<p>${absPath}</p>`, { projectRoot: PROJECT_ROOT })
         expect(result.detectedWorktreePaths).toContain(absPath)
         expect(result.html).toContain('chat-worktree-path')
     })
 
-    it('appends button after <a> tag with worktree href', async () => {
-        await seedCache(PROJECT_ROOT, MOCK_WORKTREES)
+    it('appends button after <a> tag with worktree href', () => {
         const result = annotateWorktreePaths('<a href=".worktrees/feature-x">link</a>', { projectRoot: PROJECT_ROOT })
         expect(result.detectedWorktreePaths).toContain('/home/user/project/.worktrees/feature-x')
-        expect(result.html).toContain('chat-worktree-switch-btn')
+        expect(result.html).toContain('chat-worktree-btn')
     })
 
-    it('adds class + button to <code> tag with worktree content', async () => {
-        await seedCache(PROJECT_ROOT, MOCK_WORKTREES)
+    it('adds class + button to <code> tag with worktree content', () => {
         const result = annotateWorktreePaths('<code>.worktrees/feature-x</code>', { projectRoot: PROJECT_ROOT })
         expect(result.detectedWorktreePaths).toContain('/home/user/project/.worktrees/feature-x')
         expect(result.html).toContain('chat-worktree-path')
-        expect(result.html).toContain('chat-worktree-switch-btn')
+        expect(result.html).toContain('chat-worktree-btn')
     })
 
-    it('does NOT annotate paths inside <pre> blocks', async () => {
-        await seedCache(PROJECT_ROOT, MOCK_WORKTREES)
+    it('does NOT annotate paths inside <pre> blocks', () => {
         const result = annotateWorktreePaths('<pre><code>.worktrees/feature-x</code></pre>', { projectRoot: PROJECT_ROOT })
         expect(result.detectedWorktreePaths).toEqual([])
         expect(result.html).not.toContain('chat-worktree-path')
     })
 
-    it('does NOT double-annotate paths inside <a> tags in text node step', async () => {
-        await seedCache(PROJECT_ROOT, MOCK_WORKTREES)
+    it('does NOT double-annotate paths inside <a> tags in text node step', () => {
         const result = annotateWorktreePaths('<a href=".worktrees/feature-x">.worktrees/feature-x</a>', { projectRoot: PROJECT_ROOT })
         const path = '/home/user/project/.worktrees/feature-x'
         // Should have exactly one detected path (from the <a> tag step, text inside <a> skipped)
@@ -214,257 +115,197 @@ describe('annotateWorktreePaths', () => {
         expect(count).toBe(1)
     })
 
-    it('does NOT annotate non-worktree paths', async () => {
-        await seedCache(PROJECT_ROOT, MOCK_WORKTREES)
+    it('does NOT annotate non-worktree paths', () => {
         const result = annotateWorktreePaths('<p>src/main.go</p>', { projectRoot: PROJECT_ROOT })
         expect(result.detectedWorktreePaths).toEqual([])
         expect(result.html).not.toContain('chat-worktree-path')
     })
 
-    it('annotates multiple worktree paths in one text node', async () => {
-        await seedCache(PROJECT_ROOT, MOCK_WORKTREES)
+    it('annotates multiple worktree paths in one text node', () => {
         const result = annotateWorktreePaths('<p>.worktrees/feature-x and .worktrees/bugfix-y</p>', { projectRoot: PROJECT_ROOT })
         expect(result.detectedWorktreePaths).toContain('/home/user/project/.worktrees/feature-x')
         expect(result.detectedWorktreePaths).toContain('/home/user/project/.worktrees/bugfix-y')
     })
 
-    it('returns empty result for empty input', async () => {
-        await seedCache(PROJECT_ROOT, MOCK_WORKTREES)
+    it('returns empty result for empty input', () => {
         const result = annotateWorktreePaths('', { projectRoot: PROJECT_ROOT })
         expect(result.html).toBe('')
         expect(result.detectedWorktreePaths).toEqual([])
     })
 
-    it('sets data-worktree-path attribute with absolute path', async () => {
-        await seedCache(PROJECT_ROOT, MOCK_WORKTREES)
+    it('sets data-worktree-path attribute with absolute path', () => {
         const result = annotateWorktreePaths('<code>.worktrees/feature-x</code>', { projectRoot: PROJECT_ROOT })
         expect(result.html).toContain('data-worktree-path="/home/user/project/.worktrees/feature-x"')
     })
 
-    it('skips <a> tags with non-worktree href', async () => {
-        await seedCache(PROJECT_ROOT, MOCK_WORKTREES)
+    it('skips <a> tags with non-worktree href', () => {
         const result = annotateWorktreePaths('<a href="https://example.com">link</a>', { projectRoot: PROJECT_ROOT })
         expect(result.detectedWorktreePaths).toEqual([])
-        expect(result.html).not.toContain('chat-worktree-switch-btn')
+        expect(result.html).not.toContain('chat-worktree-btn')
     })
 
-    it('skips <code> with chat-commit-hash class', async () => {
-        await seedCache(PROJECT_ROOT, MOCK_WORKTREES)
+    it('skips <code> with chat-commit-hash class', () => {
         const result = annotateWorktreePaths('<code class="chat-commit-hash">.worktrees/feature-x</code>', { projectRoot: PROJECT_ROOT })
         expect(result.detectedWorktreePaths).toEqual([])
     })
 
-    it('skips <code> with non-worktree text content', async () => {
-        await seedCache(PROJECT_ROOT, MOCK_WORKTREES)
+    it('skips <code> with non-worktree text content', () => {
         const result = annotateWorktreePaths('<code>src/main.go</code>', { projectRoot: PROJECT_ROOT })
         expect(result.detectedWorktreePaths).toEqual([])
     })
 
-    it('preserves text before and after worktree path in text node', async () => {
-        await seedCache(PROJECT_ROOT, MOCK_WORKTREES)
+    it('preserves text before and after worktree path in text node', () => {
         const result = annotateWorktreePaths('<p>Check .worktrees/feature-x for details</p>', { projectRoot: PROJECT_ROOT })
         expect(result.html).toContain('Check')
         expect(result.html).toContain('for details')
         expect(result.detectedWorktreePaths).toContain('/home/user/project/.worktrees/feature-x')
     })
 
-    it('handles mixed absolute and relative paths in same text node', async () => {
-        await seedCache(PROJECT_ROOT, MOCK_WORKTREES)
+    it('handles mixed absolute and relative paths in same text node', () => {
         const absPath = '/home/user/project/.worktrees/feature-x'
         const result = annotateWorktreePaths(`<p>${absPath} and .worktrees/bugfix-y</p>`, { projectRoot: PROJECT_ROOT })
         expect(result.detectedWorktreePaths).toContain(absPath)
         expect(result.detectedWorktreePaths).toContain('/home/user/project/.worktrees/bugfix-y')
     })
 
-    it('skips text nodes inside elements with chat-commit-hash class', async () => {
-        await seedCache(PROJECT_ROOT, MOCK_WORKTREES)
+    it('skips text nodes inside elements with chat-commit-hash class', () => {
         const result = annotateWorktreePaths('<span class="chat-commit-hash">.worktrees/feature-x</span>', { projectRoot: PROJECT_ROOT })
         expect(result.detectedWorktreePaths).toEqual([])
     })
 
-    it('skips text nodes inside elements with chat-worktree-path class', async () => {
-        await seedCache(PROJECT_ROOT, MOCK_WORKTREES)
+    it('skips text nodes inside elements with chat-worktree-path class', () => {
         const result = annotateWorktreePaths('<span class="chat-worktree-path">.worktrees/feature-x</span>', { projectRoot: PROJECT_ROOT })
         expect(result.detectedWorktreePaths).toEqual([])
     })
 
-    it('APPENDS worktree annotation to .chat-file-path elements (coexistence)', async () => {
-        await seedCache(PROJECT_ROOT, MOCK_WORKTREES)
-        // Simulate what useFilePathAnnotation would produce: a span with chat-file-path
+    it('APPENDS worktree annotation to .chat-file-path elements (coexistence)', () => {
         const result = annotateWorktreePaths('<span class="chat-file-path" data-file-path=".worktrees/feature-x">.worktrees/feature-x</span>', { projectRoot: PROJECT_ROOT })
-        // Should detect and annotate (coexistence)
         expect(result.detectedWorktreePaths).toContain('/home/user/project/.worktrees/feature-x')
         expect(result.html).toContain('chat-worktree-path')
-        expect(result.html).toContain('chat-worktree-switch-btn')
-        // The original chat-file-path should still be there
+        expect(result.html).toContain('chat-worktree-btn')
         expect(result.html).toContain('chat-file-path')
     })
 
-    it('does NOT annotate when cache is empty (triggers background fetch)', () => {
-        // No seedCache call — cache is empty
+    it('annotates without cache (regex-first design — works on first render)', () => {
+        // No cache seeding needed — regex matches .worktrees/ pattern directly
         const result = annotateWorktreePaths('<p>.worktrees/feature-x</p>', { projectRoot: PROJECT_ROOT })
-        expect(result.detectedWorktreePaths).toEqual([])
-        // The HTML should be returned as-is (no annotation)
-        expect(result.html).not.toContain('chat-worktree-path')
+        expect(result.detectedWorktreePaths.length).toBeGreaterThan(0)
+        expect(result.html).toContain('chat-worktree-path')
+        expect(result.html).toContain('chat-worktree-btn')
     })
 
-    it('does NOT annotate when all worktrees are current (no search entries)', async () => {
-        const onlyCurrent = [
-            {
-                path: '/home/user/project',
-                displayPath: '.',
-                branch: 'main',
-                isCurrent: true,
-                dirty: false,
-                changeCount: 0,
-                untrackedCount: 0,
-                locked: false,
-                missing: false,
-            },
-        ]
-        await seedCache(PROJECT_ROOT, onlyCurrent)
-        const result = annotateWorktreePaths('<p>.worktrees/feature-x</p>', { projectRoot: PROJECT_ROOT })
-        expect(result.detectedWorktreePaths).toEqual([])
-    })
-
-    it('does not annotate paths that are not in the worktree list', async () => {
-        await seedCache(PROJECT_ROOT, MOCK_WORKTREES)
-        const result = annotateWorktreePaths('<p>.worktrees/nonexistent-wt</p>', { projectRoot: PROJECT_ROOT })
-        expect(result.detectedWorktreePaths).toEqual([])
-        expect(result.html).not.toContain('chat-worktree-path')
-    })
-
-    it('uses cached worktree list on subsequent calls (fetchWorktreeList cache hit)', async () => {
-        // Seed cache using our helper (which waits for fetch to complete and cache to populate)
-        await seedCache(PROJECT_ROOT, MOCK_WORKTREES)
-        // Now make a second call — should use cache without fetching again
-        const mockFetch = vi.fn().mockResolvedValue({
-            ok: true,
-            json: () => Promise.resolve({ worktrees: [] }),
-        })
-        vi.stubGlobal('fetch', mockFetch)
-        const result = annotateWorktreePaths('<p>.worktrees/feature-x</p>', { projectRoot: PROJECT_ROOT })
-        // fetch should NOT be called again (cache hit)
-        expect(mockFetch).not.toHaveBeenCalled()
-        expect(result.detectedWorktreePaths).toContain('/home/user/project/.worktrees/feature-x')
-        vi.unstubAllGlobals()
-    })
-
-    it('handles fetch returning non-ok response', async () => {
-        const mockFetch = vi.fn().mockResolvedValue({ ok: false, status: 500 })
-        vi.stubGlobal('fetch', mockFetch)
-        // First call triggers fetch
-        annotateWorktreePaths('<p>test</p>', { projectRoot: PROJECT_ROOT })
-        await vi.waitFor(() => expect(mockFetch).toHaveBeenCalled())
-        // The cache should remain empty (fetch failed), so second call returns empty
-        const result = annotateWorktreePaths('<p>.worktrees/feature-x</p>', { projectRoot: PROJECT_ROOT })
-        expect(result.detectedWorktreePaths).toEqual([])
-        vi.unstubAllGlobals()
-    })
-
-    it('skips <code> that already has chat-worktree-path class (already annotated)', async () => {
-        await seedCache(PROJECT_ROOT, MOCK_WORKTREES)
-        // An element that already has the worktree-path class should not be double-annotated
+    it('skips <code> that already has chat-worktree-path class (already annotated)', () => {
         const result = annotateWorktreePaths('<code class="chat-worktree-path" data-worktree-path="/home/user/project/.worktrees/feature-x">.worktrees/feature-x</code>', { projectRoot: PROJECT_ROOT })
         // Should not add another button (no double annotation)
-        const btnCount = (result.html.match(/chat-worktree-switch-btn/g) || []).length
-        expect(btnCount).toBe(0) // no new button added since it's already annotated
+        const btnCount = (result.html.match(/chat-worktree-btn/g) || []).length
+        expect(btnCount).toBe(0)
     })
 
-    it('skips <code> inside <pre> with chat-file-path (worktree coexistence in pre)', async () => {
-        await seedCache(PROJECT_ROOT, MOCK_WORKTREES)
+    it('skips <code> inside <pre> with chat-file-path (worktree coexistence in pre)', () => {
         const result = annotateWorktreePaths('<pre><code class="chat-file-path">.worktrees/feature-x</code></pre>', { projectRoot: PROJECT_ROOT })
         expect(result.detectedWorktreePaths).toEqual([])
     })
 
-    it('annotates full absolute worktree path in text node', async () => {
-        await seedCache(PROJECT_ROOT, MOCK_WORKTREES)
+    it('annotates full absolute worktree path in text node', () => {
         const absPath = '/home/user/project/.worktrees/feature-x'
         const result = annotateWorktreePaths(`<p>${absPath}</p>`, { projectRoot: PROJECT_ROOT })
         expect(result.detectedWorktreePaths).toContain(absPath)
         expect(result.html).toContain('chat-worktree-path')
-        expect(result.html).toContain('chat-worktree-switch-btn')
-        // The full absolute path should be inside the span, not just a partial match
+        expect(result.html).toContain('chat-worktree-btn')
         expect(result.html).toContain('data-worktree-path="/home/user/project/.worktrees/feature-x"')
     })
 
-    it('annotates full absolute worktree path in <code> tag', async () => {
-        await seedCache(PROJECT_ROOT, MOCK_WORKTREES)
+    it('annotates full absolute worktree path in <code> tag', () => {
         const absPath = '/home/user/project/.worktrees/feature-x'
         const result = annotateWorktreePaths(`<code>${absPath}</code>`, { projectRoot: PROJECT_ROOT })
         expect(result.detectedWorktreePaths).toContain(absPath)
         expect(result.html).toContain('chat-worktree-path')
-        expect(result.html).toContain('chat-worktree-switch-btn')
+        expect(result.html).toContain('chat-worktree-btn')
     })
 
-    it('adds file-open button alongside worktree switch button for absolute path', async () => {
-        await seedCache(PROJECT_ROOT, MOCK_WORKTREES)
+    it('single button with data-worktree-path and data-file-path for path under projectRoot', () => {
         const absPath = '/home/user/project/.worktrees/feature-x'
         const result = annotateWorktreePaths(`<p>${absPath}</p>`, { projectRoot: PROJECT_ROOT })
-        // Both buttons should be present
-        expect(result.html).toContain('chat-worktree-switch-btn')
-        expect(result.html).toContain('chat-file-open-btn')
-        // The span should have both data attributes
+        expect(result.html).toContain('chat-worktree-btn')
         expect(result.html).toContain('data-worktree-path="/home/user/project/.worktrees/feature-x"')
         expect(result.html).toContain('data-file-path=".worktrees/feature-x"')
     })
 
-    it('adds file-open button alongside worktree switch button for <code> element', async () => {
-        await seedCache(PROJECT_ROOT, MOCK_WORKTREES)
-        const absPath = '/home/user/project/.worktrees/feature-x'
-        const result = annotateWorktreePaths(`<code>${absPath}</code>`, { projectRoot: PROJECT_ROOT })
-        expect(result.html).toContain('chat-worktree-switch-btn')
-        expect(result.html).toContain('chat-file-open-btn')
-        expect(result.html).toContain('data-file-path=".worktrees/feature-x"')
-    })
-
-    it('adds file-open button alongside worktree switch button for <a> element', async () => {
-        await seedCache(PROJECT_ROOT, MOCK_WORKTREES)
-        const result = annotateWorktreePaths('<a href=".worktrees/feature-x">link</a>', { projectRoot: PROJECT_ROOT })
-        expect(result.html).toContain('chat-worktree-switch-btn')
-        expect(result.html).toContain('chat-file-open-btn')
-    })
-
-    it('does NOT add file-open button for worktree path outside projectRoot', async () => {
-        // If a worktree path is not under projectRoot, only worktree switch button is added
-        const externalWorktrees = [
-            {
-                path: '/home/user/project',
-                displayPath: '.',
-                branch: 'main',
-                isCurrent: true,
-                dirty: false,
-                changeCount: 0,
-                untrackedCount: 0,
-                locked: false,
-                missing: false,
-            },
-            {
-                path: '/other/location/worktree-x',
-                displayPath: './worktree-x',
-                branch: 'worktree-x',
-                isCurrent: false,
-                dirty: false,
-                changeCount: 0,
-                untrackedCount: 0,
-                locked: false,
-                missing: false,
-            },
-        ]
-        await seedCache(PROJECT_ROOT, externalWorktrees)
+    it('does NOT add data-file-path for path outside projectRoot', () => {
+        // Absolute path that is not under projectRoot won't match regex
         const result = annotateWorktreePaths('<p>/other/location/worktree-x</p>', { projectRoot: PROJECT_ROOT })
-        expect(result.html).toContain('chat-worktree-switch-btn')
-        // No file-open button because /other/location/worktree-x is outside projectRoot
-        expect(result.html).not.toContain('chat-file-open-btn')
+        expect(result.detectedWorktreePaths).toEqual([])
+    })
+
+    it('does NOT annotate worktree-like path not under projectRoot', () => {
+        // .worktrees/ path always resolves under projectRoot, so this always works
+        // But /other/.worktrees/x won't match because it's not under projectRoot
+        const result = annotateWorktreePaths('<p>/other/path/.worktrees/x</p>', { projectRoot: PROJECT_ROOT })
+        expect(result.detectedWorktreePaths).toEqual([])
+    })
+})
+
+// ── verifyWorktreePaths ──
+
+describe('verifyWorktreePaths', () => {
+    beforeEach(() => {
+        clearWorktreeCache()
+    })
+
+    it('removes annotations for paths not in worktree list', async () => {
+        const mockFetch = vi.fn().mockResolvedValue({
+            ok: true,
+            json: () => Promise.resolve({ worktrees: [
+                { path: '/home/user/project/.worktrees/real-wt', displayPath: './.worktrees/real-wt', branch: 'real-wt', isCurrent: false, dirty: false, changeCount: 0, untrackedCount: 0, locked: false, missing: false },
+                { path: '/home/user/project', displayPath: '.', branch: 'main', isCurrent: true, dirty: false, changeCount: 0, untrackedCount: 0, locked: false, missing: false },
+            ] }),
+        })
+        vi.stubGlobal('fetch', mockFetch)
+
+        const container = document.createElement('div')
+        container.innerHTML = '<span class="chat-worktree-path" data-worktree-path="/home/user/project/.worktrees/fake-wt">.worktrees/fake-wt</span><button class="chat-worktree-btn" data-worktree-path="/home/user/project/.worktrees/fake-wt"></button>'
+
+        await verifyWorktreePaths(['/home/user/project/.worktrees/fake-wt'], container, PROJECT_ROOT)
+
+        // The fake worktree's span and button should be removed
+        expect(container.querySelector('.chat-worktree-btn')).toBeNull()
+        expect(container.querySelector('.chat-worktree-path')).toBeNull()
+        // The text content should remain (unwrapped from span)
+        expect(container.textContent).toContain('.worktrees/fake-wt')
+
+        vi.unstubAllGlobals()
+    })
+
+    it('keeps annotations for paths in worktree list', async () => {
+        const mockFetch = vi.fn().mockResolvedValue({
+            ok: true,
+            json: () => Promise.resolve({ worktrees: [
+                { path: '/home/user/project/.worktrees/real-wt', displayPath: './.worktrees/real-wt', branch: 'real-wt', isCurrent: false, dirty: false, changeCount: 0, untrackedCount: 0, locked: false, missing: false },
+                { path: '/home/user/project', displayPath: '.', branch: 'main', isCurrent: true, dirty: false, changeCount: 0, untrackedCount: 0, locked: false, missing: false },
+            ] }),
+        })
+        vi.stubGlobal('fetch', mockFetch)
+
+        const container = document.createElement('div')
+        container.innerHTML = '<span class="chat-worktree-path" data-worktree-path="/home/user/project/.worktrees/real-wt">.worktrees/real-wt</span><button class="chat-worktree-btn" data-worktree-path="/home/user/project/.worktrees/real-wt"></button>'
+
+        await verifyWorktreePaths(['/home/user/project/.worktrees/real-wt'], container, PROJECT_ROOT)
+
+        // The real worktree's span and button should remain
+        expect(container.querySelector('.chat-worktree-btn')).not.toBeNull()
+        expect(container.querySelector('.chat-worktree-path')).not.toBeNull()
+
+        vi.unstubAllGlobals()
     })
 })
 
 // ── useWorktreeAnnotation composable ──
 
 describe('useWorktreeAnnotation', () => {
-    it('returns annotateWorktreePaths and clearWorktreeCache', () => {
-        const { annotateWorktreePaths: annotate, clearWorktreeCache: clear } = useWorktreeAnnotation()
+    it('returns annotateWorktreePaths, verifyWorktreePaths and clearWorktreeCache', () => {
+        const { annotateWorktreePaths: annotate, verifyWorktreePaths: verify, clearWorktreeCache: clear } = useWorktreeAnnotation()
         expect(typeof annotate).toBe('function')
+        expect(typeof verify).toBe('function')
         expect(typeof clear).toBe('function')
     })
 })

--- a/web/src/composables/useChatRender.ts
+++ b/web/src/composables/useChatRender.ts
@@ -38,7 +38,7 @@ export function useChatRender(options) {
   const { messages, theme, currentSessionId } = options
   const { annotateFilePaths, verifyFilePaths } = useFilePathAnnotation()
   const { annotateCommitHashes, verifyCommitHashes } = useCommitHashAnnotation()
-  const { annotateWorktreePaths } = useWorktreeAnnotation()
+  const { annotateWorktreePaths, verifyWorktreePaths } = useWorktreeAnnotation()
   const { annotateLocalhostUrls } = useLocalhostAnnotation()
 
   const blockTasks = reactive({})
@@ -152,8 +152,15 @@ export function useChatRender(options) {
       // Annotate worktree paths BEFORE file paths — prevents file-path regex from
       // partially matching worktree directory paths (e.g. matching
       // /home/x/project/.worktrees instead of the full /home/x/project/.worktrees/fix)
-      const { html: worktreeHtml } = annotateWorktreePaths(html, { projectRoot })
+      const { html: worktreeHtml, detectedWorktreePaths } = annotateWorktreePaths(html, { projectRoot })
       html = worktreeHtml
+      if (detectedWorktreePaths.length > 0) {
+        const uniqueWtPaths = [...new Set(detectedWorktreePaths)]
+        nextTick(() => {
+          const el = document.getElementById('aiChatMessages')
+          if (el) verifyWorktreePaths(uniqueWtPaths, el, projectRoot)
+        })
+      }
       const { html: annotatedHtml, detectedPaths } = annotateFilePaths(html, { projectRoot })
       html = annotatedHtml
       if (detectedPaths.length > 0) {

--- a/web/src/composables/useChatRender.ts
+++ b/web/src/composables/useChatRender.ts
@@ -38,7 +38,7 @@ export function useChatRender(options) {
   const { messages, theme, currentSessionId } = options
   const { annotateFilePaths, verifyFilePaths } = useFilePathAnnotation()
   const { annotateCommitHashes, verifyCommitHashes } = useCommitHashAnnotation()
-  const { annotateWorktreePaths, verifyWorktreePaths } = useWorktreeAnnotation()
+  const { annotateWorktreePaths } = useWorktreeAnnotation()
   const { annotateLocalhostUrls } = useLocalhostAnnotation()
 
   const blockTasks = reactive({})
@@ -152,15 +152,8 @@ export function useChatRender(options) {
       // Annotate worktree paths BEFORE file paths — prevents file-path regex from
       // partially matching worktree directory paths (e.g. matching
       // /home/x/project/.worktrees instead of the full /home/x/project/.worktrees/fix)
-      const { html: worktreeHtml, detectedWorktreePaths } = annotateWorktreePaths(html, { projectRoot })
+      const { html: worktreeHtml } = annotateWorktreePaths(html, { projectRoot })
       html = worktreeHtml
-      if (detectedWorktreePaths.length > 0) {
-        const uniqueWtPaths = [...new Set(detectedWorktreePaths)]
-        nextTick(() => {
-          const el = document.getElementById('aiChatMessages')
-          if (el) verifyWorktreePaths(uniqueWtPaths, el, projectRoot)
-        })
-      }
       const { html: annotatedHtml, detectedPaths } = annotateFilePaths(html, { projectRoot })
       html = annotatedHtml
       if (detectedPaths.length > 0) {

--- a/web/src/composables/useChatSession.ts
+++ b/web/src/composables/useChatSession.ts
@@ -6,6 +6,7 @@ import { useSessionIdentity } from '@/composables/useSessionIdentity.ts'
 import { useAgents } from '@/composables/useAgents'
 import { store } from '@/stores/app.ts'
 import { buildMessageSnapshot, parseMessages } from '@/utils/chatSessionUtils.ts'
+import { warmWorktreeCache } from '@/composables/useWorktreeAnnotation.ts'
 
 // Module-level one-time session list load (replaces continuous polling)
 // Accessible from App.vue without instantiating useChatSession
@@ -159,6 +160,8 @@ export function useChatSession(options: UseChatSessionOptions) {
     try {
       // Load agents first so we can resolve agent names
       if (agents.value.length === 0) await loadAgents()
+      // Warm worktree cache so annotateWorktreePaths has data when rendering messages
+      warmWorktreeCache(store.state.projectRoot)
       // Use max of initialMessages and current loaded count to avoid truncating lazy-loaded messages
       const limit = Math.max(store.state.chatInitialMessages, messages.value.length)
       const url = currentSessionId.value

--- a/web/src/composables/useCommitHashAnnotation.ts
+++ b/web/src/composables/useCommitHashAnnotation.ts
@@ -40,7 +40,7 @@ export function commitOpenButtonHtml(sha: string): string {
  *
  * Processing order:
  *   1. <code> tags whose text content looks like a commit hash → add class + button
- *   2. Text nodes (outside pre/a/code) → regex match hashes → insert span + button
+ *   2. Text nodes (outside a/code) → regex match hashes → insert span + button
  *
  * Returns the annotated HTML and a list of detected SHAs for the caller to verify asynchronously.
  */
@@ -55,8 +55,6 @@ export function annotateCommitHashes(
 
     // ── Step 1: <code> tags whose content looks like a commit hash ──
     for (const code of doc.querySelectorAll('code')) {
-        // Skip <code> inside <pre> blocks
-        if (code.closest('pre')) continue
         // Skip <code> already annotated as file path
         if (code.classList.contains('chat-file-path')) continue
         const stripped = (code.textContent || '').trim()
@@ -67,14 +65,12 @@ export function annotateCommitHashes(
         code.insertAdjacentHTML('afterend', commitOpenButtonHtml(stripped))
     }
 
-    // ── Step 2: Text nodes (outside pre/a/code) → regex match hashes ──
+    // ── Step 2: Text nodes (outside a/code) → regex match hashes ──
     const textNodes: Text[] = []
     const walker = doc.createTreeWalker(doc.body, NodeFilter.SHOW_TEXT, {
         acceptNode(node: Text) {
             const parent = node.parentElement
             if (!parent) return NodeFilter.FILTER_REJECT
-            // Skip <pre> blocks
-            if (parent.closest('pre')) return NodeFilter.FILTER_REJECT
             // Skip text inside <a> tags
             if (parent.tagName === 'A' || parent.closest('a')) return NodeFilter.FILTER_REJECT
             // Skip text inside <code> tags (handled in step 1)

--- a/web/src/composables/useCommitHashAnnotation.ts
+++ b/web/src/composables/useCommitHashAnnotation.ts
@@ -53,7 +53,10 @@ export function annotateCommitHashes(
 
     const doc = new DOMParser().parseFromString(html, 'text/html')
 
-    // ── Step 1: <code> tags whose content looks like a commit hash ──
+    // ── Step 1: <code> tags whose content is purely a commit hash ──
+    // Only handles the case where the entire <code> content is a single hash.
+    // Mixed content is handled by Step 2's text-node walker, which now
+    // also enters <code> elements.
     for (const code of doc.querySelectorAll('code')) {
         // Skip <code> already annotated as file path
         if (code.classList.contains('chat-file-path')) continue
@@ -65,7 +68,7 @@ export function annotateCommitHashes(
         code.insertAdjacentHTML('afterend', commitOpenButtonHtml(stripped))
     }
 
-    // ── Step 2: Text nodes (outside a/code) → regex match hashes ──
+    // ── Step 2: Text nodes (outside a, but including inside <code>) → regex match hashes ──
     const textNodes: Text[] = []
     const walker = doc.createTreeWalker(doc.body, NodeFilter.SHOW_TEXT, {
         acceptNode(node: Text) {
@@ -73,10 +76,10 @@ export function annotateCommitHashes(
             if (!parent) return NodeFilter.FILTER_REJECT
             // Skip text inside <a> tags
             if (parent.tagName === 'A' || parent.closest('a')) return NodeFilter.FILTER_REJECT
-            // Skip text inside <code> tags (handled in step 1)
-            if (parent.tagName === 'CODE' || parent.closest('code')) return NodeFilter.FILTER_REJECT
+            // Skip <code> elements already annotated by step 1
+            if (parent.classList.contains('chat-commit-hash')) return NodeFilter.FILTER_REJECT
             // Skip already-annotated spans
-            if (parent.classList.contains('chat-file-path') || parent.classList.contains('chat-commit-hash')) return NodeFilter.FILTER_REJECT
+            if (parent.classList.contains('chat-file-path')) return NodeFilter.FILTER_REJECT
             return NodeFilter.FILTER_ACCEPT
         }
     })

--- a/web/src/composables/useFilePathAnnotation.ts
+++ b/web/src/composables/useFilePathAnnotation.ts
@@ -14,6 +14,8 @@ export function resolveFilePath(path: string, projectRoot: string): string | nul
     // Reject paths containing glob wildcards, angle brackets, or double-star.
     // These are glob patterns or template variables, not real filesystem paths.
     if (/[*?\\[\]<>]/.test(path) || path.includes('**')) return null
+    // Reject URLs (handled by localhost annotation, not file path annotation)
+    if (/^https?:\/\//i.test(path)) return null
 
     if (path.startsWith('/')) {
         // Absolute path: must be under projectRoot
@@ -98,6 +100,8 @@ const FILE_PATH_RE = /(?:\/[^\s<>"')\]]+(?:\/[^\s<>"')\]]+)+\.[a-zA-Z][a-zA-Z0-9
  */
 function looksLikeFilePath(text: string): boolean {
     if (/[*?\\[\]<>]/.test(text) || text.includes('**')) return false
+    // Exclude URLs (handled by localhost annotation)
+    if (/^https?:\/\//i.test(text)) return false
     return /\/|\.[a-zA-Z][a-zA-Z0-9]{0,3}$/.test(text)
 }
 

--- a/web/src/composables/useFilePathAnnotation.ts
+++ b/web/src/composables/useFilePathAnnotation.ts
@@ -146,38 +146,25 @@ export function annotateFilePaths(
         a.insertAdjacentHTML('afterend', fileOpenButtonHtml(resolved))
     }
 
-    // ── Step 2: <code> tags whose content looks like a file path ──
+    // ── Step 2: <code> tags whose content is purely a file path ──
+    // Only handles the case where the entire <code> content is a single path.
+    // Mixed content (e.g. `import "src/main.go"`) is handled by Step 3's
+    // text-node walker, which now also enters <code> elements.
     for (const code of doc.querySelectorAll('code')) {
         // Skip <code> already annotated as worktree (worktree annotation runs first)
         if (code.classList.contains('chat-worktree-path')) continue
         const stripped = (code.textContent || '').trim()
-        if (looksLikeFilePath(stripped)) {
-            // Entire <code> content is likely a file path — try to resolve it
-            const resolved = resolveFilePath(stripped, projectRoot)
-            if (resolved && !resolved.includes(' ') && !resolved.includes('"')) {
-                // Valid file path — annotate the whole <code> element
-                detectedPaths.push(resolved)
-                code.classList.add('chat-file-path')
-                code.setAttribute('data-file-path', resolved)
-                code.insertAdjacentHTML('afterend', fileOpenButtonHtml(resolved))
-                continue
-            }
-        }
-        // Check if <code> content contains a file path (e.g. `import "src/main.go"`)
-        // Use regex to find the path portion and append a button after the <code>
-        FILE_PATH_RE.lastIndex = 0
-        const match = FILE_PATH_RE.exec(stripped)
-        if (match) {
-            const pathStr = match[0]
-            const resolved = resolveFilePath(pathStr, projectRoot)
-            if (resolved) {
-                detectedPaths.push(resolved)
-                code.insertAdjacentHTML('afterend', fileOpenButtonHtml(resolved))
-            }
-        }
+        if (!looksLikeFilePath(stripped)) continue
+        const resolved = resolveFilePath(stripped, projectRoot)
+        if (!resolved || resolved.includes(' ') || resolved.includes('"')) continue
+        // Entire <code> content is a valid file path — annotate the whole element
+        detectedPaths.push(resolved)
+        code.classList.add('chat-file-path')
+        code.setAttribute('data-file-path', resolved)
+        code.insertAdjacentHTML('afterend', fileOpenButtonHtml(resolved))
     }
 
-    // ── Step 3: Text nodes (outside a/code/worktree) → regex match paths ──
+    // ── Step 3: Text nodes (outside a/worktree-annotated, but including inside <code>) → regex match paths ──
     const textNodes: Text[] = []
     const walker = doc.createTreeWalker(doc.body, NodeFilter.SHOW_TEXT, {
         acceptNode(node: Text) {
@@ -185,8 +172,8 @@ export function annotateFilePaths(
             if (!parent) return NodeFilter.FILTER_REJECT
             // Skip text inside <a> tags (handled in step 1)
             if (parent.tagName === 'A' || parent.closest('a')) return NodeFilter.FILTER_REJECT
-            // Skip text inside <code> tags (handled in step 2)
-            if (parent.tagName === 'CODE' || parent.closest('code')) return NodeFilter.FILTER_REJECT
+            // Skip text inside <code> elements already annotated by step 2
+            if (parent.classList.contains('chat-file-path')) return NodeFilter.FILTER_REJECT
             // Skip text inside worktree-annotated elements (worktree annotation runs first)
             if (parent.classList.contains('chat-worktree-path') || parent.closest('.chat-worktree-path')) return NodeFilter.FILTER_REJECT
             return NodeFilter.FILTER_ACCEPT

--- a/web/src/composables/useFilePathAnnotation.ts
+++ b/web/src/composables/useFilePathAnnotation.ts
@@ -11,6 +11,10 @@ import { clearWorktreeCache } from '@/composables/useWorktreeAnnotation.ts'
  * When projectRoot is empty, relative paths are returned as-is (best-effort).
  */
 export function resolveFilePath(path: string, projectRoot: string): string | null {
+    // Reject paths containing glob wildcards, angle brackets, or double-star.
+    // These are glob patterns or template variables, not real filesystem paths.
+    if (/[*?\\[\]<>]/.test(path) || path.includes('**')) return null
+
     if (path.startsWith('/')) {
         // Absolute path: must be under projectRoot
         if (!projectRoot) return null
@@ -89,8 +93,11 @@ const FILE_PATH_RE = /(?:\/[^\s<>"')\]]+(?:\/[^\s<>"')\]]+)+\.[a-zA-Z][a-zA-Z0-9
  * - Contains at least one '/' (e.g. src/foo.ts, ./bar.go)
  * - Or has a short file extension (e.g. ChatPanel.vue, main.go)
  * Bare identifiers like `useAutoSpeech`, `onUnmounted`, `ref` should NOT match.
+ * Rejects strings containing glob wildcards, angle brackets, or double-star
+ * — these are glob patterns or template variables, not real file paths.
  */
 function looksLikeFilePath(text: string): boolean {
+    if (/[*?\\[\]<>]/.test(text) || text.includes('**')) return false
     return /\/|\.[a-zA-Z][a-zA-Z0-9]{0,3}$/.test(text)
 }
 
@@ -246,53 +253,59 @@ export function annotateFilePaths(
 
 // Cache of verified paths: path -> true (exists) | false (not found)
 const verifiedCache = new Map<string, boolean>()
-// In-flight verification requests to avoid duplicates
-const inFlight = new Map<string, Promise<boolean>>()
-
-async function checkPathExists(path: string): Promise<boolean> {
-    if (verifiedCache.has(path)) return verifiedCache.get(path)!
-    if (inFlight.has(path)) return inFlight.get(path)!
-
-    const promise = (async () => {
-        try {
-            const [fileResp, dirResp] = await Promise.all([
-                fetch(`/api/file/${encodeURIComponent(path)}`, { method: 'HEAD' }),
-                fetch(`/api/dir?path=${encodeURIComponent(path)}`, { method: 'HEAD' }),
-            ])
-            return fileResp.ok || dirResp.ok
-        } catch {
-            return true // Network error — assume exists (best effort)
-        }
-    })()
-
-    inFlight.set(path, promise)
-    const exists = await promise
-    verifiedCache.set(path, exists)
-    inFlight.delete(path)
-    return exists
-}
+// In-flight batch request to avoid duplicate calls
+let batchInFlight: Promise<{ results: Record<string, string> }> | null = null
 
 /**
  * Check which file paths actually exist on the server,
  * and hide buttons for files that don't exist.
+ * Uses a single batch POST /api/file/batch-exists request instead of
+ * per-path HEAD requests, dramatically reducing HTTP overhead.
  */
 export async function verifyFilePaths(paths: string[], containerEl: HTMLElement): Promise<void> {
-    // Batch verification with concurrency limit
-    const limit = 6
     const unique = [...new Set(paths)]
+    if (unique.length === 0) return
+
+    // Check cache first, collect uncached paths
+    const uncached: string[] = []
     const results = new Map<string, boolean>()
 
-    for (let i = 0; i < unique.length; i += limit) {
-        const batch = unique.slice(i, i + limit)
-        const batchResults = await Promise.all(batch.map(async (path) => {
-            const exists = await checkPathExists(path)
-            return { path, exists }
-        }))
-        for (const { path, exists } of batchResults) {
-            results.set(path, exists)
+    for (const p of unique) {
+        if (verifiedCache.has(p)) {
+            results.set(p, verifiedCache.get(p)!)
+        } else {
+            uncached.push(p)
         }
     }
 
+    // Batch request for uncached paths
+    if (uncached.length > 0) {
+        try {
+            // Reuse in-flight batch request if one is already running
+            if (!batchInFlight) {
+                batchInFlight = fetch('/api/file/batch-exists', {
+                    method: 'POST',
+                    headers: { 'Content-Type': 'application/json' },
+                    body: JSON.stringify({ paths: uncached }),
+                }).then(r => r.json())
+            }
+            const resp = await batchInFlight
+            batchInFlight = null
+
+            for (const [path, type] of Object.entries(resp.results)) {
+                const exists = type === 'file' || type === 'dir'
+                results.set(path, exists)
+                verifiedCache.set(path, exists)
+            }
+        } catch {
+            // Network error — assume all exist (best effort)
+            for (const p of uncached) {
+                results.set(p, true)
+            }
+        }
+    }
+
+    // Remove non-existent path annotations from DOM
     for (const [path, exists] of results) {
         if (!exists) {
             containerEl.querySelectorAll(`.chat-file-open-btn[data-file-path="${CSS.escape(path)}"]`).forEach(btn => {
@@ -310,7 +323,7 @@ export async function verifyFilePaths(paths: string[], containerEl: HTMLElement)
  */
 export function clearVerifiedCache(): void {
     verifiedCache.clear()
-    inFlight.clear()
+    batchInFlight = null
     clearCommitHashCache()
     clearWorktreeCache()
 }

--- a/web/src/composables/useFilePathAnnotation.ts
+++ b/web/src/composables/useFilePathAnnotation.ts
@@ -113,7 +113,7 @@ function looksLikeFilePath(text: string): boolean {
  * Processing order:
  *   1. <a href="..."> tags with local-file hrefs → append open button
  *   2. <code> tags whose text content looks like a path → add class + button
- *   3. Text nodes (outside pre/a/code) → regex match paths → insert span + button
+ *   3. Text nodes (outside a/code) → regex match paths → insert span + button
  *
  * Returns the annotated HTML and a list of detected (resolved) paths
  * for the caller to verify asynchronously.
@@ -144,28 +144,41 @@ export function annotateFilePaths(
 
     // ── Step 2: <code> tags whose content looks like a file path ──
     for (const code of doc.querySelectorAll('code')) {
-        // Skip <code> inside <pre> blocks (multi-line code blocks should not get buttons)
-        if (code.closest('pre')) continue
         // Skip <code> already annotated as worktree (worktree annotation runs first)
         if (code.classList.contains('chat-worktree-path')) continue
         const stripped = (code.textContent || '').trim()
-        if (!looksLikeFilePath(stripped)) continue
-        const resolved = resolveFilePath(stripped, projectRoot)
-        if (!resolved) continue
-        detectedPaths.push(resolved)
-        code.classList.add('chat-file-path')
-        code.setAttribute('data-file-path', resolved)
-        code.insertAdjacentHTML('afterend', fileOpenButtonHtml(resolved))
+        if (looksLikeFilePath(stripped)) {
+            // Entire <code> content is likely a file path — try to resolve it
+            const resolved = resolveFilePath(stripped, projectRoot)
+            if (resolved && !resolved.includes(' ') && !resolved.includes('"')) {
+                // Valid file path — annotate the whole <code> element
+                detectedPaths.push(resolved)
+                code.classList.add('chat-file-path')
+                code.setAttribute('data-file-path', resolved)
+                code.insertAdjacentHTML('afterend', fileOpenButtonHtml(resolved))
+                continue
+            }
+        }
+        // Check if <code> content contains a file path (e.g. `import "src/main.go"`)
+        // Use regex to find the path portion and append a button after the <code>
+        FILE_PATH_RE.lastIndex = 0
+        const match = FILE_PATH_RE.exec(stripped)
+        if (match) {
+            const pathStr = match[0]
+            const resolved = resolveFilePath(pathStr, projectRoot)
+            if (resolved) {
+                detectedPaths.push(resolved)
+                code.insertAdjacentHTML('afterend', fileOpenButtonHtml(resolved))
+            }
+        }
     }
 
-    // ── Step 3: Text nodes (outside pre/a/code/worktree) → regex match paths ──
+    // ── Step 3: Text nodes (outside a/code/worktree) → regex match paths ──
     const textNodes: Text[] = []
     const walker = doc.createTreeWalker(doc.body, NodeFilter.SHOW_TEXT, {
         acceptNode(node: Text) {
             const parent = node.parentElement
             if (!parent) return NodeFilter.FILTER_REJECT
-            // Skip <pre> blocks
-            if (parent.closest('pre')) return NodeFilter.FILTER_REJECT
             // Skip text inside <a> tags (handled in step 1)
             if (parent.tagName === 'A' || parent.closest('a')) return NodeFilter.FILTER_REJECT
             // Skip text inside <code> tags (handled in step 2)

--- a/web/src/composables/useLocalhostAnnotation.ts
+++ b/web/src/composables/useLocalhostAnnotation.ts
@@ -79,7 +79,7 @@ export function annotateLocalhostUrls(html: string): string {
     const { sshInfo } = usePortForward()
     if (sshInfo.value?.enabled === false) return html
 
-    // Protect <pre> blocks from annotation (code blocks should not get buttons)
+    // Protect <pre> blocks during bare-URL regex pass (restored with annotation below)
     const preBlocks: string[] = []
     html = html.replace(/<pre[^>]*>[\s\S]*?<\/pre>/gi, (match) => {
         preBlocks.push(match)
@@ -141,8 +141,28 @@ export function annotateLocalhostUrls(html: string): string {
         return `${match}${localhostOpenButtonHtml(parsed.port, parsed.protocol, href)}`
     })
 
-    // Restore <pre> blocks
-    html = html.replace(/<!--PREBLOCK_LOCALHOST(\d+)-->/g, (_, idx) => preBlocks[parseInt(idx)])
+    // Restore <pre> blocks — annotate localhost URLs inside them
+    html = html.replace(/<!--PREBLOCK_LOCALHOST(\d+)-->/g, (_, idx) => {
+        let preHtml = preBlocks[parseInt(idx)]
+        // Find <code> elements inside <pre> that contain a localhost URL
+        // and wrap them with <a> + button (same pattern as inline <code> handling)
+        preHtml = preHtml.replace(/<code[^>]*>([\s\S]*?)<\/code>/gi, (codeMatch, codeContent) => {
+            const parsed = parseLocalhostUrl(codeContent.trim())
+            if (parsed) {
+                return `<a href="${escapeHtml(parsed.fullUrl)}" target="_blank" rel="noopener">${codeMatch}</a>${localhostOpenButtonHtml(parsed.port, parsed.protocol, parsed.fullUrl)}`
+            }
+            return codeMatch
+        })
+        // Also annotate bare localhost URLs in <pre> text (not inside <code>)
+        preHtml = preHtml.replace(LOCALHOST_URL_RE, (url, portStr) => {
+            const port = parseInt(portStr)
+            if (port <= 0 || port > 65535) return url
+            const protocol = url.startsWith('https') ? 'https' : 'http'
+            const linkHtml = `<a href="${escapeHtml(url)}" target="_blank" rel="noopener">${escapeHtml(url)}</a>`
+            return `${linkHtml}${localhostOpenButtonHtml(port, protocol, url)}`
+        })
+        return preHtml
+    })
 
     return html
 }

--- a/web/src/composables/useWorktreeAnnotation.ts
+++ b/web/src/composables/useWorktreeAnnotation.ts
@@ -162,7 +162,10 @@ export function annotateWorktreePaths(
         a.insertAdjacentHTML('afterend', worktreeButtonHtml(match.absPath, resolved || undefined))
     }
 
-    // ── Step 2: <code> and <span class="chat-file-path"> matching a worktree ──
+    // ── Step 2: <code> and <span class="chat-file-path"> whose content is purely a worktree path ──
+    // Only handles the case where the entire element content matches a worktree.
+    // Mixed content is handled by Step 3's text-node walker, which now
+    // also enters <code> elements.
     for (const el of doc.querySelectorAll('code, span.chat-file-path')) {
         if (el.classList.contains('chat-commit-hash')) continue
         if (el.classList.contains('chat-worktree-path')) continue
@@ -179,15 +182,16 @@ export function annotateWorktreePaths(
         el.insertAdjacentHTML('afterend', worktreeButtonHtml(match.absPath, resolved || undefined))
     }
 
-    // ── Step 3: Text nodes (outside a/code) → search worktree paths ──
+    // ── Step 3: Text nodes (outside a, but including inside <code>) → search worktree paths ──
     const textNodes: Text[] = []
     const walker = doc.createTreeWalker(doc.body, NodeFilter.SHOW_TEXT, {
         acceptNode(node: Text) {
             const parent = node.parentElement
             if (!parent) return NodeFilter.FILTER_REJECT
             if (parent.tagName === 'A' || parent.closest('a')) return NodeFilter.FILTER_REJECT
-            if (parent.tagName === 'CODE' || parent.closest('code')) return NodeFilter.FILTER_REJECT
-            if (parent.classList.contains('chat-file-path') || parent.classList.contains('chat-commit-hash') || parent.classList.contains('chat-worktree-path')) return NodeFilter.FILTER_REJECT
+            // Skip elements already annotated by step 2
+            if (parent.classList.contains('chat-worktree-path')) return NodeFilter.FILTER_REJECT
+            if (parent.classList.contains('chat-file-path') || parent.classList.contains('chat-commit-hash')) return NodeFilter.FILTER_REJECT
             return NodeFilter.FILTER_ACCEPT
         }
     })

--- a/web/src/composables/useWorktreeAnnotation.ts
+++ b/web/src/composables/useWorktreeAnnotation.ts
@@ -19,7 +19,7 @@ export function worktreeButtonHtml(absPath: string, resolvedPath?: string): stri
     return `<button ${attrs} title="${escapeHtml(gt('chat.attach.openWorktree'))}">${WORKTREE_ICON_SVG}</button>`
 }
 
-// ── Worktree list cache (for async verification) ──
+// ── Worktree list cache ──
 
 interface WorktreeInfo {
     path: string
@@ -57,42 +57,81 @@ async function fetchWorktreeList(projectRoot: string): Promise<WorktreeInfo[]> {
 }
 
 /**
- * Regex that matches worktree paths in plain text.
- * Matches:
- *   1. Absolute paths containing /.worktrees/ (e.g. /home/user/project/.worktrees/feature-x)
- *   2. Relative paths starting with .worktrees/ (e.g. .worktrees/feature-x)
- *   3. Relative paths starting with ./.worktrees/ (e.g. ./.worktrees/feature-x)
- *
- * This regex runs on text node content only (never on HTML attributes or tags),
- * same design as FILE_PATH_RE. It enables synchronous annotation without
- * waiting for the async worktree list API.
+ * Pre-warm the worktree list cache for a project.
+ * Call this before rendering messages (e.g. in loadHistory) so that
+ * annotateWorktreePaths has cached data available synchronously.
+ * If the cache is already populated, this is a no-op.
  */
-const WORKTREE_PATH_RE = /(?:\/[^\s<>"')\]]+\/\.worktrees\/[^\s<>"')\]]+|\.\/\.worktrees\/[^\s<>"')\]]+|\.worktrees\/[^\s<>"')\]]+)/g
+export async function warmWorktreeCache(projectRoot: string): Promise<void> {
+    if (!projectRoot) return
+    await fetchWorktreeList(projectRoot)
+}
+
+// ── Search entry building ──
+
+interface SearchEntry {
+    /** The search keyword (exact string to find in text) */
+    keyword: string
+    /** Absolute path of the worktree (for data-worktree-path) */
+    absPath: string
+}
 
 /**
- * Check if a string looks like a worktree path that should be annotated.
- * Used for <code> tag content detection (simpler than full regex).
+ * Build search entries from a worktree list.
+ * Each worktree generates up to 3 keywords: path, displayPath, displayPath without ./
+ * Entries are sorted by keyword length descending (longest first) to avoid
+ * shorter entries matching substrings of longer ones.
+ * Excludes worktrees where isCurrent is true.
  */
-function looksLikeWorktreePath(text: string): boolean {
-    return text.includes('.worktrees/')
+export function buildSearchEntries(worktrees: WorktreeInfo[]): SearchEntry[] {
+    const entries: SearchEntry[] = []
+    for (const wt of worktrees) {
+        if (wt.isCurrent) continue
+        // Absolute path
+        if (wt.path) {
+            entries.push({ keyword: wt.path, absPath: wt.path })
+        }
+        // displayPath (e.g. "./.worktrees/feature-x")
+        if (wt.displayPath && wt.displayPath !== '.') {
+            entries.push({ keyword: wt.displayPath, absPath: wt.path })
+            // displayPath without leading "./" (e.g. ".worktrees/feature-x")
+            const noDotSlash = wt.displayPath.replace(/^\.\//, '')
+            if (noDotSlash !== wt.displayPath) {
+                entries.push({ keyword: noDotSlash, absPath: wt.path })
+            }
+        }
+    }
+    // Sort by keyword length descending (longest first for greedy matching)
+    entries.sort((a, b) => b.keyword.length - a.keyword.length)
+    return entries
+}
+
+/**
+ * Find a matching worktree search entry for a given text string.
+ * Returns the first (longest) matching entry, or null.
+ */
+function findWorktreeMatch(text: string, searchEntries: SearchEntry[]): SearchEntry | null {
+    const trimmed = text.trim()
+    for (const entry of searchEntries) {
+        if (trimmed === entry.keyword) return entry
+    }
+    return null
 }
 
 /**
  * Detect worktree paths in rendered HTML and insert action buttons after them.
+ * Uses the cached worktree list (from GET /api/git/worktrees) for matching.
  *
- * Design: regex-first, verify-later — aligned with localhost/commit/file-path annotations.
- *   1. Synchronously annotate all text matching .worktrees/ patterns (no API call needed)
- *   2. Asynchronously verify via GET /api/git/worktrees, removing false positives
- *
- * This ensures annotations appear immediately on first render AND survive app restart
- * (no async cache dependency in the annotation step itself).
+ * Requires warmWorktreeCache() to be called before rendering messages
+ * (done automatically in loadHistory). On cache miss, triggers background
+ * fetch but returns un-annotated HTML (annotations will appear on next render).
  *
  * Processing order:
  *   1. <a href> tags matching a worktree path → append action button
  *   2. <code> and <span class="chat-file-path"> tags matching → add class + button
- *   3. Text nodes (outside pre/a/code) → regex match → insert span + button
+ *   3. Text nodes (outside pre/a/code) → search worktree paths → insert span + button
  *
- * Returns the annotated HTML and a list of detected worktree path strings.
+ * Returns the annotated HTML and a list of detected absolute worktree paths.
  */
 export function annotateWorktreePaths(
     html: string,
@@ -100,17 +139,27 @@ export function annotateWorktreePaths(
 ): { html: string; detectedWorktreePaths: string[] } {
     if (!html) return { html: '', detectedWorktreePaths: [] }
 
+    const worktrees = worktreeListCache.get(projectRoot)
+    if (!worktrees || worktrees.length === 0) {
+        // Cache miss — trigger background fetch, return empty for now
+        fetchWorktreeList(projectRoot)
+        return { html, detectedWorktreePaths: [] }
+    }
+
+    const searchEntries = buildSearchEntries(worktrees)
+    if (searchEntries.length === 0) return { html, detectedWorktreePaths: [] }
+
     const detectedWorktreePaths: string[] = []
     const doc = new DOMParser().parseFromString(html, 'text/html')
 
     // ── Step 1: <a href> tags matching a worktree path ──
     for (const a of doc.querySelectorAll('a[href]')) {
         const href = a.getAttribute('href') || ''
-        if (!looksLikeWorktreePath(href)) continue
-        const match = extractWorktreePath(href, projectRoot)
+        const match = findWorktreeMatch(href, searchEntries)
         if (!match) continue
-        detectedWorktreePaths.push(match)
-        a.insertAdjacentHTML('afterend', worktreeButtonHtml(match, resolveFilePath(match, projectRoot) || undefined))
+        detectedWorktreePaths.push(match.absPath)
+        const resolved = resolveFilePath(match.absPath, projectRoot)
+        a.insertAdjacentHTML('afterend', worktreeButtonHtml(match.absPath, resolved || undefined))
     }
 
     // ── Step 2: <code> and <span class="chat-file-path"> matching a worktree ──
@@ -119,20 +168,19 @@ export function annotateWorktreePaths(
         if (el.classList.contains('chat-commit-hash')) continue
         if (el.classList.contains('chat-worktree-path')) continue
         const stripped = (el.textContent || '').trim()
-        if (!looksLikeWorktreePath(stripped)) continue
-        const match = extractWorktreePath(stripped, projectRoot)
+        const match = findWorktreeMatch(stripped, searchEntries)
         if (!match) continue
-        detectedWorktreePaths.push(match)
+        detectedWorktreePaths.push(match.absPath)
         el.classList.add('chat-worktree-path')
-        el.setAttribute('data-worktree-path', match)
-        const resolved = resolveFilePath(match, projectRoot)
+        el.setAttribute('data-worktree-path', match.absPath)
+        const resolved = resolveFilePath(match.absPath, projectRoot)
         if (resolved) {
             el.setAttribute('data-file-path', resolved)
         }
-        el.insertAdjacentHTML('afterend', worktreeButtonHtml(match, resolved || undefined))
+        el.insertAdjacentHTML('afterend', worktreeButtonHtml(match.absPath, resolved || undefined))
     }
 
-    // ── Step 3: Text nodes (outside pre/a/code) → regex match → insert span + button ──
+    // ── Step 3: Text nodes (outside pre/a/code) → search worktree paths ──
     const textNodes: Text[] = []
     const walker = doc.createTreeWalker(doc.body, NodeFilter.SHOW_TEXT, {
         acceptNode(node: Text) {
@@ -153,53 +201,61 @@ export function annotateWorktreePaths(
         const textNode = textNodes[i]
         const text = textNode.textContent || ''
 
-        WORKTREE_PATH_RE.lastIndex = 0
-        if (!WORKTREE_PATH_RE.test(text)) continue
+        // Collect all matches from search entries
+        const matches: Array<{ index: number; length: number; entry: SearchEntry }> = []
 
-        // Re-run regex to collect matches
-        WORKTREE_PATH_RE.lastIndex = 0
-        const parts: Array<{ text: string; absPath: string | null }> = []
-        let lastIndex = 0
-        let match: RegExpExecArray | null
-        while ((match = WORKTREE_PATH_RE.exec(text)) !== null) {
-            const pathStr = match[0]
-            const absPath = extractWorktreePath(pathStr, projectRoot)
-            // Push text before this match
-            if (match.index > lastIndex) {
-                parts.push({ text: text.slice(lastIndex, match.index), absPath: null })
+        for (const entry of searchEntries) {
+            let pos = 0
+            while ((pos = text.indexOf(entry.keyword, pos)) !== -1) {
+                matches.push({ index: pos, length: entry.keyword.length, entry })
+                pos += entry.keyword.length
             }
-            parts.push({ text: pathStr, absPath })
-            lastIndex = match.index + pathStr.length
         }
-        // Push remaining text after last match
-        if (lastIndex < text.length) {
-            parts.push({ text: text.slice(lastIndex), absPath: null })
+
+        if (matches.length === 0) continue
+
+        // Sort by index, then deduplicate overlapping matches (longer entry wins)
+        matches.sort((a, b) => a.index - b.index || b.length - a.length)
+        const filtered: typeof matches = []
+        let lastEnd = 0
+        for (const m of matches) {
+            if (m.index >= lastEnd) {
+                filtered.push(m)
+                lastEnd = m.index + m.length
+            }
         }
 
         // Build replacement nodes
         const parent = textNode.parentNode!
         const frag = doc.createDocumentFragment()
         let hasAnnotation = false
-        for (const part of parts) {
-            if (part.absPath) {
-                hasAnnotation = true
-                detectedWorktreePaths.push(part.absPath)
-                const span = doc.createElement('span')
-                span.className = 'chat-worktree-path'
-                span.setAttribute('data-worktree-path', part.absPath)
-                const resolved = resolveFilePath(part.absPath, projectRoot)
-                if (resolved) {
-                    span.setAttribute('data-file-path', resolved)
-                }
-                span.textContent = part.text
-                frag.appendChild(span)
-                // Single action button
-                const btnContainer = doc.createElement('span')
-                btnContainer.innerHTML = worktreeButtonHtml(part.absPath, resolved || undefined)
-                while (btnContainer.firstChild) frag.appendChild(btnContainer.firstChild)
-            } else {
-                frag.appendChild(doc.createTextNode(part.text))
+        let lastIndex = 0
+
+        for (const m of filtered) {
+            // Push text before this match
+            if (m.index > lastIndex) {
+                frag.appendChild(doc.createTextNode(text.slice(lastIndex, m.index)))
             }
+            hasAnnotation = true
+            detectedWorktreePaths.push(m.entry.absPath)
+            const span = doc.createElement('span')
+            span.className = 'chat-worktree-path'
+            span.setAttribute('data-worktree-path', m.entry.absPath)
+            const resolved = resolveFilePath(m.entry.absPath, projectRoot)
+            if (resolved) {
+                span.setAttribute('data-file-path', resolved)
+            }
+            span.textContent = m.entry.keyword
+            frag.appendChild(span)
+            // Single action button
+            const btnContainer = doc.createElement('span')
+            btnContainer.innerHTML = worktreeButtonHtml(m.entry.absPath, resolved || undefined)
+            while (btnContainer.firstChild) frag.appendChild(btnContainer.firstChild)
+            lastIndex = m.index + m.length
+        }
+        // Push remaining text after last match
+        if (lastIndex < text.length) {
+            frag.appendChild(doc.createTextNode(text.slice(lastIndex)))
         }
 
         if (hasAnnotation) {
@@ -208,56 +264,6 @@ export function annotateWorktreePaths(
     }
 
     return { html: doc.body.innerHTML, detectedWorktreePaths }
-}
-
-/**
- * Extract an absolute worktree path from a matched string.
- * - If the match starts with `/`, it's already absolute — return as-is if under projectRoot.
- * - If the match starts with `.worktrees/` or `./.worktrees/`, prepend projectRoot.
- * Returns null if the path cannot be resolved.
- */
-function extractWorktreePath(matched: string, projectRoot: string): string | null {
-    if (matched.startsWith('/')) {
-        // Absolute path — must be under projectRoot
-        if (!projectRoot || !matched.startsWith(projectRoot + '/')) return null
-        return matched
-    }
-    // Relative path like .worktrees/feature-x or ./.worktrees/feature-x
-    if (!projectRoot) return null
-    const clean = matched.replace(/^\.\//, '')
-    return projectRoot + '/' + clean
-}
-
-/**
- * Verify which worktree paths actually exist on the server,
- * and remove annotations for paths that are not real worktrees.
- * Called asynchronously after the synchronous annotation pass.
- */
-export async function verifyWorktreePaths(paths: string[], containerEl: HTMLElement, projectRoot: string): Promise<void> {
-    if (paths.length === 0) return
-
-    const worktrees = await fetchWorktreeList(projectRoot)
-    if (worktrees.length === 0) return
-
-    // Build set of valid absolute worktree paths (excluding current)
-    const validPaths = new Set<string>()
-    for (const wt of worktrees) {
-        if (!wt.isCurrent && wt.path) {
-            validPaths.add(wt.path)
-        }
-    }
-
-    // Remove annotations for paths not in the valid set
-    for (const path of paths) {
-        if (!validPaths.has(path)) {
-            containerEl.querySelectorAll(`.chat-worktree-btn[data-worktree-path="${CSS.escape(path)}"]`).forEach(btn => {
-                btn.remove()
-            })
-            containerEl.querySelectorAll(`.chat-worktree-path[data-worktree-path="${CSS.escape(path)}"]`).forEach(span => {
-                span.replaceWith(...span.childNodes)
-            })
-        }
-    }
 }
 
 /**
@@ -273,7 +279,7 @@ export function clearWorktreeCache(): void {
 export function useWorktreeAnnotation() {
     return {
         annotateWorktreePaths,
-        verifyWorktreePaths,
+        warmWorktreeCache,
         clearWorktreeCache,
     }
 }

--- a/web/src/composables/useWorktreeAnnotation.ts
+++ b/web/src/composables/useWorktreeAnnotation.ts
@@ -1,20 +1,25 @@
 import { escapeHtml } from '@/utils/html.ts'
 import { gt } from '@/composables/useLocale'
-import { fileOpenButtonHtml, resolveFilePath } from '@/composables/useFilePathAnnotation.ts'
+import { resolveFilePath } from '@/composables/useFilePathAnnotation.ts'
 
 /**
- * SVG icon markup for the worktree-switch button (GitBranch icon from lucide).
+ * SVG icon markup for the worktree button (GitBranch icon from lucide).
  */
 export const WORKTREE_ICON_SVG = '<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" width="12" height="12"><line x1="6" y1="3" x2="6" y2="15"/><circle cx="18" cy="6" r="3"/><circle cx="6" cy="18" r="3"/><path d="M18 9a9 9 0 0 1-9 9"/></svg>'
 
 /**
- * Generate HTML for the small worktree-switch button.
+ * Generate HTML for a single worktree action button.
+ * Clicking it shows a modal with "Switch to worktree" or "Open directory" options.
  */
-export function worktreeSwitchButtonHtml(absPath: string): string {
-    return `<button class="chat-worktree-switch-btn" data-worktree-path="${escapeHtml(absPath)}" title="${escapeHtml(gt('chat.attach.openWorktree'))}">${WORKTREE_ICON_SVG}</button>`
+export function worktreeButtonHtml(absPath: string, resolvedPath?: string): string {
+    let attrs = `class="chat-worktree-btn" data-worktree-path="${escapeHtml(absPath)}"`
+    if (resolvedPath) {
+        attrs += ` data-file-path="${escapeHtml(resolvedPath)}"`
+    }
+    return `<button ${attrs} title="${escapeHtml(gt('chat.attach.openWorktree'))}">${WORKTREE_ICON_SVG}</button>`
 }
 
-// ── Worktree list cache ──
+// ── Worktree list cache (for async verification) ──
 
 interface WorktreeInfo {
     path: string
@@ -51,70 +56,43 @@ async function fetchWorktreeList(projectRoot: string): Promise<WorktreeInfo[]> {
     }
 }
 
-// ── Search entry building ──
-
-interface SearchEntry {
-    /** The search keyword (exact string to find in text) */
-    keyword: string
-    /** Absolute path of the worktree (for data-worktree-path) */
-    absPath: string
-}
-
 /**
- * Build search entries from a worktree list.
- * Each worktree generates up to 3 keywords: path, displayPath, displayPath without ./
- * Entries are sorted by keyword length descending (longest first) to avoid
- * shorter entries matching substrings of longer ones.
- * Excludes worktrees where isCurrent is true.
+ * Regex that matches worktree paths in plain text.
+ * Matches:
+ *   1. Absolute paths containing /.worktrees/ (e.g. /home/user/project/.worktrees/feature-x)
+ *   2. Relative paths starting with .worktrees/ (e.g. .worktrees/feature-x)
+ *   3. Relative paths starting with ./.worktrees/ (e.g. ./.worktrees/feature-x)
+ *
+ * This regex runs on text node content only (never on HTML attributes or tags),
+ * same design as FILE_PATH_RE. It enables synchronous annotation without
+ * waiting for the async worktree list API.
  */
-export function buildSearchEntries(worktrees: WorktreeInfo[]): SearchEntry[] {
-    const entries: SearchEntry[] = []
-    for (const wt of worktrees) {
-        if (wt.isCurrent) continue
-        // Absolute path
-        if (wt.path) {
-            entries.push({ keyword: wt.path, absPath: wt.path })
-        }
-        // displayPath (e.g. "./.worktrees/feature-x")
-        if (wt.displayPath && wt.displayPath !== '.') {
-            entries.push({ keyword: wt.displayPath, absPath: wt.path })
-            // displayPath without leading "./" (e.g. ".worktrees/feature-x")
-            const noDotSlash = wt.displayPath.replace(/^\.\//, '')
-            if (noDotSlash !== wt.displayPath) {
-                entries.push({ keyword: noDotSlash, absPath: wt.path })
-            }
-        }
-    }
-    // Sort by keyword length descending (longest first for greedy matching)
-    entries.sort((a, b) => b.keyword.length - a.keyword.length)
-    return entries
-}
+const WORKTREE_PATH_RE = /(?:\/[^\s<>"')\]]+\/\.worktrees\/[^\s<>"')\]]+|\.\/\.worktrees\/[^\s<>"')\]]+|\.worktrees\/[^\s<>"')\]]+)/g
 
 /**
- * Find a matching worktree search entry for a given text string.
- * Returns the first (longest) matching entry, or null.
+ * Check if a string looks like a worktree path that should be annotated.
+ * Used for <code> tag content detection (simpler than full regex).
  */
-function findWorktreeMatch(text: string, searchEntries: SearchEntry[]): SearchEntry | null {
-    const trimmed = text.trim()
-    for (const entry of searchEntries) {
-        if (trimmed === entry.keyword) return entry
-    }
-    return null
+function looksLikeWorktreePath(text: string): boolean {
+    return text.includes('.worktrees/')
 }
 
 /**
- * Detect worktree paths in rendered HTML and insert switch buttons after them.
- * Uses the cached worktree list (from GET /api/git/worktrees) for matching
- * instead of regex on .worktrees/ strings.
+ * Detect worktree paths in rendered HTML and insert action buttons after them.
+ *
+ * Design: regex-first, verify-later — aligned with localhost/commit/file-path annotations.
+ *   1. Synchronously annotate all text matching .worktrees/ patterns (no API call needed)
+ *   2. Asynchronously verify via GET /api/git/worktrees, removing false positives
+ *
+ * This ensures annotations appear immediately on first render AND survive app restart
+ * (no async cache dependency in the annotation step itself).
  *
  * Processing order:
- *   1. <a href> tags matching a worktree path → append switch button
- *   2. <code> and <span class="chat-file-path"> tags matching a worktree → add class + button
- *   3. Text nodes (outside pre/a/code) → search for worktree paths → insert span + button
+ *   1. <a href> tags matching a worktree path → append action button
+ *   2. <code> and <span class="chat-file-path"> tags matching → add class + button
+ *   3. Text nodes (outside pre/a/code) → regex match → insert span + button
  *
- * Step 2 appends to .chat-file-path elements (coexistence with file annotation).
- *
- * Returns the annotated HTML and a list of detected absolute worktree paths.
+ * Returns the annotated HTML and a list of detected worktree path strings.
  */
 export function annotateWorktreePaths(
     html: string,
@@ -122,64 +100,39 @@ export function annotateWorktreePaths(
 ): { html: string; detectedWorktreePaths: string[] } {
     if (!html) return { html: '', detectedWorktreePaths: [] }
 
-    const worktrees = worktreeListCache.get(projectRoot)
-    if (!worktrees || worktrees.length === 0) {
-        // Cache miss — trigger background fetch, return empty for now
-        fetchWorktreeList(projectRoot)
-        return { html, detectedWorktreePaths: [] }
-    }
-
-    const searchEntries = buildSearchEntries(worktrees)
-    if (searchEntries.length === 0) return { html, detectedWorktreePaths: [] }
-
     const detectedWorktreePaths: string[] = []
     const doc = new DOMParser().parseFromString(html, 'text/html')
-
-    /**
-     * Generate annotation buttons for a worktree path.
-     * Always generates the worktree switch button.
-     * Also generates a file-open button if the worktree path resolves within projectRoot.
-     */
-    function worktreeAnnotationButtons(absPath: string): string {
-        let html = worktreeSwitchButtonHtml(absPath)
-        const resolved = resolveFilePath(absPath, projectRoot)
-        if (resolved) {
-            html += fileOpenButtonHtml(resolved)
-        }
-        return html
-    }
 
     // ── Step 1: <a href> tags matching a worktree path ──
     for (const a of doc.querySelectorAll('a[href]')) {
         const href = a.getAttribute('href') || ''
-        const match = findWorktreeMatch(href, searchEntries)
+        if (!looksLikeWorktreePath(href)) continue
+        const match = extractWorktreePath(href, projectRoot)
         if (!match) continue
-        detectedWorktreePaths.push(match.absPath)
-        a.insertAdjacentHTML('afterend', worktreeAnnotationButtons(match.absPath))
+        detectedWorktreePaths.push(match)
+        a.insertAdjacentHTML('afterend', worktreeButtonHtml(match, resolveFilePath(match, projectRoot) || undefined))
     }
 
     // ── Step 2: <code> and <span class="chat-file-path"> matching a worktree ──
-    // Unlike the old implementation, we do NOT skip .chat-file-path elements.
-    // Instead we append worktree annotation to them (coexistence with file annotation).
     for (const el of doc.querySelectorAll('code, span.chat-file-path')) {
         if (el.closest('pre')) continue
         if (el.classList.contains('chat-commit-hash')) continue
-        if (el.classList.contains('chat-worktree-path')) continue // already annotated
+        if (el.classList.contains('chat-worktree-path')) continue
         const stripped = (el.textContent || '').trim()
-        const match = findWorktreeMatch(stripped, searchEntries)
+        if (!looksLikeWorktreePath(stripped)) continue
+        const match = extractWorktreePath(stripped, projectRoot)
         if (!match) continue
-        detectedWorktreePaths.push(match.absPath)
+        detectedWorktreePaths.push(match)
         el.classList.add('chat-worktree-path')
-        el.setAttribute('data-worktree-path', match.absPath)
-        // Also add data-file-path if the worktree path resolves within projectRoot
-        const resolved = resolveFilePath(match.absPath, projectRoot)
+        el.setAttribute('data-worktree-path', match)
+        const resolved = resolveFilePath(match, projectRoot)
         if (resolved) {
             el.setAttribute('data-file-path', resolved)
         }
-        el.insertAdjacentHTML('afterend', worktreeAnnotationButtons(match.absPath))
+        el.insertAdjacentHTML('afterend', worktreeButtonHtml(match, resolved || undefined))
     }
 
-    // ── Step 3: Text nodes (outside pre/a/code) → search worktree paths ──
+    // ── Step 3: Text nodes (outside pre/a/code) → regex match → insert span + button ──
     const textNodes: Text[] = []
     const walker = doc.createTreeWalker(doc.body, NodeFilter.SHOW_TEXT, {
         acceptNode(node: Text) {
@@ -200,62 +153,53 @@ export function annotateWorktreePaths(
         const textNode = textNodes[i]
         const text = textNode.textContent || ''
 
-        // Collect all matches from search entries
-        const matches: Array<{ index: number; length: number; entry: SearchEntry }> = []
+        WORKTREE_PATH_RE.lastIndex = 0
+        if (!WORKTREE_PATH_RE.test(text)) continue
 
-        for (const entry of searchEntries) {
-            let pos = 0
-            while ((pos = text.indexOf(entry.keyword, pos)) !== -1) {
-                matches.push({ index: pos, length: entry.keyword.length, entry })
-                pos += entry.keyword.length
+        // Re-run regex to collect matches
+        WORKTREE_PATH_RE.lastIndex = 0
+        const parts: Array<{ text: string; absPath: string | null }> = []
+        let lastIndex = 0
+        let match: RegExpExecArray | null
+        while ((match = WORKTREE_PATH_RE.exec(text)) !== null) {
+            const pathStr = match[0]
+            const absPath = extractWorktreePath(pathStr, projectRoot)
+            // Push text before this match
+            if (match.index > lastIndex) {
+                parts.push({ text: text.slice(lastIndex, match.index), absPath: null })
             }
+            parts.push({ text: pathStr, absPath })
+            lastIndex = match.index + pathStr.length
         }
-
-        if (matches.length === 0) continue
-
-        // Sort by index, then deduplicate overlapping matches (longer entry wins)
-        matches.sort((a, b) => a.index - b.index || b.length - a.length)
-        const filtered: typeof matches = []
-        let lastEnd = 0
-        for (const m of matches) {
-            if (m.index >= lastEnd) {
-                filtered.push(m)
-                lastEnd = m.index + m.length
-            }
+        // Push remaining text after last match
+        if (lastIndex < text.length) {
+            parts.push({ text: text.slice(lastIndex), absPath: null })
         }
 
         // Build replacement nodes
         const parent = textNode.parentNode!
         const frag = doc.createDocumentFragment()
         let hasAnnotation = false
-        let lastIndex = 0
-
-        for (const m of filtered) {
-            // Push text before this match
-            if (m.index > lastIndex) {
-                frag.appendChild(doc.createTextNode(text.slice(lastIndex, m.index)))
+        for (const part of parts) {
+            if (part.absPath) {
+                hasAnnotation = true
+                detectedWorktreePaths.push(part.absPath)
+                const span = doc.createElement('span')
+                span.className = 'chat-worktree-path'
+                span.setAttribute('data-worktree-path', part.absPath)
+                const resolved = resolveFilePath(part.absPath, projectRoot)
+                if (resolved) {
+                    span.setAttribute('data-file-path', resolved)
+                }
+                span.textContent = part.text
+                frag.appendChild(span)
+                // Single action button
+                const btnContainer = doc.createElement('span')
+                btnContainer.innerHTML = worktreeButtonHtml(part.absPath, resolved || undefined)
+                while (btnContainer.firstChild) frag.appendChild(btnContainer.firstChild)
+            } else {
+                frag.appendChild(doc.createTextNode(part.text))
             }
-            hasAnnotation = true
-            detectedWorktreePaths.push(m.entry.absPath)
-            const span = doc.createElement('span')
-            span.className = 'chat-worktree-path'
-            span.setAttribute('data-worktree-path', m.entry.absPath)
-            // Also add data-file-path if the worktree path resolves within projectRoot
-            const resolved = resolveFilePath(m.entry.absPath, projectRoot)
-            if (resolved) {
-                span.setAttribute('data-file-path', resolved)
-            }
-            span.textContent = m.entry.keyword
-            frag.appendChild(span)
-            // Worktree switch + file open buttons
-            const btnContainer = doc.createElement('span')
-            btnContainer.innerHTML = worktreeAnnotationButtons(m.entry.absPath)
-            while (btnContainer.firstChild) frag.appendChild(btnContainer.firstChild)
-            lastIndex = m.index + m.length
-        }
-        // Push remaining text after last match
-        if (lastIndex < text.length) {
-            frag.appendChild(doc.createTextNode(text.slice(lastIndex)))
         }
 
         if (hasAnnotation) {
@@ -264,6 +208,56 @@ export function annotateWorktreePaths(
     }
 
     return { html: doc.body.innerHTML, detectedWorktreePaths }
+}
+
+/**
+ * Extract an absolute worktree path from a matched string.
+ * - If the match starts with `/`, it's already absolute — return as-is if under projectRoot.
+ * - If the match starts with `.worktrees/` or `./.worktrees/`, prepend projectRoot.
+ * Returns null if the path cannot be resolved.
+ */
+function extractWorktreePath(matched: string, projectRoot: string): string | null {
+    if (matched.startsWith('/')) {
+        // Absolute path — must be under projectRoot
+        if (!projectRoot || !matched.startsWith(projectRoot + '/')) return null
+        return matched
+    }
+    // Relative path like .worktrees/feature-x or ./.worktrees/feature-x
+    if (!projectRoot) return null
+    const clean = matched.replace(/^\.\//, '')
+    return projectRoot + '/' + clean
+}
+
+/**
+ * Verify which worktree paths actually exist on the server,
+ * and remove annotations for paths that are not real worktrees.
+ * Called asynchronously after the synchronous annotation pass.
+ */
+export async function verifyWorktreePaths(paths: string[], containerEl: HTMLElement, projectRoot: string): Promise<void> {
+    if (paths.length === 0) return
+
+    const worktrees = await fetchWorktreeList(projectRoot)
+    if (worktrees.length === 0) return
+
+    // Build set of valid absolute worktree paths (excluding current)
+    const validPaths = new Set<string>()
+    for (const wt of worktrees) {
+        if (!wt.isCurrent && wt.path) {
+            validPaths.add(wt.path)
+        }
+    }
+
+    // Remove annotations for paths not in the valid set
+    for (const path of paths) {
+        if (!validPaths.has(path)) {
+            containerEl.querySelectorAll(`.chat-worktree-btn[data-worktree-path="${CSS.escape(path)}"]`).forEach(btn => {
+                btn.remove()
+            })
+            containerEl.querySelectorAll(`.chat-worktree-path[data-worktree-path="${CSS.escape(path)}"]`).forEach(span => {
+                span.replaceWith(...span.childNodes)
+            })
+        }
+    }
 }
 
 /**
@@ -279,6 +273,7 @@ export function clearWorktreeCache(): void {
 export function useWorktreeAnnotation() {
     return {
         annotateWorktreePaths,
+        verifyWorktreePaths,
         clearWorktreeCache,
     }
 }

--- a/web/src/composables/useWorktreeAnnotation.ts
+++ b/web/src/composables/useWorktreeAnnotation.ts
@@ -129,7 +129,7 @@ function findWorktreeMatch(text: string, searchEntries: SearchEntry[]): SearchEn
  * Processing order:
  *   1. <a href> tags matching a worktree path → append action button
  *   2. <code> and <span class="chat-file-path"> tags matching → add class + button
- *   3. Text nodes (outside pre/a/code) → search worktree paths → insert span + button
+ *   3. Text nodes (outside a/code) → search worktree paths → insert span + button
  *
  * Returns the annotated HTML and a list of detected absolute worktree paths.
  */
@@ -164,7 +164,6 @@ export function annotateWorktreePaths(
 
     // ── Step 2: <code> and <span class="chat-file-path"> matching a worktree ──
     for (const el of doc.querySelectorAll('code, span.chat-file-path')) {
-        if (el.closest('pre')) continue
         if (el.classList.contains('chat-commit-hash')) continue
         if (el.classList.contains('chat-worktree-path')) continue
         const stripped = (el.textContent || '').trim()
@@ -180,13 +179,12 @@ export function annotateWorktreePaths(
         el.insertAdjacentHTML('afterend', worktreeButtonHtml(match.absPath, resolved || undefined))
     }
 
-    // ── Step 3: Text nodes (outside pre/a/code) → search worktree paths ──
+    // ── Step 3: Text nodes (outside a/code) → search worktree paths ──
     const textNodes: Text[] = []
     const walker = doc.createTreeWalker(doc.body, NodeFilter.SHOW_TEXT, {
         acceptNode(node: Text) {
             const parent = node.parentElement
             if (!parent) return NodeFilter.FILTER_REJECT
-            if (parent.closest('pre')) return NodeFilter.FILTER_REJECT
             if (parent.tagName === 'A' || parent.closest('a')) return NodeFilter.FILTER_REJECT
             if (parent.tagName === 'CODE' || parent.closest('code')) return NodeFilter.FILTER_REJECT
             if (parent.classList.contains('chat-file-path') || parent.classList.contains('chat-commit-hash') || parent.classList.contains('chat-worktree-path')) return NodeFilter.FILTER_REJECT

--- a/web/src/i18n/locales/en.ts
+++ b/web/src/i18n/locales/en.ts
@@ -124,7 +124,9 @@ export default {
       uploading: 'Uploading...',
       openFile: 'Open file',
       openCommit: 'Open commit details',
-      openWorktree: 'Switch to Worktree',
+      openWorktree: 'Worktree Actions',
+      switchWorktree: 'Switch worktree',
+      openDirectory: 'Open directory',
     },
     quickSend: {
       title: 'Quick send',
@@ -599,7 +601,9 @@ export default {
       workingTree: 'Working tree',
       openFile: 'Open file',
       openCommit: 'Open commit details',
-      openWorktree: 'Switch to Worktree',
+      openWorktree: 'Worktree Actions',
+      switchWorktree: 'Switch worktree',
+      openDirectory: 'Open directory',
     },
     graph: {
       workingTree: 'Working tree',

--- a/web/src/i18n/locales/zh.ts
+++ b/web/src/i18n/locales/zh.ts
@@ -124,7 +124,9 @@ export default {
       uploading: '上传中...',
       openFile: '打开文件',
       openCommit: '打开 Commit 详情',
-      openWorktree: '切换到 Worktree',
+      openWorktree: 'Worktree 操作',
+      switchWorktree: '切换工作树',
+      openDirectory: '打开目录',
     },
     quickSend: {
       title: '快捷发送',
@@ -599,7 +601,9 @@ export default {
       workingTree: '工作区',
       openFile: '打开文件',
       openCommit: '打开 Commit 详情',
-      openWorktree: '切换到 Worktree',
+      openWorktree: 'Worktree 操作',
+      switchWorktree: '切换工作树',
+      openDirectory: '打开目录',
     },
     graph: {
       workingTree: '工作区',


### PR DESCRIPTION
## Summary

Fixes #50 — File path annotation false positives and missing annotations inside code blocks.

### Problem
1. **False positives**: Glob patterns (`*.class`, `**/*.ts`), template variables (`<source>/<line>`), and localhost URLs (`http://localhost:20003`) were incorrectly annotated as file paths
2. **Missing code block annotations**: File paths, worktree paths, and commit hashes inside `<pre><code>` blocks were never annotated
3. **Worktree annotations disappearing on app restart**: Cache-only matching with no pre-warming
4. **Excessive 404 HEAD requests**: Per-path 2×HEAD verification replaced with batch POST API
5. **Worktree two-button UI**: Replaced with single button + modal dialog

### Changes

**Backend (Go)**
- `POST /api/file/batch-exists`: New endpoint accepting up to 100 paths, returns `{path: "file"|"dir"|"none"}`. Glob characters short-circuited to `"none"` without filesystem access.
- `containsGlobChars()`: Rejects paths with `*?[]<>` or `**`

**Frontend — Annotation fixes**
- `looksLikeFilePath()` / `resolveFilePath()`: Reject glob chars and URLs (`http://`, `https://`)
- `verifyFilePaths()`: Replaced per-path 2×HEAD with single batch POST
- Worktree annotation: API-based matching (from `GET /api/git/worktrees`) instead of `.worktrees/` regex pattern, with `warmWorktreeCache()` pre-warming in `loadHistory`
- TreeWalker now enters `<code>` elements (including inside `<pre>`), skipping only already-annotated elements by class

**Frontend — UI**
- Worktree: Single `chat-worktree-btn` button with modal dialog (Switch worktree / Open directory)
- Localhost: Annotates URLs inside `<pre>` blocks (both in `<code>` and bare text)
- All 4 annotation types now work inside `<pre><code>` blocks

### Test plan
- [x] Go: 12 sub-tests for `ServeFileBatchExists` (existing/dir/none/glob/traversal/mixed/boundary)
- [x] Frontend: `resolveFilePath` illegal chars (5), `annotateFilePaths` glob rejection (4), `verifyFilePaths` (8)
- [x] Frontend: worktree annotation (34), commit hash, localhost — all updated for code block coverage
- [x] CI coverage gates pass: Go 92%, Frontend 100% diff coverage