### PR TITLE
fix: prevent streaming duplicate content on AutoResume (Issue #60)

### DIFF
--- a/internal/ai/claude_stream_test.go
+++ b/internal/ai/claude_stream_test.go
@@ -1602,3 +1602,123 @@ func TestStreamParser_FullFlowWithEmptyInputJsonDeltaAndUserToolResult(t *testin
 		t.Errorf("expected output containing 'drwxr-xr-x', got %q", toolResultEvents[0].Tool.Output)
 	}
 }
+
+// --- Issue #60: Resume dedup tests ---
+
+func TestStreamParser_ResumeDedup_VerboseMessageAfterDeltaIsSkipped(t *testing.T) {
+	// In normal streaming with --include-partial-messages, content arrives as
+	// text_delta (incremental) followed by an assistant verbose message (complete).
+	// The parser correctly skips the verbose message because receivedPartial=true.
+	lines := []string{
+		`{"type":"stream_event","event":{"type":"message_start","message":{"model":"claude-3.5-sonnet"}}}`,
+		`{"type":"stream_event","event":{"type":"content_block_delta","index":0,"delta":{"type":"thinking_delta","thinking":"I need to plan..."}}}`,
+		`{"type":"stream_event","event":{"type":"content_block_delta","index":1,"delta":{"type":"text_delta","text":"Here is my plan."}}}`,
+		`{"type":"stream_event","event":{"type":"content_block_start","index":2,"content_block":{"type":"tool_use","id":"toolu_epm","name":"ExitPlanMode"}}}`,
+		`{"type":"stream_event","event":{"type":"content_block_stop","index":2}}`,
+		// Assistant verbose message — thinking and text should be SKIPPED
+		`{"type":"assistant","message":{"content":[{"type":"thinking","thinking":"I need to plan..."},{"type":"text","text":"Here is my plan."},{"type":"tool_use","id":"toolu_epm","name":"ExitPlanMode","input":{}}]}}`,
+		`{"type":"result","session_id":"sess-1","duration_ms":5000}`,
+	}
+
+	events := parseLines(lines)
+
+	var thinkingCount, contentCount int
+	for _, ev := range events {
+		switch ev.Type {
+		case "thinking":
+			thinkingCount++
+		case "content":
+			contentCount++
+		}
+	}
+
+	if thinkingCount != 1 {
+		t.Errorf("expected 1 thinking event (from delta only), got %d", thinkingCount)
+	}
+	if contentCount != 1 {
+		t.Errorf("expected 1 content event (from delta only), got %d", contentCount)
+	}
+}
+
+func TestStreamParser_ResumeDedup_MessageStartResetsFlags(t *testing.T) {
+	// When a new message_start arrives, partial flags are reset so that
+	// content from the new turn is not suppressed.
+	// This is the normal behavior (ISS-028).
+	lines := []string{
+		// Turn 1: text_delta sets receivedPartial=true
+		`{"type":"stream_event","event":{"type":"message_start","message":{"model":"claude-3.5-sonnet"}}}`,
+		`{"type":"stream_event","event":{"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"Turn 1 content."}}}`,
+		// Turn 2: message_start resets receivedPartial=false
+		`{"type":"stream_event","event":{"type":"message_start","message":{"model":"claude-3.5-sonnet"}}}`,
+		// New text_delta should be emitted (not suppressed)
+		`{"type":"stream_event","event":{"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"Turn 2 content."}}}`,
+	}
+
+	events := parseLines(lines)
+
+	var contentCount int
+	var contentText string
+	for _, ev := range events {
+		if ev.Type == "content" {
+			contentCount++
+			contentText += ev.Content
+		}
+	}
+
+	if contentCount != 2 {
+		t.Errorf("expected 2 content events (one per turn), got %d", contentCount)
+	}
+	if contentText != "Turn 1 content.Turn 2 content." {
+		t.Errorf("expected combined content from both turns, got %q", contentText)
+	}
+}
+
+func TestStreamParser_ResumeDedup_AssistantVerboseWithoutDelta(t *testing.T) {
+	// When there is NO --include-partial-messages (verbose-only mode),
+	// content comes from assistant messages as full text blocks.
+	// Each assistant message represents a complete turn — no dedup needed.
+	// This tests the scenario where message_start resets flags correctly
+	// even without prior deltas.
+	msg1 := ClaudeStreamMessage{
+		Type: "assistant",
+		Message: &ClaudeStreamMessageBody{
+			Content: []ClaudeContentBlock{
+				{Type: "thinking", Thinking: "First thought"},
+				{Type: "text", Text: "First response."},
+			},
+		},
+	}
+	msg2 := ClaudeStreamMessage{
+		Type: "assistant",
+		Message: &ClaudeStreamMessageBody{
+			Content: []ClaudeContentBlock{
+				{Type: "text", Text: "Second response after tool."},
+			},
+		},
+	}
+
+	var lines []string
+	for _, msg := range []ClaudeStreamMessage{msg1, msg2} {
+		data, _ := json.Marshal(msg)
+		lines = append(lines, string(data))
+	}
+
+	events := parseLines(lines)
+
+	var thinkingCount, contentCount int
+	for _, ev := range events {
+		switch ev.Type {
+		case "thinking":
+			thinkingCount++
+		case "content":
+			contentCount++
+		}
+	}
+
+	if thinkingCount != 1 {
+		t.Errorf("expected 1 thinking event, got %d", thinkingCount)
+	}
+	if contentCount != 2 {
+		t.Errorf("expected 2 content events, got %d", contentCount)
+	}
+}

--- a/internal/handler/chat_stream.go
+++ b/internal/handler/chat_stream.go
@@ -176,6 +176,11 @@ func AIChatStream(w http.ResponseWriter, r *http.Request) {
 				}
 			case "queue_done":
 				fmt.Fprintf(w, "event: queue_done\ndata: {}\n\n")
+			case "resume_split":
+				// Internal event from AutoResumeBackend: the AI detected ExitPlanMode
+				// and will auto-resume. Forward to frontend so it can reset streaming
+				// state (clear blocks, prepare for new content after resume).
+				fmt.Fprintf(w, "event: resume_split\ndata: {}\n\n")
 			}
 
 			if canFlush {

--- a/internal/handler/chat_stream_test.go
+++ b/internal/handler/chat_stream_test.go
@@ -497,6 +497,48 @@ func TestAIChatStream_ErrorEventWithReason(t *testing.T) {
 	assert.Equal(t, "timeout", data["reason"])
 }
 
+func TestAIChatStream_ResumeSplitEvent(t *testing.T) {
+	env, teardown := setupTestEnv(t)
+	defer teardown()
+
+	sessionID := "stream-resume-split"
+	ch := setupStreamSession(sessionID)
+	defer cleanupStreamSession(sessionID)
+
+	go func() {
+		ch <- ai.StreamEvent{Type: "content", Content: "phase 1 content"}
+		ch <- ai.StreamEvent{Type: "resume_split"}
+		ch <- ai.StreamEvent{Type: "content", Content: "phase 2 content"}
+		ch <- ai.StreamEvent{Type: "done"}
+	}()
+
+	req := newRequest(t, http.MethodGet, "/api/ai/chat/stream?session_id="+sessionID, nil)
+	req = withProjectCookie(req, env.ProjectDir)
+	w := callHandler(AIChatStream, req)
+
+	events := parseSSEEvents(w.Body.String())
+	assert.Equal(t, 4, len(events), "expected content, resume_split, content, done events")
+
+	// First event: content from phase 1
+	assert.Equal(t, "content", events[0]["event"])
+	var data1 map[string]string
+	require.NoError(t, json.Unmarshal([]byte(events[0]["data"]), &data1))
+	assert.Equal(t, "phase 1 content", data1["content"])
+
+	// Second event: resume_split
+	assert.Equal(t, "resume_split", events[1]["event"])
+	assert.Equal(t, "{}", events[1]["data"])
+
+	// Third event: content from phase 2
+	assert.Equal(t, "content", events[2]["event"])
+	var data2 map[string]string
+	require.NoError(t, json.Unmarshal([]byte(events[2]["data"]), &data2))
+	assert.Equal(t, "phase 2 content", data2["content"])
+
+	// Final event: done
+	assert.Equal(t, "done", events[3]["event"])
+}
+
 func TestAIChatStream_WarningEvent(t *testing.T) {
 	env, teardown := setupTestEnv(t)
 	defer teardown()

--- a/web/src/composables/useChatStream.ts
+++ b/web/src/composables/useChatStream.ts
@@ -260,6 +260,17 @@ export function useChatStream(options: UseChatStreamOptions) {
     // Start stream timeout
     resetStreamTimeout()
 
+    eventSource.addEventListener('resume_split', () => {
+      if (!guard()) return
+      resetStreamTimeout()
+      // AutoResumeBackend detected ExitPlanMode and will auto-resume.
+      // Clear the streaming message's blocks so that resume content
+      // starts fresh — prevents duplicate rendering of pre-resume
+      // content (Issue #60).
+      streamingMsg.blocks = []
+      debouncedRender()
+    })
+
     eventSource.addEventListener('content', (e) => {
       if (!guard()) return
       resetStreamTimeout()


### PR DESCRIPTION
Fixes #60 — Real-time streaming response displays duplicate content (same thinking/text block appears 2-3 times). Refreshing the page restores normal display.

## Root Cause

When AutoResumeBackend detects ExitPlanMode and auto-resumes, it emits a resume_split event. However, chat_stream.go had no resume_split case in its SSE event switch — the event was silently dropped. The frontend never learned it should reset streaming state, so Phase 2 content was appended to Phase 1 blocks, causing duplicates.

## Fix

1. Backend (chat_stream.go): Forward resume_split as an SSE event
2. Frontend (useChatStream.ts): On resume_split, clear streaming blocks
3. Tests: Add regression tests for dedup behavior