### PR TITLE
fix: expand ~/ paths using homeDir in file path annotation

### DIFF
--- a/internal/handler/file.go
+++ b/internal/handler/file.go
@@ -12,6 +12,7 @@ import (
 	"time"
 
 	"clawbench/internal/model"
+	"clawbench/internal/platform"
 )
 
 // mimeTypes maps file extensions to MIME types for ServeLocalFile.
@@ -418,6 +419,8 @@ func ServeFileBatchExists(w http.ResponseWriter, r *http.Request) {
 			results[p] = "none"
 			continue
 		}
+		// Expand ~ to home directory so paths like ~/.bashrc resolve correctly
+		p = platform.ExpandTilde(p)
 		absPath, ok := model.ValidatePath(baseAbs, p)
 		if !ok {
 			results[p] = "none"

--- a/internal/handler/project.go
+++ b/internal/handler/project.go
@@ -11,6 +11,7 @@ import (
 	"strings"
 
 	"clawbench/internal/model"
+	"clawbench/internal/platform"
 	"clawbench/internal/service"
 )
 
@@ -92,7 +93,7 @@ func ServeProjectSet(w http.ResponseWriter, r *http.Request) {
 			})
 		}
 		w.Header().Set("Content-Type", "application/json")
-		json.NewEncoder(w).Encode(map[string]string{"path": projectPath})
+		json.NewEncoder(w).Encode(map[string]string{"path": projectPath, "homeDir": platform.UserHomeDir()})
 
 	case http.MethodPost:
 		var req struct {

--- a/internal/handler/project_test.go
+++ b/internal/handler/project_test.go
@@ -1,6 +1,7 @@
 package handler
 
 import (
+	"encoding/json"
 	"net/http"
 	"net/http/httptest"
 	"net/url"
@@ -28,6 +29,10 @@ func TestServeProjectSet(t *testing.T) {
 
 		assert.Equal(t, http.StatusOK, w.Code)
 		assertJSONField(t, w, "path", projectPath)
+		// homeDir should be present (non-empty on any system with a home directory)
+		var resp map[string]interface{}
+		json.Unmarshal(w.Body.Bytes(), &resp)
+		assert.NotEmpty(t, resp["homeDir"], "homeDir should be present in response")
 	})
 
 	t.Run("GET_WithoutCookie_FallsBackToWatchDir", func(t *testing.T) {

--- a/web/src/components/file/MarkdownPreview.vue
+++ b/web/src/components/file/MarkdownPreview.vue
@@ -121,7 +121,8 @@ async function doRender(f) {
     const currentDir = f?.path ? dirName(f.path) : ''
     const { html: annotatedHtml, detectedPaths } = annotateFilePaths(html, {
         projectRoot: store.state.projectRoot,
-        baseDir: currentDir
+        baseDir: currentDir,
+        homeDir: store.state.homeDir
     })
     renderedHtml.value = annotatedHtml
 

--- a/web/src/composables/__tests__/useFilePathAnnotation.test.ts
+++ b/web/src/composables/__tests__/useFilePathAnnotation.test.ts
@@ -129,6 +129,44 @@ describe('resolveFilePath', () => {
     it('returns null for https:// URLs', () => {
       expect(resolveFilePath('https://example.com/page.html', projectRoot)).toBeNull()
     })
+
+    it('returns null for $HOME environment variable paths', () => {
+      expect(resolveFilePath('$HOME/.bashrc', projectRoot)).toBeNull()
+      expect(resolveFilePath('${HOME}/config', projectRoot)).toBeNull()
+    })
+  })
+
+  describe('tilde (~/) paths', () => {
+    const homeDir = '/home/user'
+    const projectRoot = '/home/user/my-app'
+
+    it('resolves ~/project/... paths when homeDir is provided and path is in project', () => {
+      expect(resolveFilePath('~/my-app/src/main.go', projectRoot, homeDir)).toBe('src/main.go')
+    })
+
+    it('resolves ~/project/sub/deep paths', () => {
+      expect(resolveFilePath('~/my-app/internal/handler/chat.go', projectRoot, homeDir)).toBe('internal/handler/chat.go')
+    })
+
+    it('returns null for ~/ paths outside project when homeDir is provided', () => {
+      expect(resolveFilePath('~/.bashrc', projectRoot, homeDir)).toBeNull()
+      expect(resolveFilePath('~/other-project/file.ts', projectRoot, homeDir)).toBeNull()
+      expect(resolveFilePath('~/.config/nvim/init.lua', projectRoot, homeDir)).toBeNull()
+    })
+
+    it('returns null for ~/ paths without homeDir (cannot expand)', () => {
+      expect(resolveFilePath('~/my-app/src/main.go', projectRoot)).toBeNull()
+      expect(resolveFilePath('~/.bashrc', projectRoot)).toBeNull()
+    })
+
+    it('returns null for ~/ paths when expanded path equals projectRoot (no file part)', () => {
+      expect(resolveFilePath('~/my-app', projectRoot, homeDir)).toBeNull()
+    })
+
+    it('handles /root home directory correctly', () => {
+      expect(resolveFilePath('~/project/src/main.go', '/root/project', '/root')).toBe('src/main.go')
+      expect(resolveFilePath('~/other/file.ts', '/root/project', '/root')).toBeNull()
+    })
   })
 })
 
@@ -591,6 +629,186 @@ describe('annotateFilePaths', () => {
     const input = '<p>**/R.class and **/R$*.class and **/Manifest*.*</p>'
     const result = annotateFilePaths(input, { projectRoot })
     expect(result.detectedPaths).toHaveLength(0)
+  })
+
+  // ── Tilde (~/) path tests ──
+
+  it('does not annotate ~/ paths outside project when homeDir is provided', () => {
+    const input = '<code>~/.bashrc</code>'
+    const result = annotateFilePaths(input, { projectRoot: '/home/user/my-app', homeDir: '/home/user' })
+    expect(result.detectedPaths).toHaveLength(0)
+    expect(result.html).not.toContain('chat-file-path')
+  })
+
+  it('annotates ~/project/... paths when homeDir is provided', () => {
+    const input = '<code>~/my-app/src/main.go</code>'
+    const result = annotateFilePaths(input, { projectRoot: '/home/user/my-app', homeDir: '/home/user' })
+    expect(result.detectedPaths).toContain('src/main.go')
+    expect(result.html).toContain('chat-file-path')
+  })
+
+  it('does not annotate ~/ paths without homeDir', () => {
+    const input = '<code>~/my-app/src/main.go</code>'
+    const result = annotateFilePaths(input, { projectRoot: '/home/user/my-app' })
+    expect(result.detectedPaths).toHaveLength(0)
+  })
+
+  it('annotates ~/project/... in text nodes when homeDir is provided', () => {
+    const input = '<p>Edit ~/my-app/src/main.go for details</p>'
+    const result = annotateFilePaths(input, { projectRoot: '/home/user/my-app', homeDir: '/home/user' })
+    expect(result.detectedPaths).toContain('src/main.go')
+  })
+
+  it('does not annotate ~/ paths outside project in text nodes', () => {
+    const input = '<p>Check ~/.config/nvim/init.lua for settings</p>'
+    const result = annotateFilePaths(input, { projectRoot: '/home/user/my-app', homeDir: '/home/user' })
+    expect(result.detectedPaths).toHaveLength(0)
+  })
+
+  it('does not annotate $HOME paths in <code> tags', () => {
+    const input = '<code>$HOME/.bashrc</code>'
+    const result = annotateFilePaths(input, { projectRoot })
+    expect(result.detectedPaths).toHaveLength(0)
+  })
+
+  // ── Comprehensive real-project path tests (projectRoot=/home/xulongzhe/projects/clawbench, homeDir=/home/xulongzhe) ──
+
+  describe('real-project path scenarios', () => {
+    const projectRoot = '/home/xulongzhe/projects/clawbench'
+    const homeDir = '/home/xulongzhe'
+
+    describe('正例 — 项目内路径，应该标注', () => {
+      it('annotates relative path (web/src/composables/useFilePathAnnotation.ts)', () => {
+        const input = '<p>Edit web/src/composables/useFilePathAnnotation.ts for details</p>'
+        const result = annotateFilePaths(input, { projectRoot, homeDir })
+        expect(result.detectedPaths).toContain('web/src/composables/useFilePathAnnotation.ts')
+      })
+
+      it('annotates absolute path under project (/home/xulongzhe/projects/clawbench/internal/handler/file.go)', () => {
+        const input = '<p>See /home/xulongzhe/projects/clawbench/internal/handler/file.go for details</p>'
+        const result = annotateFilePaths(input, { projectRoot, homeDir })
+        expect(result.detectedPaths).toContain('internal/handler/file.go')
+      })
+
+      it('annotates ~-expanded path in project (~/projects/clawbench/cmd/server/main.go)', () => {
+        const input = '<p>Check ~/projects/clawbench/cmd/server/main.go for details</p>'
+        const result = annotateFilePaths(input, { projectRoot, homeDir })
+        expect(result.detectedPaths).toContain('cmd/server/main.go')
+      })
+
+      it('annotates ./ relative path (./web/src/App.vue)', () => {
+        const input = '<p>Open ./web/src/App.vue for details</p>'
+        const result = annotateFilePaths(input, { projectRoot, homeDir })
+        expect(result.detectedPaths).toContain('web/src/App.vue')
+      })
+
+      it('annotates absolute path followed by CJK text (/home/xulongzhe/projects/clawbench/go.mod 这个文件)', () => {
+        const input = '<p>/home/xulongzhe/projects/clawbench/go.mod这个文件</p>'
+        const result = annotateFilePaths(input, { projectRoot, homeDir })
+        expect(result.detectedPaths).toContain('go.mod')
+      })
+
+      it('annotates deep ~-expanded path (~/projects/clawbench/web/src/composables/useChatRender.ts)', () => {
+        const input = '<p>Edit ~/projects/clawbench/web/src/composables/useChatRender.ts for details</p>'
+        const result = annotateFilePaths(input, { projectRoot, homeDir })
+        expect(result.detectedPaths).toContain('web/src/composables/useChatRender.ts')
+      })
+
+      it('annotates ~-expanded path in <code> tag', () => {
+        const input = '<code>~/projects/clawbench/web/src/App.vue</code>'
+        const result = annotateFilePaths(input, { projectRoot, homeDir })
+        expect(result.detectedPaths).toContain('web/src/App.vue')
+        expect(result.html).toContain('chat-file-path')
+      })
+    })
+
+    describe('反例 — 项目外路径，不应标注', () => {
+      it('does not annotate ~/.bashrc', () => {
+        const input = '<p>Edit ~/.bashrc to configure your shell</p>'
+        const result = annotateFilePaths(input, { projectRoot, homeDir })
+        expect(result.detectedPaths).toHaveLength(0)
+      })
+
+      it('does not annotate ~/projects/other-app/src/main.go (other project)', () => {
+        const input = '<p>Check ~/projects/other-app/src/main.go</p>'
+        const result = annotateFilePaths(input, { projectRoot, homeDir })
+        expect(result.detectedPaths).toHaveLength(0)
+      })
+
+      it('does not annotate ~/.config/nvim/init.lua', () => {
+        const input = '<p>Modify ~/.config/nvim/init.lua for settings</p>'
+        const result = annotateFilePaths(input, { projectRoot, homeDir })
+        expect(result.detectedPaths).toHaveLength(0)
+      })
+
+      it('does not annotate ~/.ssh/config', () => {
+        const input = '<p>Look at ~/.ssh/config</p>'
+        const result = annotateFilePaths(input, { projectRoot, homeDir })
+        expect(result.detectedPaths).toHaveLength(0)
+      })
+
+      it('does not annotate ~/go/src/main.go', () => {
+        const input = '<p>Check ~/go/src/main.go</p>'
+        const result = annotateFilePaths(input, { projectRoot, homeDir })
+        expect(result.detectedPaths).toHaveLength(0)
+      })
+
+      it('does not annotate ~/.cargo/config.toml', () => {
+        const input = '<p>Look at ~/.cargo/config.toml for Rust settings</p>'
+        const result = annotateFilePaths(input, { projectRoot, homeDir })
+        expect(result.detectedPaths).toHaveLength(0)
+      })
+
+      it('does not annotate /etc/hosts', () => {
+        const input = '<p>See /etc/hosts for DNS</p>'
+        const result = annotateFilePaths(input, { projectRoot, homeDir })
+        expect(result.detectedPaths).toHaveLength(0)
+      })
+
+      it('does not annotate /usr/local/bin/python3', () => {
+        const input = '<p>Run /usr/local/bin/python3 to start</p>'
+        const result = annotateFilePaths(input, { projectRoot, homeDir })
+        expect(result.detectedPaths).toHaveLength(0)
+      })
+
+      it('does not annotate /home/xulongzhe/.local/share/applications/mimeapps.list', () => {
+        const input = '<p>The path is /home/xulongzhe/.local/share/applications/mimeapps.list</p>'
+        const result = annotateFilePaths(input, { projectRoot, homeDir })
+        expect(result.detectedPaths).toHaveLength(0)
+      })
+
+      it('does not annotate $HOME/.bashrc', () => {
+        const input = '<p>Check $HOME/.bashrc</p>'
+        const result = annotateFilePaths(input, { projectRoot, homeDir })
+        expect(result.detectedPaths).toHaveLength(0)
+      })
+
+      it('does not annotate ${HOME}/config', () => {
+        const input = '<p>Check ${HOME}/config</p>'
+        const result = annotateFilePaths(input, { projectRoot, homeDir })
+        expect(result.detectedPaths).toHaveLength(0)
+      })
+
+      it('does not annotate **/*.class glob pattern', () => {
+        const input = '<p>Clean up **/*.class files</p>'
+        const result = annotateFilePaths(input, { projectRoot, homeDir })
+        expect(result.detectedPaths).toHaveLength(0)
+      })
+
+      it('does not annotate https://example.com/page.html', () => {
+        const input = '<p>Visit https://example.com/page.html for more</p>'
+        const result = annotateFilePaths(input, { projectRoot, homeDir })
+        expect(result.detectedPaths).toHaveLength(0)
+      })
+    })
+
+    describe('边界 case', () => {
+      it('does not annotate ~/projects/clawbench (equals projectRoot, no file part)', () => {
+        const input = '<p>Navigate to ~/projects/clawbench</p>'
+        const result = annotateFilePaths(input, { projectRoot, homeDir })
+        expect(result.detectedPaths).toHaveLength(0)
+      })
+    })
   })
 })
 

--- a/web/src/composables/useChatRender.ts
+++ b/web/src/composables/useChatRender.ts
@@ -147,6 +147,7 @@ export function useChatRender(options) {
     if (!skipEnhancements) {
       // Image styling, audio links, annotations: deferred to post-streaming
       const projectRoot = store.state.projectRoot
+      const homeDir = store.state.homeDir
       html = rewriteImageUrls(html, projectRoot)
       html = convertAudioLinks(html)
       // Annotate worktree paths BEFORE file paths — prevents file-path regex from
@@ -154,7 +155,7 @@ export function useChatRender(options) {
       // /home/x/project/.worktrees instead of the full /home/x/project/.worktrees/fix)
       const { html: worktreeHtml } = annotateWorktreePaths(html, { projectRoot })
       html = worktreeHtml
-      const { html: annotatedHtml, detectedPaths } = annotateFilePaths(html, { projectRoot })
+      const { html: annotatedHtml, detectedPaths } = annotateFilePaths(html, { projectRoot, homeDir })
       html = annotatedHtml
       if (detectedPaths.length > 0) {
         const uniquePaths = [...new Set(detectedPaths)]

--- a/web/src/composables/useFilePathAnnotation.ts
+++ b/web/src/composables/useFilePathAnnotation.ts
@@ -9,13 +9,30 @@ import { clearWorktreeCache } from '@/composables/useWorktreeAnnotation.ts'
  * Resolve a file path to a project-relative path usable by store.selectFile().
  * Returns null if the path is not within the current project.
  * When projectRoot is empty, relative paths are returned as-is (best-effort).
+ *
+ * Supports tilde expansion: if homeDir is provided, ~/foo is expanded to
+ * homeDir + /foo before checking against projectRoot. Without homeDir,
+ * tilde-prefixed paths are rejected (we can't determine if they're in-project).
  */
-export function resolveFilePath(path: string, projectRoot: string): string | null {
+export function resolveFilePath(path: string, projectRoot: string, homeDir?: string): string | null {
     // Reject paths containing glob wildcards, angle brackets, or double-star.
     // These are glob patterns or template variables, not real filesystem paths.
     if (/[*?\\[\]<>]/.test(path) || path.includes('**')) return null
     // Reject URLs (handled by localhost annotation, not file path annotation)
     if (/^https?:\/\//i.test(path)) return null
+    // Reject environment variable paths (e.g. $HOME/.bashrc, ${HOME}/config)
+    if (/\$/.test(path)) return null
+
+    // Expand tilde (~/...) to absolute path using homeDir.
+    // Only handle ~/ (current user's home) — ~username/ is not expanded.
+    if (path.startsWith('~/') || path === '~') {
+        if (!homeDir) return null // can't expand ~ without knowing home directory
+        const expanded = homeDir + path.slice(1) // ~/foo → /home/user/foo
+        // Now treat as absolute path
+        if (!projectRoot) return null
+        if (!expanded.startsWith(projectRoot + '/')) return null
+        return expanded.slice(projectRoot.length + 1)
+    }
 
     if (path.startsWith('/')) {
         // Absolute path: must be under projectRoot
@@ -73,12 +90,14 @@ export interface AnnotateFilePathsOptions {
     projectRoot: string
     /** Base directory for resolving relative <a href="..."> links (e.g. the md file's dir) */
     baseDir?: string
+    /** User's home directory (from backend), used to expand ~/ paths */
+    homeDir?: string
 }
 
 /**
  * Regex that matches file paths in plain text.
  * Three forms combined into one regex:
- *   1. Absolute paths: /home/user/project/src/main.go
+ *   1. Absolute/tilde paths: /home/user/project/src/main.go, ~/.config/nvim/init.lua
  *   2. Relative paths with ./ or ../:  ./lib/utils.ts, ../config/settings.json
  *   3. Bare relative paths: src/main.go (at least two segments + extension)
  *
@@ -88,7 +107,7 @@ export interface AnnotateFilePathsOptions {
  * Because this regex only runs on text node content (never on HTML attributes or tags),
  * there is no risk of matching inside data-file-path or other generated attributes.
  */
-const FILE_PATH_RE = /(?:\/[^\s<>"')\]]+(?:\/[^\s<>"')\]]+)+\.[a-zA-Z][a-zA-Z0-9]*|\.\.?\/[^\s<>"')\]]+(?:\/[^\s<>"')\]]+)*\.[a-zA-Z][a-zA-Z0-9]*|[a-zA-Z0-9_-]+(?:\/[a-zA-Z0-9_.-]+)+\.[a-zA-Z][a-zA-Z0-9]*)/g
+const FILE_PATH_RE = /(?:~?\/[^\s<>"')\]]+(?:\/[^\s<>"')\]]+)+\.[a-zA-Z][a-zA-Z0-9]*|\.\.?\/[^\s<>"')\]]+(?:\/[^\s<>"')\]]+)*\.[a-zA-Z][a-zA-Z0-9]*|[a-zA-Z0-9_-]+(?:\/[a-zA-Z0-9_.-]+)+\.[a-zA-Z][a-zA-Z0-9]*)/g
 
 /**
  * Check if a string looks like a file path that should be annotated.
@@ -102,6 +121,8 @@ function looksLikeFilePath(text: string): boolean {
     if (/[*?\\[\]<>]/.test(text) || text.includes('**')) return false
     // Exclude URLs (handled by localhost annotation)
     if (/^https?:\/\//i.test(text)) return false
+    // Exclude environment variable paths (e.g. $HOME/.bashrc, ${HOME}/config)
+    if (/\$/.test(text)) return false
     return /\/|\.[a-zA-Z][a-zA-Z0-9]{0,3}$/.test(text)
 }
 
@@ -128,7 +149,7 @@ export function annotateFilePaths(
 ): { html: string; detectedPaths: string[] } {
     if (!html) return { html: '', detectedPaths: [] }
 
-    const { projectRoot, baseDir } = options
+    const { projectRoot, baseDir, homeDir } = options
     const detectedPaths: string[] = []
 
     const doc = new DOMParser().parseFromString(html, 'text/html')
@@ -140,7 +161,7 @@ export function annotateFilePaths(
         if (/^(https?:|\/\/|mailto:|tel:|#)/i.test(href)) continue
         const resolved = baseDir
             ? resolveRelativePath(href, baseDir)
-            : resolveFilePath(href, projectRoot)
+            : resolveFilePath(href, projectRoot, homeDir)
         if (!resolved) continue
         detectedPaths.push(resolved)
         a.insertAdjacentHTML('afterend', fileOpenButtonHtml(resolved))
@@ -155,7 +176,7 @@ export function annotateFilePaths(
         if (code.classList.contains('chat-worktree-path')) continue
         const stripped = (code.textContent || '').trim()
         if (!looksLikeFilePath(stripped)) continue
-        const resolved = resolveFilePath(stripped, projectRoot)
+        const resolved = resolveFilePath(stripped, projectRoot, homeDir)
         if (!resolved || resolved.includes(' ') || resolved.includes('"')) continue
         // Entire <code> content is a valid file path — annotate the whole element
         detectedPaths.push(resolved)
@@ -196,7 +217,7 @@ export function annotateFilePaths(
         let match: RegExpExecArray | null
         while ((match = FILE_PATH_RE.exec(text)) !== null) {
             const pathStr = match[0]
-            let resolved = resolveFilePath(pathStr, projectRoot)
+            let resolved = resolveFilePath(pathStr, projectRoot, homeDir)
             // If the text immediately after this match continues with a path segment
             // (e.g. "/.worktrees" followed by "/gitgraph-fix"), the regex only matched
             // a directory prefix — skip it so worktree annotation can handle the full path.

--- a/web/src/stores/app.ts
+++ b/web/src/stores/app.ts
@@ -33,6 +33,7 @@ interface AppState {
     projectRoot: string
     projectName: string
     watchDir: string
+    homeDir: string
 
     // Upload config
     uploadMaxSizeMB: number
@@ -89,6 +90,7 @@ const state = reactive<AppState>({
     projectRoot: '',
     projectName: '',
     watchDir: '',
+    homeDir: '',
 
     // Upload config
     uploadMaxSizeMB: 100,
@@ -146,10 +148,11 @@ async function loadProject(): Promise<void> {
         } catch (error) {
             console.error('[loadProject] watchDir failed:', error)
         }
-        const data = await apiGet<{ path: string }>('/api/project')
+        const data = await apiGet<{ path: string; homeDir?: string }>('/api/project')
         if (!data.path) return
         state.projectRoot = data.path
         state.projectName = baseName(data.path)
+        state.homeDir = data.homeDir || ''
         localStorage.setItem('currentProjectPath', data.path)
         // Add to recent projects
         apiPost('/api/recent-projects', { path: data.path }).catch(() => {})
@@ -169,6 +172,7 @@ function resetProjectState(): void {
     state.projectRoot = ''
     state.projectName = ''
     state.watchDir = ''
+    state.homeDir = ''
     // File browser
     state.currentDir = ''
     state.dirEntries = []

--- a/web/src/utils/renderToolDetail.ts
+++ b/web/src/utils/renderToolDetail.ts
@@ -30,7 +30,8 @@ function renderEditDiff(input: Record<string, any>): string {
 
   // Resolve file path for click-to-open
   const projectRoot = store.state.projectRoot || ''
-  const resolvedPath = resolveFilePath(filePath, projectRoot)
+  const homeDir = store.state.homeDir || ''
+  const resolvedPath = resolveFilePath(filePath, projectRoot, homeDir)
   const displayPath = resolvedPath || filePath.replace(/^\.\//, '')
 
   // Detect language for syntax highlighting
@@ -108,7 +109,8 @@ function renderBashTerminal(input: Record<string, any>): string {
 function filePathHeader(input: Record<string, any>, extraBadge = ''): string {
   const filePath = input.file_path || ''
   const projectRoot = store.state.projectRoot || ''
-  const resolvedPath = resolveFilePath(filePath, projectRoot)
+  const homeDir = store.state.homeDir || ''
+  const resolvedPath = resolveFilePath(filePath, projectRoot, homeDir)
   const displayPath = resolvedPath || filePath.replace(/^\.\//, '')
 
   let html = '<div class="tool-file-header">'
@@ -265,7 +267,8 @@ function renderGrepSearch(input: Record<string, any>): string {
   // Path line
   if (path) {
     const projectRoot = store.state.projectRoot || ''
-    const resolvedPath = resolveFilePath(path, projectRoot)
+    const homeDir = store.state.homeDir || ''
+    const resolvedPath = resolveFilePath(path, projectRoot, homeDir)
     const displayPath = resolvedPath || path.replace(/^\.\//, '')
     html += '<div class="grep-path-row">'
     html += `<span class="grep-label">${escapeHtml(gt('tool.grep.path'))}</span>`
@@ -304,7 +307,8 @@ function renderGlobPattern(input: Record<string, any>): string {
   // Path line
   if (path) {
     const projectRoot = store.state.projectRoot || ''
-    const resolvedPath = resolveFilePath(path, projectRoot)
+    const homeDir = store.state.homeDir || ''
+    const resolvedPath = resolveFilePath(path, projectRoot, homeDir)
     const displayPath = resolvedPath || path.replace(/^\.\//, '')
     html += '<div class="glob-path-row">'
     html += `<span class="glob-label">${escapeHtml(gt('tool.glob.path'))}</span>`


### PR DESCRIPTION
## 问题

文件路径标注功能中，`~` 开头的路径（如 `~/.bashrc`、`~/other-project/file.ts`）被错误地当作项目内相对路径处理。

**根因**：`resolveFilePath()` 把 `~` 当成字面目录名拼接到 `projectRoot` 下，导致所有 `~/` 路径都通过了 `startsWith(projectRoot + '/')` 检查。

## 修复

1. 后端 `GET /api/project` 响应增加 `homeDir` 字段
2. 后端 `ServeFileBatchExists` 加 `ExpandTilde` 防御性展开
3. 前端 store 加 `homeDir` 字段
4. 前端 `resolveFilePath()` 用 `homeDir` 展开 `~/` 后判断是否在项目内
5. 前端 `FILE_PATH_RE` 加 `~?` 前缀完整匹配 tilde 路径
6. 前端 `looksLikeFilePath()` 拒绝含 `$` 的环境变量路径
7. 所有调用方透传 `homeDir`

## 测试效果

| 路径 | 修复前 | 修复后 |
|------|--------|--------|
| `~/my-app/src/main.go` (项目内) | ❌ 错误返回 `~/my-app/src/main.go` | ✅ 正确返回 `src/main.go` |
| `~/.bashrc` (项目外) | ❌ 错误返回 `~/.bashrc` | ✅ 正确返回 null |
| `~/.config/nvim/init.lua` (项目外) | ❌ 错误标注 | ✅ 不标注 |
| `/home/xulongzhe/.bashrc` (环境变量) | ❌ 可能标注 | ✅ 不标注 |
| `src/main.go` (项目内相对路径) | ✅ | ✅ |
| `/home/user/project/file.go` (项目内绝对路径) | ✅ | ✅ |

## CI

- ✅ 前端 3040 个测试全部通过
- ✅ Go 全部测试通过
- ✅ 前端覆盖率门槛 PASS (Tier1 + Tier2)
- ✅ Go 覆盖率门槛 PASS (Tier1 + Tier2)