### PR TITLE
feat: 端口转发增加重连按钮 + 打开前自动检测隧道健康

### DIFF
--- a/android/app/src/main/java/com/clawbench/app/BackgroundService.java
+++ b/android/app/src/main/java/com/clawbench/app/BackgroundService.java
@@ -38,9 +38,11 @@ import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
 
 import javax.net.ssl.HttpsURLConnection;
 import javax.net.ssl.SSLContext;
@@ -168,6 +170,44 @@ public class BackgroundService extends Service {
             lastError = null;
         }
         return connected;
+    }
+
+    /**
+     * Force-reconnect the SSH tunnel from an external caller (e.g. WebAppInterface).
+     * Disconnects the current (possibly stale) session, then reconnects and
+     * re-establishes all port forwards.
+     * Blocks the calling thread until reconnection completes or times out.
+     *
+     * @param timeoutMs Maximum time to wait for reconnection (milliseconds)
+     * @return true if reconnection succeeded, false if failed or timed out
+     */
+    public static boolean forceReconnect(long timeoutMs) {
+        if (instance == null) return false;
+
+        CountDownLatch latch = new CountDownLatch(1);
+        AtomicBoolean result = new AtomicBoolean(false);
+
+        instance.networkExecutor.execute(() -> {
+            try {
+                instance.intentionalDisconnect = false;
+                instance.disconnectInternal();
+                instance.ensureConnection();
+                result.set(true);
+                AppLog.i(TAG, "SSH: forceReconnect succeeded");
+            } catch (Exception e) {
+                lastError = e.getMessage();
+                AppLog.e(TAG, "SSH: forceReconnect failed: " + e.getMessage(), e);
+            } finally {
+                latch.countDown();
+            }
+        });
+
+        try {
+            return latch.await(timeoutMs, TimeUnit.MILLISECONDS) && result.get();
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            return false;
+        }
     }
 
     /**

--- a/android/app/src/main/java/com/clawbench/app/MainActivity.java
+++ b/android/app/src/main/java/com/clawbench/app/MainActivity.java
@@ -1564,6 +1564,45 @@ public class MainActivity extends AppCompatActivity {
         }
 
         /**
+         * Test whether a local forwarded port is reachable by attempting a TCP connect.
+         * Uses a short timeout (3s) since we're connecting to localhost.
+         * Returns true if the port accepts a TCP connection, false otherwise.
+         * Used by the frontend to verify tunnel health before opening a port.
+         */
+        @JavascriptInterface
+        public boolean testPortReachable(int port) {
+            if (port <= 0 || port > 65535) return false;
+            try (java.net.Socket socket = new java.net.Socket()) {
+                socket.connect(new java.net.InetSocketAddress("127.0.0.1", port), 3000);
+                return true;
+            } catch (Exception e) {
+                AppLog.d(TAG, "testPortReachable: port " + port + " unreachable: " + e.getMessage());
+                return false;
+            }
+        }
+
+        /**
+         * Force-reconnect the SSH tunnel.
+         * Disconnects the current (possibly stale) session and establishes a new one.
+         * Returns true if reconnection succeeded (port forwards re-established),
+         * false if reconnection failed or timed out.
+         * This is a blocking call (up to 15s) — runs on the JavaBridge thread.
+         */
+        @JavascriptInterface
+        public boolean reconnectTunnel() {
+            if (!BackgroundService.isRunning()) {
+                AppLog.w(TAG, "reconnectTunnel: BackgroundService not running");
+                return false;
+            }
+            try {
+                return BackgroundService.forceReconnect(15000);
+            } catch (Exception e) {
+                AppLog.e(TAG, "reconnectTunnel: failed", e);
+                return false;
+            }
+        }
+
+        /**
          * Get the saved SSH/web password for auto-login.
          * Returns empty string if no password is saved.
          */

--- a/android/app/src/test/java/com/clawbench/app/BackgroundServiceForceReconnectTest.java
+++ b/android/app/src/test/java/com/clawbench/app/BackgroundServiceForceReconnectTest.java
@@ -1,0 +1,116 @@
+package com.clawbench.app;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.lang.reflect.Field;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+
+import static org.junit.Assert.*;
+
+/**
+ * Unit tests for BackgroundService.forceReconnect() static method.
+ *
+ * Tests the control flow of forceReconnect:
+ * - Returns false when instance is null
+ * - Returns false when ensureConnection fails (no server URL configured)
+ * - Resets intentionalDisconnect to false before reconnecting
+ *
+ * Note: Successful reconnection requires a real SSH server, tested via integration.
+ */
+public class BackgroundServiceForceReconnectTest {
+
+    private BackgroundService service;
+    private ExecutorService testExecutor;
+
+    @Before
+    public void setUp() throws Exception {
+        // Create a minimal BackgroundService instance via Unsafe allocation
+        var unsafeField = Class.forName("sun.misc.Unsafe").getDeclaredField("theUnsafe");
+        unsafeField.setAccessible(true);
+        Object unsafe = unsafeField.get(null);
+        var allocate = unsafe.getClass().getDeclaredMethod("allocateInstance", Class.class);
+        allocate.setAccessible(true);
+        service = (BackgroundService) allocate.invoke(unsafe, BackgroundService.class);
+
+        // Set static fields
+        setStaticField("instance", service);
+        setStaticField("isRunning", true);
+        setStaticField("lastError", null);
+
+        // Set up networkExecutor (required by forceReconnect)
+        testExecutor = Executors.newSingleThreadExecutor();
+        Field executorField = BackgroundService.class.getDeclaredField("networkExecutor");
+        executorField.setAccessible(true);
+        executorField.set(service, testExecutor);
+
+        // Set intentionalDisconnect to false (instance field)
+        setInstanceField(service, "intentionalDisconnect", false);
+    }
+
+    @After
+    public void tearDown() throws Exception {
+        try {
+            setStaticField("instance", null);
+            setStaticField("isRunning", false);
+            setStaticField("lastError", null);
+        } catch (Exception ignored) {}
+        if (testExecutor != null) {
+            testExecutor.shutdownNow();
+        }
+    }
+
+    @Test
+    public void testForceReconnect_nullInstance_returnsFalse() throws Exception {
+        setStaticField("instance", null);
+        boolean result = BackgroundService.forceReconnect(5000);
+        assertFalse("Should return false when instance is null", result);
+    }
+
+    @Test
+    public void testForceReconnect_noServerUrl_returnsFalse() throws Exception {
+        // No SharedPreferences with server URL — ensureConnection will fail
+        boolean result = BackgroundService.forceReconnect(10000);
+        assertFalse("Should return false when ensureConnection fails", result);
+    }
+
+    @Test
+    public void testForceReconnect_resetsIntentionalDisconnect() throws Exception {
+        // Set intentionalDisconnect to true (instance field)
+        setInstanceField(service, "intentionalDisconnect", true);
+
+        // Even though ensureConnection will fail, forceReconnect should still reset
+        // intentionalDisconnect to false as its first step
+        BackgroundService.forceReconnect(10000);
+
+        Field idField = BackgroundService.class.getDeclaredField("intentionalDisconnect");
+        idField.setAccessible(true);
+        boolean intentionalDisconnect = (boolean) idField.get(service);
+        assertFalse("intentionalDisconnect should be reset to false", intentionalDisconnect);
+    }
+
+    @Test
+    public void testForceReconnect_setsLastErrorOnFailure() throws Exception {
+        BackgroundService.forceReconnect(10000);
+
+        // lastError should be set by the failed ensureConnection
+        String error = BackgroundService.getLastError();
+        assertNotNull("lastError should be set when forceReconnect fails", error);
+    }
+
+    // --- Helper methods ---
+
+    private void setStaticField(String name, Object value) throws Exception {
+        Field field = BackgroundService.class.getDeclaredField(name);
+        field.setAccessible(true);
+        field.set(null, value);
+    }
+
+    private void setInstanceField(Object target, String name, Object value) throws Exception {
+        Field field = BackgroundService.class.getDeclaredField(name);
+        field.setAccessible(true);
+        field.set(target, value);
+    }
+}

--- a/android/app/src/test/java/com/clawbench/app/MainActivityTunnelBridgeTest.java
+++ b/android/app/src/test/java/com/clawbench/app/MainActivityTunnelBridgeTest.java
@@ -1,0 +1,149 @@
+package com.clawbench.app;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.lang.reflect.Constructor;
+import java.lang.reflect.Field;
+import java.lang.reflect.Method;
+
+import static org.junit.Assert.*;
+
+/**
+ * Unit tests for the new WebAppInterface bridge methods:
+ * - testPortReachable(int port): TCP Socket connect to localhost
+ * - reconnectTunnel(): calls BackgroundService.forceReconnect()
+ *
+ * Since these are @JavascriptInterface methods on an inner class,
+ * we test them via reflection to avoid needing a full Android Activity.
+ */
+public class MainActivityTunnelBridgeTest {
+
+    private Object webAppInterface;
+    private MainActivity activity;
+
+    @Before
+    public void setUp() throws Exception {
+        // Allocate a minimal MainActivity instance
+        activity = allocate(MainActivity.class);
+
+        // Set the static instance field
+        Field instanceField = MainActivity.class.getDeclaredField("instance");
+        instanceField.setAccessible(true);
+        instanceField.set(null, activity);
+
+        // Create a WebAppInterface instance via reflection
+        Class<?> waiClass = Class.forName("com.clawbench.app.MainActivity$WebAppInterface");
+        Constructor<?> constructor = waiClass.getDeclaredConstructor(MainActivity.class);
+        constructor.setAccessible(true);
+        webAppInterface = constructor.newInstance(activity);
+    }
+
+    @After
+    public void tearDown() throws Exception {
+        try {
+            Field instanceField = MainActivity.class.getDeclaredField("instance");
+            instanceField.setAccessible(true);
+            instanceField.set(null, null);
+        } catch (Exception ignored) {}
+    }
+
+    // =====================================================
+    // testPortReachable tests
+    // =====================================================
+
+    @Test
+    public void testPortReachable_invalidPortZero_returnsFalse() throws Exception {
+        boolean result = invokeTestPortReachable(0);
+        assertFalse("Port 0 should be invalid", result);
+    }
+
+    @Test
+    public void testPortReachable_negativePort_returnsFalse() throws Exception {
+        boolean result = invokeTestPortReachable(-1);
+        assertFalse("Negative port should be invalid", result);
+    }
+
+    @Test
+    public void testPortReachable_portTooLarge_returnsFalse() throws Exception {
+        boolean result = invokeTestPortReachable(65536);
+        assertFalse("Port > 65535 should be invalid", result);
+    }
+
+    @Test
+    public void testPortReachable_unusedPort_returnsFalse() throws Exception {
+        // Port 1 is almost certainly not listening on localhost
+        boolean result = invokeTestPortReachable(1);
+        assertFalse("Port 1 should not be reachable on localhost", result);
+    }
+
+    // =====================================================
+    // reconnectTunnel tests
+    // =====================================================
+
+    @Test
+    public void reconnectTunnel_serviceNotRunning_returnsFalse() throws Exception {
+        // Ensure BackgroundService is not running
+        Field isRunningField = BackgroundService.class.getDeclaredField("isRunning");
+        isRunningField.setAccessible(true);
+        isRunningField.set(null, false);
+
+        boolean result = invokeReconnectTunnel();
+        assertFalse("Should return false when BackgroundService is not running", result);
+    }
+
+    // =====================================================
+    // Method signature verification
+    // =====================================================
+
+    @Test
+    public void testPortReachable_methodExists() throws Exception {
+        Method method = webAppInterface.getClass().getDeclaredMethod("testPortReachable", int.class);
+        assertNotNull("testPortReachable method should exist", method);
+    }
+
+    @Test
+    public void reconnectTunnel_methodExists() throws Exception {
+        Method method = webAppInterface.getClass().getDeclaredMethod("reconnectTunnel");
+        assertNotNull("reconnectTunnel method should exist", method);
+    }
+
+    @Test
+    public void testPortReachable_hasJavascriptInterfaceAnnotation() throws Exception {
+        Method method = webAppInterface.getClass().getDeclaredMethod("testPortReachable", int.class);
+        assertNotNull("Should have @JavascriptInterface annotation",
+                method.getAnnotation(android.webkit.JavascriptInterface.class));
+    }
+
+    @Test
+    public void reconnectTunnel_hasJavascriptInterfaceAnnotation() throws Exception {
+        Method method = webAppInterface.getClass().getDeclaredMethod("reconnectTunnel");
+        assertNotNull("Should have @JavascriptInterface annotation",
+                method.getAnnotation(android.webkit.JavascriptInterface.class));
+    }
+
+    // --- Helper methods ---
+
+    @SuppressWarnings("unchecked")
+    private static <T> T allocate(Class<T> clazz) throws Exception {
+        var unsafeField = Class.forName("sun.misc.Unsafe").getDeclaredField("theUnsafe");
+        unsafeField.setAccessible(true);
+        Object unsafe = unsafeField.get(null);
+        var allocate = unsafe.getClass().getDeclaredMethod("allocateInstance", Class.class);
+        allocate.setAccessible(true);
+        return (T) allocate.invoke(unsafe, clazz);
+    }
+
+    private boolean invokeTestPortReachable(int port) throws Exception {
+        Method method = webAppInterface.getClass().getDeclaredMethod("testPortReachable", int.class);
+        method.setAccessible(true);
+        return (boolean) method.invoke(webAppInterface, port);
+    }
+
+    private boolean invokeReconnectTunnel() throws Exception {
+        Method method = webAppInterface.getClass().getDeclaredMethod("reconnectTunnel");
+        method.setAccessible(true);
+        return (boolean) method.invoke(webAppInterface);
+    }
+}

--- a/web/src/components/proxy/ProxyPanelContent.vue
+++ b/web/src/components/proxy/ProxyPanelContent.vue
@@ -114,8 +114,10 @@
               :protocol="p.protocol"
               :active="p.active"
               :tunnel-disconnected="tunnelStatus === 'disconnected'"
+              :reconnecting="reconnectingPorts.has(p.localPort)"
               @open="openPort"
               @open-external="openInExternalBrowser"
+              @reconnect="handleReconnect"
               @edit="handleEdit"
               @remove="handleRemove"
             />
@@ -245,10 +247,13 @@ watch(showForm, (val) => {
   }
 })
 
-const { ports, detectedPorts, loading, isAppMode, sshInfo, tunnelStatus, tunnelMessage, tunnelChecking, tunnelError, tunnelErrorType, registerPort, updatePort, unregisterPort, detectPorts, checkTunnelHealth, openPort, openInExternalBrowser } = usePortForward()
+const { ports, detectedPorts, loading, isAppMode, sshInfo, tunnelStatus, tunnelMessage, tunnelChecking, tunnelError, tunnelErrorType, registerPort, updatePort, unregisterPort, detectPorts, checkTunnelHealth, openPort, openInExternalBrowser, reconnectPort } = usePortForward()
 const toast = useToast()
 
 const sshCopied = ref(false)
+
+// Track which ports are currently reconnecting (for spinning button state)
+const reconnectingPorts = ref(new Set())
 
 // Compute contextual error detail based on error type from native bridge
 const tunnelErrorDetail = computed(() => {
@@ -331,6 +336,19 @@ async function handleDetect() {
     await detectPorts()
   } finally {
     detecting.value = false
+  }
+}
+
+async function handleReconnect(localPort) {
+  if (reconnectingPorts.value.has(localPort)) return
+  reconnectingPorts.value.add(localPort)
+  // Trigger reactivity by replacing the Set
+  reconnectingPorts.value = new Set(reconnectingPorts.value)
+  try {
+    await reconnectPort(localPort)
+  } finally {
+    reconnectingPorts.value.delete(localPort)
+    reconnectingPorts.value = new Set(reconnectingPorts.value)
   }
 }
 

--- a/web/src/components/proxy/ProxyPortItem.vue
+++ b/web/src/components/proxy/ProxyPortItem.vue
@@ -14,6 +14,9 @@
         <button class="port-action-btn open" @click.stop="$emit('openExternal', localPort, protocol, host)" :title="t('proxy.openInBrowser')">
           <ExternalLink :size="14" />
         </button>
+        <button class="port-action-btn reconnect" :class="{ spinning: reconnecting }" :disabled="reconnecting" @click.stop="$emit('reconnect', localPort)" :title="t('proxy.reconnectPort')">
+          <RotateCcw :size="14" />
+        </button>
         <button class="port-action-btn edit" @click.stop="$emit('edit', localPort)" :title="t('common.edit')">
           <Pencil :size="14" />
         </button>
@@ -32,7 +35,7 @@
 </template>
 
 <script setup>
-import { Box, ExternalLink, Pencil, Trash2 } from 'lucide-vue-next'
+import { Box, ExternalLink, RotateCcw, Pencil, Trash2 } from 'lucide-vue-next'
 import { computed } from 'vue'
 import { useI18n } from 'vue-i18n'
 
@@ -46,9 +49,10 @@ const props = defineProps({
   protocol: { type: String, default: 'http' },
   active: { type: Boolean, default: false },
   tunnelDisconnected: { type: Boolean, default: false },
+  reconnecting: { type: Boolean, default: false },
 })
 
-defineEmits(['open', 'openExternal', 'edit', 'remove'])
+defineEmits(['open', 'openExternal', 'reconnect', 'edit', 'remove'])
 
 const hasDetail = computed(() => {
   return props.port !== props.localPort || props.host || props.name
@@ -188,6 +192,20 @@ const statusTitle = computed(() => {
   background: var(--bg-tertiary, #f0f0f0);
 }
 
+.port-action-btn.reconnect:hover {
+  color: #22c55e;
+  background: var(--bg-tertiary, #f0f0f0);
+}
+
+.port-action-btn.reconnect.spinning svg {
+  animation: spin 1s linear infinite;
+}
+
+.port-action-btn.reconnect:disabled {
+  cursor: not-allowed;
+  opacity: 0.6;
+}
+
 .port-action-btn.edit:hover {
   color: #f59e0b;
   background: var(--bg-tertiary, #f0f0f0);
@@ -196,6 +214,11 @@ const statusTitle = computed(() => {
 .port-action-btn.delete:hover {
   color: #dc3545;
   background: var(--bg-tertiary, #f0f0f0);
+}
+
+@keyframes spin {
+  from { transform: rotate(0deg); }
+  to { transform: rotate(360deg); }
 }
 
 /* Bottom row: secondary info */

--- a/web/src/composables/__tests__/usePortForward.test.ts
+++ b/web/src/composables/__tests__/usePortForward.test.ts
@@ -23,6 +23,11 @@ vi.mock('@/composables/useLocale', () => ({
     gt: (key: string) => key,
 }))
 
+const mockToastShow = vi.fn()
+vi.mock('@/composables/useToast', () => ({
+    useToast: () => ({ show: mockToastShow, dismiss: vi.fn(), visible: ref(false), message: ref(''), icon: ref(''), type: ref('success'), onClick: ref(null) }),
+}))
+
 vi.mock('@/utils/portForwardUtils', () => ({
     tunnelStatusFromPorts: () => 'ok',
     buildPortUrl: (port: number, protocol?: string, host?: string) => `${protocol || 'http'}://${host || 'localhost'}:${port}`,
@@ -36,6 +41,8 @@ describe('usePortForward', () => {
         mockApiPut.mockReset()
         mockApiDelete.mockReset()
         mockIsAppMode.value = false
+        mockToastShow.mockReset()
+        delete (window as any).AndroidNative
     })
 
     describe('loadSSHInfo', () => {
@@ -216,14 +223,77 @@ describe('usePortForward', () => {
             const { usePortForward } = await import('@/composables/usePortForward')
             const { openPort } = usePortForward()
 
-            openPort(3000, 'http')
+            await openPort(3000, 'http')
 
             expect(openSpy).toHaveBeenCalledWith('http://localhost:3000', '_blank')
 
             openSpy.mockRestore()
         })
 
-        it('calls Android native sandbox browser in app mode', async () => {
+        it('opens immediately in app mode when port is reachable', async () => {
+            mockIsAppMode.value = true
+            const mockOpenInSandbox = vi.fn()
+            const mockTestPortReachable = vi.fn().mockReturnValue(true)
+            ;(window as any).AndroidNative = { openInSandbox: mockOpenInSandbox, testPortReachable: mockTestPortReachable }
+
+            const { usePortForward } = await import('@/composables/usePortForward')
+            const { openPort } = usePortForward()
+
+            await openPort(3000, 'http')
+
+            expect(mockTestPortReachable).toHaveBeenCalledWith(3000)
+            expect(mockOpenInSandbox).toHaveBeenCalledWith(3000, 'http', '')
+        })
+
+        it('reconnects and opens when port unreachable then reachable', async () => {
+            mockIsAppMode.value = true
+            const mockOpenInSandbox = vi.fn()
+            // First testPortReachable returns false, second returns true
+            const mockTestPortReachable = vi.fn().mockReturnValueOnce(false).mockReturnValueOnce(true)
+            const mockReconnectTunnel = vi.fn().mockReturnValue(true)
+            ;(window as any).AndroidNative = { openInSandbox: mockOpenInSandbox, testPortReachable: mockTestPortReachable, reconnectTunnel: mockReconnectTunnel }
+
+            const { usePortForward } = await import('@/composables/usePortForward')
+            const { openPort } = usePortForward()
+
+            await openPort(3000, 'http')
+
+            expect(mockReconnectTunnel).toHaveBeenCalled()
+            expect(mockToastShow).toHaveBeenCalledWith('portForward.tunnelReconnected', expect.objectContaining({ type: 'success' }))
+            expect(mockOpenInSandbox).toHaveBeenCalledWith(3000, 'http', '')
+        })
+
+        it('shows error toast when port unreachable after reconnect', async () => {
+            mockIsAppMode.value = true
+            const mockOpenInSandbox = vi.fn()
+            const mockTestPortReachable = vi.fn().mockReturnValue(false)
+            const mockReconnectTunnel = vi.fn().mockReturnValue(true)
+            ;(window as any).AndroidNative = { openInSandbox: mockOpenInSandbox, testPortReachable: mockTestPortReachable, reconnectTunnel: mockReconnectTunnel }
+
+            const { usePortForward } = await import('@/composables/usePortForward')
+            const { openPort } = usePortForward()
+
+            await openPort(3000, 'http')
+
+            expect(mockOpenInSandbox).not.toHaveBeenCalled()
+            expect(mockToastShow).toHaveBeenCalledWith('portForward.portUnreachable', expect.objectContaining({ type: 'error' }))
+        })
+
+        it('shows error toast when reconnect fails', async () => {
+            mockIsAppMode.value = true
+            const mockTestPortReachable = vi.fn().mockReturnValue(false)
+            const mockReconnectTunnel = vi.fn().mockReturnValue(false)
+            ;(window as any).AndroidNative = { testPortReachable: mockTestPortReachable, reconnectTunnel: mockReconnectTunnel }
+
+            const { usePortForward } = await import('@/composables/usePortForward')
+            const { openPort } = usePortForward()
+
+            await openPort(3000, 'http')
+
+            expect(mockToastShow).toHaveBeenCalledWith('portForward.portUnreachable', expect.objectContaining({ type: 'error' }))
+        })
+
+        it('falls back to direct open when testPortReachable not available (old APK)', async () => {
             mockIsAppMode.value = true
             const mockOpenInSandbox = vi.fn()
             ;(window as any).AndroidNative = { openInSandbox: mockOpenInSandbox }
@@ -231,41 +301,113 @@ describe('usePortForward', () => {
             const { usePortForward } = await import('@/composables/usePortForward')
             const { openPort } = usePortForward()
 
-            openPort(3000, 'http')
+            await openPort(3000, 'http')
 
             expect(mockOpenInSandbox).toHaveBeenCalledWith(3000, 'http', '')
-
-            delete (window as any).AndroidNative
         })
 
         it('passes host parameter to native sandbox browser', async () => {
             mockIsAppMode.value = true
             const mockOpenInSandbox = vi.fn()
-            ;(window as any).AndroidNative = { openInSandbox: mockOpenInSandbox }
+            const mockTestPortReachable = vi.fn().mockReturnValue(true)
+            ;(window as any).AndroidNative = { openInSandbox: mockOpenInSandbox, testPortReachable: mockTestPortReachable }
 
             const { usePortForward } = await import('@/composables/usePortForward')
             const { openPort } = usePortForward()
 
-            openPort(3000, 'http', '192.168.1.1')
+            await openPort(3000, 'http', '192.168.1.1')
 
             expect(mockOpenInSandbox).toHaveBeenCalledWith(3000, 'http', '192.168.1.1')
-
-            delete (window as any).AndroidNative
         })
 
         it('falls back to openInBrowser when sandbox not available', async () => {
             mockIsAppMode.value = true
             const mockOpenInBrowser = vi.fn()
-            ;(window as any).AndroidNative = { openInBrowser: mockOpenInBrowser }
+            const mockTestPortReachable = vi.fn().mockReturnValue(true)
+            ;(window as any).AndroidNative = { openInBrowser: mockOpenInBrowser, testPortReachable: mockTestPortReachable }
 
             const { usePortForward } = await import('@/composables/usePortForward')
             const { openPort } = usePortForward()
 
-            openPort(3000, 'https')
+            await openPort(3000, 'https')
 
             expect(mockOpenInBrowser).toHaveBeenCalledWith(3000, 'https', '')
+        })
+    })
 
-            delete (window as any).AndroidNative
+    describe('reconnectPort', () => {
+        it('shows success toast and refreshes when port is already reachable', async () => {
+            mockIsAppMode.value = true
+            const mockTestPortReachable = vi.fn().mockReturnValue(true)
+            mockApiGet.mockResolvedValue({ ports: [] })
+            ;(window as any).AndroidNative = { testPortReachable: mockTestPortReachable }
+
+            const { usePortForward } = await import('@/composables/usePortForward')
+            const { reconnectPort } = usePortForward()
+
+            await reconnectPort(3000)
+
+            expect(mockTestPortReachable).toHaveBeenCalledWith(3000)
+            expect(mockToastShow).toHaveBeenCalledWith('portForward.tunnelReconnected', expect.objectContaining({ type: 'success' }))
+        })
+
+        it('reconnects and shows success toast when port becomes reachable', async () => {
+            mockIsAppMode.value = true
+            // First testPortReachable returns false (before reconnect), second returns true (after)
+            const mockTestPortReachable = vi.fn().mockReturnValueOnce(false).mockReturnValueOnce(true)
+            const mockReconnectTunnel = vi.fn().mockReturnValue(true)
+            mockApiGet.mockResolvedValue({ ports: [] })
+            ;(window as any).AndroidNative = { testPortReachable: mockTestPortReachable, reconnectTunnel: mockReconnectTunnel }
+
+            const { usePortForward } = await import('@/composables/usePortForward')
+            const { reconnectPort } = usePortForward()
+
+            await reconnectPort(3000)
+
+            expect(mockReconnectTunnel).toHaveBeenCalled()
+            expect(mockToastShow).toHaveBeenCalledWith('portForward.tunnelReconnected', expect.objectContaining({ type: 'success' }))
+        })
+
+        it('shows error toast when port still unreachable after reconnect', async () => {
+            mockIsAppMode.value = true
+            const mockTestPortReachable = vi.fn().mockReturnValue(false)
+            const mockReconnectTunnel = vi.fn().mockReturnValue(true)
+            mockApiGet.mockResolvedValue({ ports: [] })
+            ;(window as any).AndroidNative = { testPortReachable: mockTestPortReachable, reconnectTunnel: mockReconnectTunnel }
+
+            const { usePortForward } = await import('@/composables/usePortForward')
+            const { reconnectPort } = usePortForward()
+
+            await reconnectPort(3000)
+
+            expect(mockToastShow).toHaveBeenCalledWith('portForward.portUnreachable', expect.objectContaining({ type: 'error' }))
+        })
+
+        it('shows error toast when reconnect fails', async () => {
+            mockIsAppMode.value = true
+            const mockTestPortReachable = vi.fn().mockReturnValue(false)
+            const mockReconnectTunnel = vi.fn().mockReturnValue(false)
+            mockApiGet.mockResolvedValue({ ports: [] })
+            ;(window as any).AndroidNative = { testPortReachable: mockTestPortReachable, reconnectTunnel: mockReconnectTunnel }
+
+            const { usePortForward } = await import('@/composables/usePortForward')
+            const { reconnectPort } = usePortForward()
+
+            await reconnectPort(3000)
+
+            expect(mockToastShow).toHaveBeenCalledWith('portForward.portUnreachable', expect.objectContaining({ type: 'error' }))
+        })
+
+        it('refreshes port list even without native bridge (web mode)', async () => {
+            mockIsAppMode.value = false
+            mockApiGet.mockResolvedValue({ ports: [] })
+
+            const { usePortForward } = await import('@/composables/usePortForward')
+            const { reconnectPort } = usePortForward()
+
+            await reconnectPort(3000)
+
+            expect(mockApiGet).toHaveBeenCalledWith('/api/proxy/ports')
         })
     })
 

--- a/web/src/composables/useLocalhostAnnotation.ts
+++ b/web/src/composables/useLocalhostAnnotation.ts
@@ -208,7 +208,7 @@ export function useLocalhostUrlClickHandler() {
 
         try {
             const localPort = await ensurePortRegistered(port, protocol)
-            openPort(localPort, protocol)
+            await openPort(localPort, protocol)
         } catch (err) {
             toast.show(gt('chat.localhost.openFailed'), { type: 'error' })
         } finally {

--- a/web/src/composables/usePortForward.ts
+++ b/web/src/composables/usePortForward.ts
@@ -2,6 +2,7 @@ import { ref } from 'vue'
 import { apiGet, apiPost, apiPut, apiDelete } from '@/utils/api'
 import { useAppMode } from './useAppMode.ts'
 import { gt } from '@/composables/useLocale'
+import { useToast } from '@/composables/useToast.ts'
 import { tunnelStatusFromPorts as tunnelStatusFromPortsUtil, buildPortUrl } from '@/utils/portForwardUtils.ts'
 
 interface ForwardedPort {
@@ -339,21 +340,106 @@ export function usePortForward() {
     }
   }
 
-  /** Open a forwarded port — in app mode opens sandbox browser, otherwise window.open */
-  function openPort(localPort: number, protocol?: string, host?: string) {
+  /** Internal helper: actually open the port in sandbox or external browser */
+  function doOpen(native: any, localPort: number, protocol?: string, hostArg?: string) {
+    if (native?.openInSandbox) {
+      native.openInSandbox(localPort, protocol === 'https' ? 'https' : 'http', hostArg || '')
+    } else if (native?.openInBrowser) {
+      native.openInBrowser(localPort, protocol === 'https' ? 'https' : 'http', hostArg || '')
+    }
+  }
+
+  /** Open a forwarded port — in app mode opens sandbox browser, otherwise window.open.
+   *  In app mode: first tests if the port is reachable, auto-reconnects SSH tunnel if not.
+   *  Shows toast on success or failure after reconnection attempt. */
+  async function openPort(localPort: number, protocol?: string, host?: string) {
     console.log('[PortForward] openPort: localPort=' + localPort + ', protocol=' + protocol + ', host=' + (host || ''))
+
     if (isAppMode.value) {
       const native = (window as any).AndroidNative
       const hostArg = host || ''
-      // Prefer sandbox browser (isolated process), fall back to external browser
-      if (native?.openInSandbox) {
-        native.openInSandbox(localPort, protocol === 'https' ? 'https' : 'http', hostArg)
-      } else if (native?.openInBrowser) {
-        native.openInBrowser(localPort, protocol === 'https' ? 'https' : 'http', hostArg)
+
+      // Pre-check: test if the local port is reachable
+      if (native?.testPortReachable) {
+        const reachable = native.testPortReachable(localPort)
+        if (reachable) {
+          // Port is reachable — open immediately
+          doOpen(native, localPort, protocol, hostArg)
+          return
+        }
+
+        // Port unreachable — yield UI then reconnect tunnel
+        console.log('[PortForward] openPort: port ' + localPort + ' unreachable, attempting tunnel reconnect')
+        await new Promise(r => setTimeout(r, 50))
+
+        let reconnected = false
+        if (native?.reconnectTunnel) {
+          reconnected = native.reconnectTunnel()
+        }
+
+        const toast = useToast()
+        if (reconnected) {
+          // Re-test after reconnect
+          const reachableAfter = native.testPortReachable(localPort)
+          if (reachableAfter) {
+            toast.show(gt('portForward.tunnelReconnected'), { type: 'success' })
+            doOpen(native, localPort, protocol, hostArg)
+            return
+          }
+        }
+
+        // Still unreachable after reconnect — show error
+        toast.show(gt('portForward.portUnreachable'), { type: 'error' })
+        return
       }
+
+      // Fallback: no testPortReachable available (old APK) — open directly
+      doOpen(native, localPort, protocol, hostArg)
     } else {
       window.open(buildPortUrl(localPort, protocol), '_blank')
     }
+  }
+
+  /** Reconnect a specific forwarded port: test reachability, reconnect tunnel if needed.
+   *  Used by the per-port reconnect button in the port forwarding panel.
+   *  The caller tracks which ports are reconnecting and shows a spinning icon.
+   *  Shows toast on success or failure, not during checking. */
+  async function reconnectPort(localPort: number) {
+    const native = (window as any).AndroidNative
+    const toast = useToast()
+
+    // Yield to let Vue render the spinning button before any blocking bridge calls
+    await new Promise(r => setTimeout(r, 50))
+
+    if (isAppMode.value && native?.testPortReachable) {
+      // Step 1: Test if the port is already reachable
+      const reachable = native.testPortReachable(localPort)
+      if (reachable) {
+        toast.show(gt('portForward.tunnelReconnected'), { type: 'success' })
+        await loadPorts(true)
+        return
+      }
+
+      // Step 2: Port unreachable — reconnect tunnel
+      let reconnected = false
+      if (native?.reconnectTunnel) {
+        reconnected = native.reconnectTunnel()
+      }
+
+      if (reconnected) {
+        const reachableAfter = native.testPortReachable(localPort)
+        if (reachableAfter) {
+          toast.show(gt('portForward.tunnelReconnected'), { type: 'success' })
+        } else {
+          toast.show(gt('portForward.portUnreachable'), { type: 'error' })
+        }
+      } else {
+        toast.show(gt('portForward.portUnreachable'), { type: 'error' })
+      }
+    }
+
+    // Refresh port list — spinning button stops when caller sees this resolve
+    await loadPorts(true)
   }
 
   /** Open a forwarded port in external/system browser */
@@ -408,6 +494,7 @@ export function usePortForward() {
     checkTunnelHealth,
     openPort,
     openInExternalBrowser,
+    reconnectPort,
     ensurePortRegistered,
   }
 }

--- a/web/src/i18n/locales/en.ts
+++ b/web/src/i18n/locales/en.ts
@@ -477,6 +477,7 @@ export default {
     tunnelConnectedButNoResponse: 'SSH tunnel connected, but all port services are unresponsive',
     backgroundTip: 'When using external browser, ensure background running permission is granted — otherwise the SSH tunnel will be killed when app goes to background',
     retryCheck: 'Retry',
+    reconnectPort: 'Reconnect',
     noPorts: 'No forwarded ports',
     emptyHint: 'Add a server port to access it directly from browser or other apps',
     addPort: 'Add port',
@@ -519,6 +520,8 @@ export default {
   portForward: {
     tunnelDegraded: 'SSH tunnel connected, but all forwarded ports are unresponsive',
     tunnelDisconnected: 'SSH tunnel disconnected, port forwarding unavailable',
+    tunnelReconnected: 'SSH tunnel reconnected',
+    portUnreachable: 'Port unreachable, please check if the service is running',
   },
   pwa: {
     installTitle: 'Install ClawBench',

--- a/web/src/i18n/locales/zh.ts
+++ b/web/src/i18n/locales/zh.ts
@@ -477,6 +477,7 @@ export default {
     tunnelConnectedButNoResponse: 'SSH 隧道已连接，但所有端口的服务均未响应',
     backgroundTip: '使用外部浏览器时，请确保已授予应用后台运行权限，否则 APP 进入后台后 SSH 隧道会被系统终止',
     retryCheck: '重新检测',
+    reconnectPort: '重连',
     noPorts: '暂无转发端口',
     emptyHint: '添加服务器上的端口，即可在浏览器或其他应用中直接访问',
     addPort: '添加端口',
@@ -519,6 +520,8 @@ export default {
   portForward: {
     tunnelDegraded: 'SSH 隧道已连接，但所有转发端口均无服务响应',
     tunnelDisconnected: 'SSH 隧道未连接，端口转发将无法使用',
+    tunnelReconnected: 'SSH 隧道已重连',
+    portUnreachable: '端口连接失败，请检查服务是否运行',
   },
   pwa: {
     installTitle: '安装 ClawBench',


### PR DESCRIPTION
## 问题

端口转发 UI 显示绿灯但实际访问不了。根因：
1. 后端 active 只检查服务端本地端口监听，不检查 SSH 隧道通畅
2. Android isTunnelConnected() 有 90 秒过期窗口
3. openPort() 无任何预检，直接打开

## 改动

### Android 原生桥接
- **BackgroundService.forceReconnect()**: 新增静态方法，用 CountDownLatch + AtomicBinary 在 networkExecutor 上执行 disconnectInternal() + ensureConnection()
- **MainActivity.testPortReachable()**: TCP Socket 连 127.0.0.1:port，3s 超时
- **MainActivity.reconnectTunnel()**: 调用 forceReconnect(15000)

### 前端核心逻辑
- **usePortForward.openPort()**: 改为 async，打开前先 testPortReachable，不可达则自动 reconnectTunnel 重建隧道，成功弹 toast 后打开
- **usePortForward.reconnectPort()**: 新增方法，供每个端口条目的重连按钮调用
- **usePortForward.doOpen()**: 辅助函数，实际调用原生 openInSandbox/openInBrowser

### 前端 UI
- **ProxyPortItem**: 增加 RotateCcw 重连按钮，reconnecting 时 spinning 动画
- **ProxyPanelContent**: 增加 reconnectingPorts Set 状态追踪 + handleReconnect 事件处理
- **useLocalhostAnnotation**: openPort 改为 await 以享受预检+自动重连

### 测试
- 补充 usePortForward 单元测试：openPort 预检 7 个用例 + reconnectPort 5 个用例

### i18n
- portForward.tunnelReconnected / portForward.portUnreachable
- proxy.reconnectPort