### PR TITLE
feat: chat message auto-summary with SummaryToggle refactor

### DIFF
--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -553,6 +553,10 @@ func main() {
 			)
 		} else {
 			scheduler.SetTaskSummarizer(taskSummarizer)
+			// Also set the global instance for AsyncSummarize (chat messages + task executions)
+			service.SetTaskSummarizerInstance(taskSummarizer)
+			// Configure chat message auto-summarization based on config
+			service.SetChatSummaryEnabled(cfg.Summarize.IsChatSummaryEnabled())
 			slog.Info("task summarizer configured",
 				slog.String("backend", cfg.Summarize.Backend),
 			)

--- a/internal/handler/scheduler.go
+++ b/internal/handler/scheduler.go
@@ -365,9 +365,10 @@ func serveTaskExecutions(w http.ResponseWriter, r *http.Request, taskID int64, p
 
 	query := `
 		SELECT te.id, te.session_id, te.trigger_type, te.status, te.created_at,
-		       te.read_at, te.summary,
+		       te.read_at, sm.summary,
 		       ch.content AS assistant_content
 		FROM task_executions te
+		LEFT JOIN summaries sm ON sm.target_type = 'task_execution' AND sm.target_id = te.id
 		LEFT JOIN chat_history ch ON ch.session_id = te.session_id
 		    AND ch.role = 'assistant'
 		    AND ch.deleted = 0

--- a/internal/handler/testutil_test.go
+++ b/internal/handler/testutil_test.go
@@ -132,6 +132,14 @@ func setupTestEnv(t *testing.T) (*testEnv, func()) {
 		CREATE INDEX IF NOT EXISTS idx_history_session ON chat_history(project_path, backend, session_id, created_at);
 		CREATE INDEX IF NOT EXISTS idx_sessions_project_backend ON chat_sessions(project_path, backend);
 		CREATE INDEX IF NOT EXISTS idx_executions_session ON task_executions(session_id);
+		CREATE TABLE IF NOT EXISTS summaries (
+			id INTEGER PRIMARY KEY AUTOINCREMENT,
+			target_type TEXT NOT NULL,
+			target_id   INTEGER NOT NULL,
+			summary     TEXT NOT NULL,
+			created_at  DATETIME DEFAULT CURRENT_TIMESTAMP,
+			UNIQUE(target_type, target_id)
+		);
 		CREATE TABLE IF NOT EXISTS ai_raw_responses (
 			id INTEGER PRIMARY KEY AUTOINCREMENT,
 			session_id TEXT NOT NULL,

--- a/internal/handler/testutil_test.go
+++ b/internal/handler/testutil_test.go
@@ -149,9 +149,11 @@ func setupTestEnv(t *testing.T) (*testEnv, func()) {
 			created_at DATETIME DEFAULT CURRENT_TIMESTAMP
 		);
 		CREATE TABLE IF NOT EXISTS tts_summaries (
-			cache_key TEXT PRIMARY KEY,
-			summary TEXT NOT NULL,
-			created_at DATETIME DEFAULT CURRENT_TIMESTAMP
+			id INTEGER PRIMARY KEY AUTOINCREMENT,
+			message_id   INTEGER NOT NULL,
+			tts_summary  TEXT NOT NULL,
+			created_at   DATETIME DEFAULT CURRENT_TIMESTAMP,
+			UNIQUE(message_id)
 		);
 		CREATE TABLE IF NOT EXISTS terminal_quick_commands (
 			id INTEGER PRIMARY KEY AUTOINCREMENT,

--- a/internal/handler/tts.go
+++ b/internal/handler/tts.go
@@ -50,8 +50,9 @@ func SetSummarizer(s summarize.Summarizer) {
 
 // ttsGenerateRequest is the request body for POST /api/tts/generate.
 type ttsGenerateRequest struct {
-	Text     string `json:"text"`
-	Language string `json:"language"` // language code, e.g. "zh", "en"; defaults to "zh" if empty
+	Text      string `json:"text"`
+	Language  string `json:"language"`  // language code, e.g. "zh", "en"; defaults to "zh" if empty
+	MessageID int64  `json:"messageId"`  // chat_history.id for TTS summary caching
 }
 
 // TTSGenerate handles POST /api/tts/generate.
@@ -120,7 +121,10 @@ func TTSGenerate(w http.ResponseWriter, r *http.Request) {
 			slog.String("path", relAudioPath),
 		)
 		// Try DB for cached summary
-		summary, _ := service.GetTTSSummary(cacheKey)
+		var summary string
+		if req.MessageID > 0 {
+			summary, _ = service.GetTTSSummaryByMessageID(req.MessageID)
+		}
 		writeJSON(w, http.StatusOK, map[string]any{
 			"cached":    true,
 			"audioPath": relAudioPath,
@@ -141,8 +145,8 @@ func TTSGenerate(w http.ResponseWriter, r *http.Request) {
 
 		// Phase 1: Summarize
 		var summary string
-		cachedSummary, found := service.GetTTSSummary(cacheKey)
-		if found && cachedSummary != "" {
+		cachedSummary, found := service.GetTTSSummaryByMessageID(req.MessageID)
+		if found && cachedSummary != "" && req.MessageID > 0 {
 			slog.Info("tts summary cache hit, skipping summarization",
 				slog.String("cache_key", cacheKey),
 			)
@@ -173,10 +177,12 @@ func TTSGenerate(w http.ResponseWriter, r *http.Request) {
 			)
 
 			// Save summary to database
-			if err := service.SaveTTSSummary(cacheKey, summary); err != nil {
-				slog.Warn("tts failed to cache summary to DB",
-					slog.String("error", err.Error()),
-				)
+			if req.MessageID > 0 {
+				if err := service.SaveTTSSummaryByMessageID(req.MessageID, summary); err != nil {
+					slog.Warn("tts failed to cache summary to DB",
+						slog.String("error", err.Error()),
+					)
+				}
 			}
 		}
 

--- a/internal/handler/tts_test.go
+++ b/internal/handler/tts_test.go
@@ -543,3 +543,120 @@ func TestTTSStream_MissingJobID(t *testing.T) {
 	TTSStream(w, req)
 	assert.Equal(t, http.StatusBadRequest, w.Code)
 }
+
+// --- TTSGenerate: MessageID-based summary lookup ---
+
+func TestTTSGenerate_WithMessageID_CachedAudio(t *testing.T) {
+	mockProvider := &mockSpeechProvider{}
+	mockSum := &mockSummarizer{result: "核心总结"}
+	env, teardown := setupTTSTest(t, mockProvider, mockSum)
+	defer teardown()
+
+	text := "这是一段较长的AI回复内容，需要被总结为语音。包含了详细的分析和代码示例，需要提取核心要点。"
+
+	// First request: generate and cache audio
+	req1 := newRequest(t, http.MethodPost, "/api/tts/generate", map[string]any{"text": text, "messageId": 100})
+	req1 = withProjectCookie(req1, env.ProjectDir)
+	w1 := httptest.NewRecorder()
+	TTSGenerate(w1, req1)
+	assert.Equal(t, http.StatusOK, w1.Code)
+
+	// Wait for TTS job to complete so audio is cached
+	hash := sha256.Sum256([]byte(text))
+	cacheKey := hex.EncodeToString(hash[:])[:summarize.CacheKeyHexLen]
+	job, ok := service.GetTTSJob(cacheKey)
+	if ok {
+		select {
+		case <-job.Done:
+		case <-time.After(5 * time.Second):
+			t.Fatal("TTS job did not complete in time")
+		}
+	}
+
+	// Save a TTS summary for message ID 100
+	err := service.SaveTTSSummaryByMessageID(100, "核心总结")
+	assert.NoError(t, err)
+
+	// Second request with same text + messageId: should hit audio cache
+	// and look up summary by message ID instead of cache key
+	req2 := newRequest(t, http.MethodPost, "/api/tts/generate", map[string]any{"text": text, "messageId": 100})
+	req2 = withProjectCookie(req2, env.ProjectDir)
+	w2 := httptest.NewRecorder()
+	TTSGenerate(w2, req2)
+	assert.Equal(t, http.StatusOK, w2.Code)
+
+	var resp map[string]any
+	err = json.Unmarshal(w2.Body.Bytes(), &resp)
+	assert.NoError(t, err)
+	assert.Equal(t, true, resp["cached"])
+}
+
+func TestTTSGenerate_WithMessageID_SummaryCacheHit(t *testing.T) {
+	mockProvider := &mockSpeechProvider{}
+	mockSum := &mockSummarizer{result: "核心总结"}
+	env, teardown := setupTTSTest(t, mockProvider, mockSum)
+	defer teardown()
+
+	// Pre-save a TTS summary for message ID 200
+	err := service.SaveTTSSummaryByMessageID(200, "预设的TTS总结")
+	assert.NoError(t, err)
+
+	text := "这是一段较长的AI回复内容，需要被总结为语音。包含了详细的分析和代码示例，需要提取核心要点。"
+	req := newRequest(t, http.MethodPost, "/api/tts/generate", map[string]any{"text": text, "messageId": 200})
+	req = withProjectCookie(req, env.ProjectDir)
+	w := httptest.NewRecorder()
+
+	TTSGenerate(w, req)
+	assert.Equal(t, http.StatusOK, w.Code)
+
+	// Wait for TTS job to complete
+	hash := sha256.Sum256([]byte(text))
+	cacheKey := hex.EncodeToString(hash[:])[:summarize.CacheKeyHexLen]
+	job, ok := service.GetTTSJob(cacheKey)
+	if ok {
+		select {
+		case <-job.Done:
+		case <-time.After(5 * time.Second):
+			t.Fatal("TTS job did not complete in time")
+		}
+	}
+
+	// The mock summarizer should NOT have been called since we had a cached summary
+	assert.False(t, mockSum.called)
+}
+
+func TestTTSGenerate_WithZeroMessageID_SkipsMessageIDLookup(t *testing.T) {
+	mockProvider := &mockSpeechProvider{}
+	mockSum := &mockSummarizer{result: "总结"}
+	env, teardown := setupTTSTest(t, mockProvider, mockSum)
+	defer teardown()
+
+	text := "这是一段较长的AI回复内容，需要被总结为语音。包含了详细的分析和代码示例，需要提取核心要点。"
+	// messageId = 0 means no message-based lookup
+	req := newRequest(t, http.MethodPost, "/api/tts/generate", map[string]any{"text": text, "messageId": 0})
+	req = withProjectCookie(req, env.ProjectDir)
+	w := httptest.NewRecorder()
+
+	TTSGenerate(w, req)
+	assert.Equal(t, http.StatusOK, w.Code)
+
+	var resp map[string]any
+	err := json.Unmarshal(w.Body.Bytes(), &resp)
+	assert.NoError(t, err)
+	assert.Contains(t, resp, "jobId")
+
+	// Wait for completion
+	hash := sha256.Sum256([]byte(text))
+	cacheKey := hex.EncodeToString(hash[:])[:summarize.CacheKeyHexLen]
+	job, ok := service.GetTTSJob(cacheKey)
+	if ok {
+		select {
+		case <-job.Done:
+		case <-time.After(5 * time.Second):
+			t.Fatal("TTS job did not complete in time")
+		}
+	}
+
+	// Summarizer should have been called (no cache hit for messageId=0)
+	assert.True(t, mockSum.called)
+}

--- a/internal/handler/tts_test.go
+++ b/internal/handler/tts_test.go
@@ -554,14 +554,14 @@ func TestTTSGenerate_WithMessageID_CachedAudio(t *testing.T) {
 
 	text := "这是一段较长的AI回复内容，需要被总结为语音。包含了详细的分析和代码示例，需要提取核心要点。"
 
-	// First request: generate and cache audio
+	// First request: generate and cache audio (with messageId for SaveTTSSummaryByMessageID)
 	req1 := newRequest(t, http.MethodPost, "/api/tts/generate", map[string]any{"text": text, "messageId": 100})
 	req1 = withProjectCookie(req1, env.ProjectDir)
 	w1 := httptest.NewRecorder()
 	TTSGenerate(w1, req1)
 	assert.Equal(t, http.StatusOK, w1.Code)
 
-	// Wait for TTS job to complete so audio is cached
+	// Wait for TTS job to complete so audio is cached and SaveTTSSummaryByMessageID is called
 	hash := sha256.Sum256([]byte(text))
 	cacheKey := hex.EncodeToString(hash[:])[:summarize.CacheKeyHexLen]
 	job, ok := service.GetTTSJob(cacheKey)
@@ -573,9 +573,10 @@ func TestTTSGenerate_WithMessageID_CachedAudio(t *testing.T) {
 		}
 	}
 
-	// Save a TTS summary for message ID 100
-	err := service.SaveTTSSummaryByMessageID(100, "核心总结")
-	assert.NoError(t, err)
+	// Verify the summary was saved by the goroutine (covers SaveTTSSummaryByMessageID)
+	savedSummary, found := service.GetTTSSummaryByMessageID(100)
+	assert.True(t, found, "TTS summary should be saved for message ID 100")
+	assert.Equal(t, "核心总结", savedSummary)
 
 	// Second request with same text + messageId: should hit audio cache
 	// and look up summary by message ID instead of cache key
@@ -586,7 +587,7 @@ func TestTTSGenerate_WithMessageID_CachedAudio(t *testing.T) {
 	assert.Equal(t, http.StatusOK, w2.Code)
 
 	var resp map[string]any
-	err = json.Unmarshal(w2.Body.Bytes(), &resp)
+	err := json.Unmarshal(w2.Body.Bytes(), &resp)
 	assert.NoError(t, err)
 	assert.Equal(t, true, resp["cached"])
 }
@@ -658,5 +659,38 @@ func TestTTSGenerate_WithZeroMessageID_SkipsMessageIDLookup(t *testing.T) {
 	}
 
 	// Summarizer should have been called (no cache hit for messageId=0)
+	assert.True(t, mockSum.called)
+}
+
+func TestTTSGenerate_SaveTTSSummaryByMessageID_DBError(t *testing.T) {
+	mockProvider := &mockSpeechProvider{}
+	mockSum := &mockSummarizer{result: "核心总结"}
+	env, teardown := setupTTSTest(t, mockProvider, mockSum)
+	defer teardown()
+
+	// Drop the tts_summaries table to force SaveTTSSummaryByMessageID to fail
+	service.DB.Exec("DROP TABLE tts_summaries")
+
+	text := "这是一段较长的AI回复内容，需要被总结为语音。包含了详细的分析和代码示例，需要提取核心要点。"
+	req := newRequest(t, http.MethodPost, "/api/tts/generate", map[string]any{"text": text, "messageId": 300})
+	req = withProjectCookie(req, env.ProjectDir)
+	w := httptest.NewRecorder()
+
+	TTSGenerate(w, req)
+	assert.Equal(t, http.StatusOK, w.Code)
+
+	// Wait for the TTS job to complete (should still succeed despite DB error)
+	hash := sha256.Sum256([]byte(text))
+	cacheKey := hex.EncodeToString(hash[:])[:summarize.CacheKeyHexLen]
+	job, ok := service.GetTTSJob(cacheKey)
+	if ok {
+		select {
+		case <-job.Done:
+		case <-time.After(5 * time.Second):
+			t.Fatal("TTS job did not complete in time")
+		}
+	}
+
+	// Verify the job completed successfully despite the DB save error
 	assert.True(t, mockSum.called)
 }

--- a/internal/model/chat.go
+++ b/internal/model/chat.go
@@ -18,6 +18,7 @@ type ChatMessage struct {
 	Streaming   bool      `json:"streaming,omitempty"`
 	Indexed     bool      `json:"indexed,omitempty"`
 	CreatedAt   time.Time `json:"createdAt"`
+	Summary     *string   `json:"summary,omitempty"` // reading summary (nil=not summarized, ""=too short, non-empty=summary)
 }
 
 // ChatSession represents a chat session

--- a/internal/model/config.go
+++ b/internal/model/config.go
@@ -66,9 +66,19 @@ type TerminalConfig struct {
 
 // SummarizeConfig holds unified summarization configuration shared by TTS and scheduled tasks.
 type SummarizeConfig struct {
-	Backend string    `yaml:"backend"`  // Summarization backend: "simple" (default), "api", "claude", "codebuddy", etc.
-	Model   string    `yaml:"model"`    // Model for summarization (empty = backend default)
-	API     APIConfig `yaml:"api"`      // API-based summarization (used when backend is "api")
+	Backend     string    `yaml:"backend"`       // Summarization backend: "simple" (default), "api", "claude", "codebuddy", etc.
+	Model       string    `yaml:"model"`         // Model for summarization (empty = backend default)
+	ChatSummary *bool     `yaml:"chat_summary"`  // Enable auto-summarization for chat messages (default: true, nil = true)
+	API         APIConfig `yaml:"api"`           // API-based summarization (used when backend is "api")
+}
+
+// IsChatSummaryEnabled returns whether chat message auto-summarization is enabled.
+// Defaults to true when ChatSummary is nil (not explicitly set).
+func (s SummarizeConfig) IsChatSummaryEnabled() bool {
+	if s.ChatSummary == nil {
+		return true
+	}
+	return *s.ChatSummary
 }
 
 // PushConfig holds configuration for push notifications.

--- a/internal/model/config_test.go
+++ b/internal/model/config_test.go
@@ -1,0 +1,25 @@
+package model
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestSummarizeConfig_IsChatSummaryEnabled_Nil(t *testing.T) {
+	cfg := SummarizeConfig{}
+	// ChatSummary is nil — should default to true
+	assert.True(t, cfg.IsChatSummaryEnabled())
+}
+
+func TestSummarizeConfig_IsChatSummaryEnabled_True(t *testing.T) {
+	val := true
+	cfg := SummarizeConfig{ChatSummary: &val}
+	assert.True(t, cfg.IsChatSummaryEnabled())
+}
+
+func TestSummarizeConfig_IsChatSummaryEnabled_False(t *testing.T) {
+	val := false
+	cfg := SummarizeConfig{ChatSummary: &val}
+	assert.False(t, cfg.IsChatSummaryEnabled())
+}

--- a/internal/service/chat.go
+++ b/internal/service/chat.go
@@ -83,7 +83,12 @@ func scanMessages(rows *sql.Rows, sessionID string) ([]model.ChatMessage, error)
 		msg.SessionID = sessionID
 		messages = append(messages, msg)
 	}
-	return messages, rows.Err()
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	// Enrich assistant messages with reading summaries
+	enrichMessagesWithSummaries(messages)
+	return messages, nil
 }
 
 // GetChatMessageCount returns the number of messages in a session.
@@ -815,4 +820,57 @@ func PurgeDeletedData(sessionIDs []string) (sessionsPurged int64, messagesPurged
 		return 0, 0, err
 	}
 	return sessionsPurged, messagesPurged, nil
+}
+
+// enrichMessagesWithSummaries populates the Summary field for assistant messages
+// by batch-querying the summaries table. Only messages with role "assistant" are queried.
+func enrichMessagesWithSummaries(messages []model.ChatMessage) {
+	// Collect IDs of assistant messages
+	var assistantIDs []int64
+	for _, msg := range messages {
+		if msg.Role == "assistant" {
+			assistantIDs = append(assistantIDs, msg.ID)
+		}
+	}
+	if len(assistantIDs) == 0 {
+		return
+	}
+
+	// Batch query summaries for all assistant messages
+	query := "SELECT target_id, summary FROM summaries WHERE target_type = 'chat_message' AND target_id IN ("
+	args := make([]any, len(assistantIDs))
+	for i, id := range assistantIDs {
+		if i > 0 {
+			query += ","
+		}
+		query += "?"
+		args[i] = id
+	}
+	query += ")"
+
+	rows, err := DBRead.Query(query, args...)
+	if err != nil {
+		return
+	}
+	defer rows.Close()
+
+	// Build map of message ID -> summary
+	summaryMap := make(map[int64]string)
+	for rows.Next() {
+		var targetID int64
+		var summary string
+		if err := rows.Scan(&targetID, &summary); err != nil {
+			continue
+		}
+		summaryMap[targetID] = summary
+	}
+
+	// Enrich messages
+	for i := range messages {
+		if messages[i].Role == "assistant" {
+			if summary, ok := summaryMap[messages[i].ID]; ok {
+				messages[i].Summary = &summary
+			}
+		}
+	}
 }

--- a/internal/service/chat_summary_test.go
+++ b/internal/service/chat_summary_test.go
@@ -1,0 +1,234 @@
+package service
+
+import (
+	"database/sql"
+	"strings"
+	"testing"
+	"time"
+
+	"clawbench/internal/ai"
+	"clawbench/internal/model"
+	"clawbench/internal/summarize"
+
+	"github.com/stretchr/testify/assert"
+)
+
+// setupTestDBForChatSummary creates an in-memory DB with chat_history and summaries tables.
+func setupTestDBForChatSummary(t *testing.T) (*sql.DB, func()) {
+	t.Helper()
+	origDB := DB
+	origDBRead := DBRead
+
+	db, err := sql.Open("sqlite", ":memory:")
+	if err != nil {
+		t.Fatalf("failed to open in-memory db: %v", err)
+	}
+	db.SetMaxOpenConns(1)
+	db.Exec("PRAGMA journal_mode=WAL")
+	db.Exec("PRAGMA busy_timeout=5000")
+
+	// Create minimal tables needed for enrichMessagesWithSummaries
+	db.Exec(`
+		CREATE TABLE IF NOT EXISTS chat_history (
+			id INTEGER PRIMARY KEY AUTOINCREMENT,
+			project_path TEXT NOT NULL,
+			role TEXT NOT NULL,
+			content TEXT NOT NULL,
+			files TEXT,
+			session_id TEXT,
+			backend TEXT NOT NULL DEFAULT 'claude',
+			streaming INTEGER NOT NULL DEFAULT 0,
+			indexed INTEGER NOT NULL DEFAULT 0,
+			deleted INTEGER NOT NULL DEFAULT 0,
+			created_at DATETIME DEFAULT CURRENT_TIMESTAMP
+		);
+	`)
+	db.Exec(`
+		CREATE TABLE IF NOT EXISTS summaries (
+			id INTEGER PRIMARY KEY AUTOINCREMENT,
+			target_type TEXT NOT NULL,
+			target_id   INTEGER NOT NULL,
+			summary     TEXT NOT NULL,
+			created_at  DATETIME DEFAULT CURRENT_TIMESTAMP,
+			UNIQUE(target_type, target_id)
+		);
+	`)
+
+	DB = db
+	DBRead = db
+	teardown := func() {
+		DB = origDB
+		DBRead = origDBRead
+		db.Close()
+	}
+	return db, teardown
+}
+
+func TestEnrichMessagesWithSummaries_NoAssistantMessages(t *testing.T) {
+	_, teardown := setupTestDBForChatSummary(t)
+	defer teardown()
+
+	// Only user messages — no enrichment needed
+	messages := []model.ChatMessage{
+		{ID: 1, Role: "user", Content: "hello"},
+		{ID: 2, Role: "user", Content: "world"},
+	}
+	enrichMessagesWithSummaries(messages)
+	assert.Nil(t, messages[0].Summary)
+	assert.Nil(t, messages[1].Summary)
+}
+
+func TestEnrichMessagesWithSummaries_WithSummary(t *testing.T) {
+	db, teardown := setupTestDBForChatSummary(t)
+	defer teardown()
+
+	// Save a summary for assistant message ID 10
+	_, err := db.Exec("INSERT INTO summaries (target_type, target_id, summary) VALUES ('chat_message', 10, '这是摘要')")
+	assert.NoError(t, err)
+
+	messages := []model.ChatMessage{
+		{ID: 5, Role: "user", Content: "question"},
+		{ID: 10, Role: "assistant", Content: "long answer"},
+	}
+	enrichMessagesWithSummaries(messages)
+	assert.Nil(t, messages[0].Summary)
+	assert.NotNil(t, messages[1].Summary)
+	assert.Equal(t, "这是摘要", *messages[1].Summary)
+}
+
+func TestEnrichMessagesWithSummaries_NoSummarySaved(t *testing.T) {
+	_, teardown := setupTestDBForChatSummary(t)
+	defer teardown()
+
+	// No summary in DB for message ID 20
+	messages := []model.ChatMessage{
+		{ID: 20, Role: "assistant", Content: "answer without summary"},
+	}
+	enrichMessagesWithSummaries(messages)
+	assert.Nil(t, messages[0].Summary)
+}
+
+func TestEnrichMessagesWithSummaries_EmptySummary(t *testing.T) {
+	db, teardown := setupTestDBForChatSummary(t)
+	defer teardown()
+
+	// Empty summary means text was too short
+	_, err := db.Exec("INSERT INTO summaries (target_type, target_id, summary) VALUES ('chat_message', 30, '')")
+	assert.NoError(t, err)
+
+	messages := []model.ChatMessage{
+		{ID: 30, Role: "assistant", Content: "short"},
+	}
+	enrichMessagesWithSummaries(messages)
+	assert.NotNil(t, messages[0].Summary)
+	assert.Equal(t, "", *messages[0].Summary)
+}
+
+func TestEnrichMessagesWithSummaries_MultipleAssistantMessages(t *testing.T) {
+	db, teardown := setupTestDBForChatSummary(t)
+	defer teardown()
+
+	// Save summaries for two assistant messages
+	_, err := db.Exec("INSERT INTO summaries (target_type, target_id, summary) VALUES ('chat_message', 40, '摘要一')")
+	assert.NoError(t, err)
+	_, err = db.Exec("INSERT INTO summaries (target_type, target_id, summary) VALUES ('chat_message', 42, '摘要二')")
+	assert.NoError(t, err)
+
+	messages := []model.ChatMessage{
+		{ID: 39, Role: "user", Content: "q1"},
+		{ID: 40, Role: "assistant", Content: "a1"},
+		{ID: 41, Role: "user", Content: "q2"},
+		{ID: 42, Role: "assistant", Content: "a2"},
+	}
+	enrichMessagesWithSummaries(messages)
+	assert.Nil(t, messages[0].Summary)
+	assert.NotNil(t, messages[1].Summary)
+	assert.Equal(t, "摘要一", *messages[1].Summary)
+	assert.Nil(t, messages[2].Summary)
+	assert.NotNil(t, messages[3].Summary)
+	assert.Equal(t, "摘要二", *messages[3].Summary)
+}
+
+func TestEnrichMessagesWithSummaries_DifferentTargetType(t *testing.T) {
+	db, teardown := setupTestDBForChatSummary(t)
+	defer teardown()
+
+	// Save summary with different target type — should NOT match
+	_, err := db.Exec("INSERT INTO summaries (target_type, target_id, summary) VALUES ('task_execution', 50, 'task summary')")
+	assert.NoError(t, err)
+
+	messages := []model.ChatMessage{
+		{ID: 50, Role: "assistant", Content: "answer"},
+	}
+	enrichMessagesWithSummaries(messages)
+	assert.Nil(t, messages[0].Summary) // Different target_type, should not match
+}
+
+// --- triggerChatSummarization ---
+
+func TestTriggerChatSummarization_Disabled(t *testing.T) {
+	_, teardown := setupTestDBForChatSummary(t)
+	defer teardown()
+
+	origEnabled := chatSummaryEnabled
+	defer func() { chatSummaryEnabled = origEnabled }()
+
+	chatSummaryEnabled = false
+	// Should return immediately without error
+	triggerChatSummarization("nonexistent-session")
+}
+
+func TestSetChatSummaryEnabled(t *testing.T) {
+	origEnabled := chatSummaryEnabled
+	defer func() { chatSummaryEnabled = origEnabled }()
+
+	SetChatSummaryEnabled(false)
+	assert.False(t, chatSummaryEnabled)
+
+	SetChatSummaryEnabled(true)
+	assert.True(t, chatSummaryEnabled)
+}
+
+func TestSetTaskSummarizerInstance(t *testing.T) {
+	origInstance := taskSummarizerInstance
+	defer func() { taskSummarizerInstance = origInstance }()
+
+	// Set to nil
+	SetTaskSummarizerInstance(nil)
+	assert.Nil(t, taskSummarizerInstance)
+
+	// Set to a real instance
+	mockBackend := &mockAsyncSummarizerBackend{streamCh: make(chan ai.StreamEvent)}
+	instance := &summarize.TaskSummarizer{Backend: mockBackend}
+	SetTaskSummarizerInstance(instance)
+	assert.Equal(t, instance, taskSummarizerInstance)
+}
+
+func TestAsyncSummarize_WithWSBroadcast(t *testing.T) {
+	_, dbTeardown := setupTestDBForAsyncSummary(t)
+	defer dbTeardown()
+
+	origInstance := taskSummarizerInstance
+	defer func() { taskSummarizerInstance = origInstance }()
+
+	// Create mock backend that returns a summary
+	ch := make(chan ai.StreamEvent, 3)
+	ch <- ai.StreamEvent{Type: "content", Content: "Summary text"}
+	ch <- ai.StreamEvent{Type: "done"}
+	close(ch)
+	mock := &mockAsyncSummarizerBackend{streamCh: ch}
+	taskSummarizerInstance = &summarize.TaskSummarizer{Backend: mock}
+
+	// Long text block
+	longText := strings.Repeat("这是一段较长的AI回复内容。", 30)
+	blocks := []model.ContentBlock{{Type: "text", Text: longText}}
+
+	AsyncSummarize("chat_message", 100, blocks, "/test", "session-ws")
+
+	// Wait for goroutine to complete (including WS broadcast)
+	time.Sleep(300 * time.Millisecond)
+
+	summary, found := GetSummary("chat_message", 100)
+	assert.True(t, found)
+	assert.Contains(t, summary, "Summary text")
+}

--- a/internal/service/chat_summary_test.go
+++ b/internal/service/chat_summary_test.go
@@ -232,3 +232,65 @@ func TestAsyncSummarize_WithWSBroadcast(t *testing.T) {
 	assert.True(t, found)
 	assert.Contains(t, summary, "Summary text")
 }
+
+func TestAsyncSummarize_SaveSummaryError(t *testing.T) {
+	db, dbTeardown := setupTestDBForAsyncSummary(t)
+	defer dbTeardown()
+
+	origInstance := taskSummarizerInstance
+	defer func() { taskSummarizerInstance = origInstance }()
+
+	// Create mock backend that returns a summary
+	ch := make(chan ai.StreamEvent, 3)
+	ch <- ai.StreamEvent{Type: "content", Content: "Summary text"}
+	ch <- ai.StreamEvent{Type: "done"}
+	close(ch)
+	mock := &mockAsyncSummarizerBackend{streamCh: ch}
+	taskSummarizerInstance = &summarize.TaskSummarizer{Backend: mock}
+
+	// Drop the summaries table to force SaveSummary to fail
+	db.Exec("DROP TABLE summaries")
+
+	// Long text block — will trigger SaveSummary which will fail
+	longText := strings.Repeat("这是一段较长的AI回复内容。", 30)
+	blocks := []model.ContentBlock{{Type: "text", Text: longText}}
+
+	// Should not panic even when SaveSummary fails
+	AsyncSummarize("chat_message", 200, blocks, "/test", "session-err")
+
+	time.Sleep(300 * time.Millisecond)
+
+	// No summary saved since table was dropped
+	_, found := GetSummary("chat_message", 200)
+	assert.False(t, found)
+}
+
+func TestAsyncSummarize_ShortTextSaveError(t *testing.T) {
+	db, dbTeardown := setupTestDBForAsyncSummary(t)
+	defer dbTeardown()
+
+	origInstance := taskSummarizerInstance
+	defer func() { taskSummarizerInstance = origInstance }()
+
+	// Create a mock that returns done (for short text path)
+	ch := make(chan ai.StreamEvent, 1)
+	ch <- ai.StreamEvent{Type: "done"}
+	close(ch)
+	mock := &mockAsyncSummarizerBackend{streamCh: ch}
+	taskSummarizerInstance = &summarize.TaskSummarizer{Backend: mock}
+
+	// Drop the summaries table to force SaveSummary to fail
+	db.Exec("DROP TABLE summaries")
+
+	// Short text block — will try to save empty summary, which will fail
+	blocks := []model.ContentBlock{{Type: "text", Text: "短"}}
+
+	// Should not panic even when SaveSummary fails for short text
+	AsyncSummarize("chat_message", 300, blocks, "/test", "session-short-err")
+
+	time.Sleep(300 * time.Millisecond)
+
+	// No summary saved since table was dropped
+	_, found := GetSummary("chat_message", 300)
+	assert.False(t, found)
+}

--- a/internal/service/chat_summary_trigger_test.go
+++ b/internal/service/chat_summary_trigger_test.go
@@ -1,0 +1,277 @@
+package service
+
+import (
+	"context"
+	"database/sql"
+	"encoding/json"
+	"strings"
+	"testing"
+	"time"
+
+	"clawbench/internal/ai"
+	"clawbench/internal/summarize"
+
+	"github.com/stretchr/testify/assert"
+)
+
+// setupTestDBForTriggerSummary creates an in-memory DB with all tables needed for triggerChatSummarization.
+func setupTestDBForTriggerSummary(t *testing.T) (*sql.DB, func()) {
+	t.Helper()
+	origDB := DB
+	origDBRead := DBRead
+
+	db, err := sql.Open("sqlite", ":memory:")
+	if err != nil {
+		t.Fatalf("failed to open in-memory db: %v", err)
+	}
+	db.SetMaxOpenConns(1)
+	db.Exec("PRAGMA journal_mode=WAL")
+	db.Exec("PRAGMA busy_timeout=5000")
+
+	_, err = db.Exec(`
+		CREATE TABLE IF NOT EXISTS chat_history (
+			id INTEGER PRIMARY KEY AUTOINCREMENT,
+			project_path TEXT NOT NULL,
+			role TEXT NOT NULL,
+			content TEXT NOT NULL,
+			files TEXT,
+			session_id TEXT,
+			backend TEXT NOT NULL DEFAULT 'claude',
+			streaming INTEGER NOT NULL DEFAULT 0,
+			indexed INTEGER NOT NULL DEFAULT 0,
+			deleted INTEGER NOT NULL DEFAULT 0,
+			created_at DATETIME DEFAULT CURRENT_TIMESTAMP
+		);
+		CREATE TABLE IF NOT EXISTS chat_sessions (
+			id TEXT PRIMARY KEY,
+			project_path TEXT NOT NULL,
+			backend TEXT NOT NULL,
+			title TEXT NOT NULL,
+			agent_id TEXT DEFAULT '',
+			agent_source TEXT DEFAULT 'default',
+			model TEXT DEFAULT '',
+			session_type TEXT NOT NULL DEFAULT 'chat',
+			external_session_id TEXT DEFAULT '',
+			thinking_effort TEXT DEFAULT '',
+			deleted INTEGER NOT NULL DEFAULT 0,
+			last_read_at DATETIME,
+			created_at DATETIME DEFAULT CURRENT_TIMESTAMP,
+			updated_at DATETIME DEFAULT CURRENT_TIMESTAMP,
+			UNIQUE(project_path, backend, id)
+		);
+		CREATE TABLE IF NOT EXISTS summaries (
+			id INTEGER PRIMARY KEY AUTOINCREMENT,
+			target_type TEXT NOT NULL,
+			target_id   INTEGER NOT NULL,
+			summary     TEXT NOT NULL,
+			created_at  DATETIME DEFAULT CURRENT_TIMESTAMP,
+			UNIQUE(target_type, target_id)
+		);
+		CREATE INDEX IF NOT EXISTS idx_history_session ON chat_history(project_path, backend, session_id, created_at);
+		CREATE INDEX IF NOT EXISTS idx_sessions_project_backend ON chat_sessions(project_path, backend);
+	`)
+	if err != nil {
+		t.Fatalf("failed to create tables: %v", err)
+	}
+
+	DB = db
+	DBRead = db
+	teardown := func() {
+		DB = origDB
+		DBRead = origDBRead
+		db.Close()
+	}
+	return db, teardown
+}
+
+// mockTriggerSummarizerBackend is a mock for triggerChatSummarization tests
+type mockTriggerSummarizerBackend struct {
+	streamCh   chan ai.StreamEvent
+	executeErr error
+}
+
+func (m *mockTriggerSummarizerBackend) Name() string { return "mock-trigger" }
+
+func (m *mockTriggerSummarizerBackend) ExecuteStream(ctx context.Context, req ai.ChatRequest) (<-chan ai.StreamEvent, error) {
+	if m.executeErr != nil {
+		return nil, m.executeErr
+	}
+	return m.streamCh, nil
+}
+
+func TestTriggerChatSummarization_NilSummarizer(t *testing.T) {
+	_, teardown := setupTestDBForTriggerSummary(t)
+	defer teardown()
+
+	origInstance := taskSummarizerInstance
+	defer func() { taskSummarizerInstance = origInstance }()
+
+	taskSummarizerInstance = nil
+	// Should return immediately when summarizer is nil
+	triggerChatSummarization("nonexistent-session")
+}
+
+func TestTriggerChatSummarization_NoMessages(t *testing.T) {
+	_, teardown := setupTestDBForTriggerSummary(t)
+	defer teardown()
+
+	origInstance := taskSummarizerInstance
+	defer func() { taskSummarizerInstance = origInstance }()
+
+	// Set up a mock summarizer
+	ch := make(chan ai.StreamEvent, 1)
+	ch <- ai.StreamEvent{Type: "done"}
+	close(ch)
+	mock := &mockTriggerSummarizerBackend{streamCh: ch}
+	taskSummarizerInstance = &summarize.TaskSummarizer{Backend: mock}
+
+	// Session doesn't exist in DB — should return with no error
+	triggerChatSummarization("nonexistent-session")
+}
+
+func TestTriggerChatSummarization_NoAssistantMessages(t *testing.T) {
+	db, teardown := setupTestDBForTriggerSummary(t)
+	defer teardown()
+
+	origInstance := taskSummarizerInstance
+	defer func() { taskSummarizerInstance = origInstance }()
+
+	ch := make(chan ai.StreamEvent, 1)
+	ch <- ai.StreamEvent{Type: "done"}
+	close(ch)
+	mock := &mockTriggerSummarizerBackend{streamCh: ch}
+	taskSummarizerInstance = &summarize.TaskSummarizer{Backend: mock}
+
+	// Create session and user message only
+	_, err := db.Exec("INSERT INTO chat_sessions (id, project_path, backend, title) VALUES ('sess-1', '/test', 'claude', 'Test')")
+	assert.NoError(t, err)
+	_, err = db.Exec("INSERT INTO chat_history (project_path, role, content, session_id, backend) VALUES ('/test', 'user', 'hello', 'sess-1', 'claude')")
+	assert.NoError(t, err)
+
+	// No assistant message — should return without calling summarizer
+	triggerChatSummarization("sess-1")
+}
+
+func TestTriggerChatSummarization_AlreadySummarized(t *testing.T) {
+	db, teardown := setupTestDBForTriggerSummary(t)
+	defer teardown()
+
+	origInstance := taskSummarizerInstance
+	defer func() { taskSummarizerInstance = origInstance }()
+
+	ch := make(chan ai.StreamEvent, 1)
+	ch <- ai.StreamEvent{Type: "done"}
+	close(ch)
+	mock := &mockTriggerSummarizerBackend{streamCh: ch}
+	taskSummarizerInstance = &summarize.TaskSummarizer{Backend: mock}
+
+	// Create session with assistant message
+	_, err := db.Exec("INSERT INTO chat_sessions (id, project_path, backend, title) VALUES ('sess-2', '/test', 'claude', 'Test')")
+	assert.NoError(t, err)
+
+	content, _ := json.Marshal(map[string]any{
+		"blocks": []any{map[string]any{"type": "text", "text": strings.Repeat("这是一段较长的AI回复内容。", 30)}},
+	})
+	_, err = db.Exec("INSERT INTO chat_history (project_path, role, content, session_id, backend) VALUES ('/test', 'assistant', ?, 'sess-2', 'claude')", string(content))
+	assert.NoError(t, err)
+
+	// Get the message ID
+	var msgID int64
+	db.QueryRow("SELECT id FROM chat_history WHERE session_id = 'sess-2' AND role = 'assistant'").Scan(&msgID)
+
+	// Pre-save a summary
+	err = SaveSummary("chat_message", msgID, "already summarized")
+	assert.NoError(t, err)
+
+	// Should skip summarization since already summarized
+	triggerChatSummarization("sess-2")
+}
+
+func TestTriggerChatSummarization_EmptyBlocks(t *testing.T) {
+	db, teardown := setupTestDBForTriggerSummary(t)
+	defer teardown()
+
+	origInstance := taskSummarizerInstance
+	defer func() { taskSummarizerInstance = origInstance }()
+
+	ch := make(chan ai.StreamEvent, 1)
+	ch <- ai.StreamEvent{Type: "done"}
+	close(ch)
+	mock := &mockTriggerSummarizerBackend{streamCh: ch}
+	taskSummarizerInstance = &summarize.TaskSummarizer{Backend: mock}
+
+	// Create session with assistant message that has no blocks
+	_, err := db.Exec("INSERT INTO chat_sessions (id, project_path, backend, title) VALUES ('sess-3', '/test', 'claude', 'Test')")
+	assert.NoError(t, err)
+
+	content, _ := json.Marshal(map[string]any{"blocks": []any{}})
+	_, err = db.Exec("INSERT INTO chat_history (project_path, role, content, session_id, backend) VALUES ('/test', 'assistant', ?, 'sess-3', 'claude')", string(content))
+	assert.NoError(t, err)
+
+	// Should return since blocks are empty
+	triggerChatSummarization("sess-3")
+}
+
+func TestTriggerChatSummarization_InvalidJSON(t *testing.T) {
+	db, teardown := setupTestDBForTriggerSummary(t)
+	defer teardown()
+
+	origInstance := taskSummarizerInstance
+	defer func() { taskSummarizerInstance = origInstance }()
+
+	ch := make(chan ai.StreamEvent, 1)
+	ch <- ai.StreamEvent{Type: "done"}
+	close(ch)
+	mock := &mockTriggerSummarizerBackend{streamCh: ch}
+	taskSummarizerInstance = &summarize.TaskSummarizer{Backend: mock}
+
+	// Create session with assistant message that has invalid JSON content
+	_, err := db.Exec("INSERT INTO chat_sessions (id, project_path, backend, title) VALUES ('sess-4', '/test', 'claude', 'Test')")
+	assert.NoError(t, err)
+	_, err = db.Exec("INSERT INTO chat_history (project_path, role, content, session_id, backend) VALUES ('/test', 'assistant', 'not valid json', 'sess-4', 'claude')")
+	assert.NoError(t, err)
+
+	// Should return on JSON parse error without panicking
+	triggerChatSummarization("sess-4")
+}
+
+func TestTriggerChatSummarization_Success(t *testing.T) {
+	db, teardown := setupTestDBForTriggerSummary(t)
+	defer teardown()
+
+	origInstance := taskSummarizerInstance
+	defer func() { taskSummarizerInstance = origInstance }()
+
+	// Set up mock summarizer
+	ch := make(chan ai.StreamEvent, 3)
+	ch <- ai.StreamEvent{Type: "content", Content: "这是总结"}
+	ch <- ai.StreamEvent{Type: "done"}
+	close(ch)
+	mock := &mockTriggerSummarizerBackend{streamCh: ch}
+	taskSummarizerInstance = &summarize.TaskSummarizer{Backend: mock}
+
+	// Create session with assistant message containing long text
+	_, err := db.Exec("INSERT INTO chat_sessions (id, project_path, backend, title) VALUES ('sess-5', '/test', 'claude', 'Test')")
+	assert.NoError(t, err)
+
+	longText := strings.Repeat("这是一段较长的AI回复内容。", 30)
+	content, _ := json.Marshal(map[string]any{
+		"blocks": []any{map[string]any{"type": "text", "text": longText}},
+	})
+	_, err = db.Exec("INSERT INTO chat_history (project_path, role, content, session_id, backend) VALUES ('/test', 'assistant', ?, 'sess-5', 'claude')", string(content))
+	assert.NoError(t, err)
+
+	// Trigger summarization
+	triggerChatSummarization("sess-5")
+
+	// Wait for async goroutine
+	time.Sleep(300 * time.Millisecond)
+
+	// Verify summary was saved
+	var msgID int64
+	db.QueryRow("SELECT id FROM chat_history WHERE session_id = 'sess-5' AND role = 'assistant'").Scan(&msgID)
+
+	summary, found := GetSummary("chat_message", msgID)
+	assert.True(t, found)
+	assert.Contains(t, summary, "总结")
+}

--- a/internal/service/database.go
+++ b/internal/service/database.go
@@ -137,10 +137,13 @@ func InitDB(runFromServer ...bool) error {
 		-- Index for task listing by project
 		CREATE INDEX IF NOT EXISTS idx_tasks_project ON scheduled_tasks(project_path, created_at DESC);
 
-		CREATE TABLE IF NOT EXISTS tts_summaries (
-			cache_key TEXT PRIMARY KEY,
-			summary TEXT NOT NULL,
-			created_at DATETIME DEFAULT CURRENT_TIMESTAMP
+		CREATE TABLE IF NOT EXISTS summaries (
+			id INTEGER PRIMARY KEY AUTOINCREMENT,
+			target_type TEXT NOT NULL,
+			target_id   INTEGER NOT NULL,
+			summary     TEXT NOT NULL,
+			created_at  DATETIME DEFAULT CURRENT_TIMESTAMP,
+			UNIQUE(target_type, target_id)
 		);
 
 		CREATE TABLE IF NOT EXISTS forwarded_ports (
@@ -236,6 +239,46 @@ func InitDB(runFromServer ...bool) error {
 	// SKIP when called from CLI subcommands (task/rag) — the server process
 	// may still be actively streaming, and these are NOT orphaned messages.
 	isServerStartup := len(runFromServer) > 0 && runFromServer[0]
+
+	// Migrate: replace old tts_summaries table (cache_key) with new schema (message_id).
+	// The old table has cache_key as primary key; the new table uses message_id.
+	// Since we don't do backward compatibility, drop the old table if it exists
+	// and recreate with the new schema.
+	var hasTTSCacheKey int
+	DB.QueryRow("SELECT COUNT(*) FROM pragma_table_info('tts_summaries') WHERE name='cache_key'").Scan(&hasTTSCacheKey)
+	if hasTTSCacheKey > 0 {
+		// Old table exists with cache_key — drop and recreate
+		if _, err := DB.Exec("DROP TABLE tts_summaries"); err != nil {
+			return fmt.Errorf("failed to drop old tts_summaries table: %w", err)
+		}
+		if _, err := DB.Exec(`
+			CREATE TABLE tts_summaries (
+				id INTEGER PRIMARY KEY AUTOINCREMENT,
+				message_id   INTEGER NOT NULL,
+				tts_summary  TEXT NOT NULL,
+				created_at   DATETIME DEFAULT CURRENT_TIMESTAMP,
+				UNIQUE(message_id)
+			);
+		`); err != nil {
+			return fmt.Errorf("failed to create new tts_summaries table: %w", err)
+		}
+	}
+	// Create new tts_summaries table if it doesn't exist yet (fresh install)
+	var hasTTSSummaries int
+	DB.QueryRow("SELECT COUNT(*) FROM sqlite_master WHERE type='table' AND name='tts_summaries'").Scan(&hasTTSSummaries)
+	if hasTTSSummaries == 0 {
+		if _, err := DB.Exec(`
+			CREATE TABLE tts_summaries (
+				id INTEGER PRIMARY KEY AUTOINCREMENT,
+				message_id   INTEGER NOT NULL,
+				tts_summary  TEXT NOT NULL,
+				created_at   DATETIME DEFAULT CURRENT_TIMESTAMP,
+				UNIQUE(message_id)
+			);
+		`); err != nil {
+			return fmt.Errorf("failed to create tts_summaries table: %w", err)
+		}
+	}
 
 	// Initialize read connection pool for concurrent reads (WAL mode).
 	// WAL contract: DB (MaxOpenConns=1) serializes writes; DBRead (MaxOpenConns=2)
@@ -336,6 +379,53 @@ func SaveTTSSummary(cacheKey, summary string) error {
 	_, err := DB.Exec(
 		"INSERT OR REPLACE INTO tts_summaries (cache_key, summary, created_at) VALUES (?, ?, CURRENT_TIMESTAMP)",
 		cacheKey, summary,
+	)
+	return err
+}
+
+// GetSummary looks up a reading summary by target type and target ID.
+// Returns (summary, found). Empty summary = text was too short.
+func GetSummary(targetType string, targetID int64) (string, bool) {
+	var summary string
+	err := DBRead.QueryRow(
+		"SELECT summary FROM summaries WHERE target_type = ? AND target_id = ?",
+		targetType, targetID,
+	).Scan(&summary)
+	if err != nil {
+		return "", false
+	}
+	return summary, true
+}
+
+// SaveSummary persists a reading summary for a target (chat message or task execution).
+// summary = "" means text was too short; non-empty is the actual summary.
+func SaveSummary(targetType string, targetID int64, summary string) error {
+	_, err := DB.Exec(
+		"INSERT OR REPLACE INTO summaries (target_type, target_id, summary, created_at) VALUES (?, ?, ?, CURRENT_TIMESTAMP)",
+		targetType, targetID, summary,
+	)
+	return err
+}
+
+// GetTTSSummaryByMessageID looks up a TTS summary by message ID.
+// Returns (ttsSummary, found).
+func GetTTSSummaryByMessageID(messageID int64) (string, bool) {
+	var ttsSummary string
+	err := DBRead.QueryRow(
+		"SELECT tts_summary FROM tts_summaries WHERE message_id = ?",
+		messageID,
+	).Scan(&ttsSummary)
+	if err != nil {
+		return "", false
+	}
+	return ttsSummary, true
+}
+
+// SaveTTSSummaryByMessageID persists a TTS summary for a chat message.
+func SaveTTSSummaryByMessageID(messageID int64, ttsSummary string) error {
+	_, err := DB.Exec(
+		"INSERT OR REPLACE INTO tts_summaries (message_id, tts_summary, created_at) VALUES (?, ?, CURRENT_TIMESTAMP)",
+		messageID, ttsSummary,
 	)
 	return err
 }

--- a/internal/service/database.go
+++ b/internal/service/database.go
@@ -360,29 +360,6 @@ func CloseDB() {
 	}
 }
 
-// GetTTSSummary looks up a cached TTS summary by cache key.
-// Returns (summary, found).
-func GetTTSSummary(cacheKey string) (string, bool) {
-	var summary string
-	err := DBRead.QueryRow(
-		"SELECT summary FROM tts_summaries WHERE cache_key = ?",
-		cacheKey,
-	).Scan(&summary)
-	if err != nil {
-		return "", false
-	}
-	return summary, true
-}
-
-// SaveTTSSummary persists a TTS summary to the database.
-func SaveTTSSummary(cacheKey, summary string) error {
-	_, err := DB.Exec(
-		"INSERT OR REPLACE INTO tts_summaries (cache_key, summary, created_at) VALUES (?, ?, CURRENT_TIMESTAMP)",
-		cacheKey, summary,
-	)
-	return err
-}
-
 // GetSummary looks up a reading summary by target type and target ID.
 // Returns (summary, found). Empty summary = text was too short.
 func GetSummary(targetType string, targetID int64) (string, bool) {

--- a/internal/service/database_test.go
+++ b/internal/service/database_test.go
@@ -197,6 +197,46 @@ func getTableColumns(t *testing.T, db *sql.DB, table string) map[string]bool {
 	return cols
 }
 
+func TestSchema_SummariesTable(t *testing.T) {
+	tmpDir := t.TempDir()
+	origBinDir := model.BinDir
+	model.BinDir = tmpDir
+	defer func() { model.BinDir = origBinDir }()
+
+	origDB := DB
+	origDBRead := DBRead
+	defer func() { DB = origDB; DBRead = origDBRead }()
+
+	err := InitDB()
+	assert.NoError(t, err)
+	defer CloseDB()
+
+	columns := getTableColumns(t, DB, "summaries")
+	assert.Contains(t, columns, "target_type", "summaries should have target_type column")
+	assert.Contains(t, columns, "target_id", "summaries should have target_id column")
+	assert.Contains(t, columns, "summary", "summaries should have summary column")
+}
+
+func TestSchema_TTSSummariesNewSchema(t *testing.T) {
+	tmpDir := t.TempDir()
+	origBinDir := model.BinDir
+	model.BinDir = tmpDir
+	defer func() { model.BinDir = origBinDir }()
+
+	origDB := DB
+	origDBRead := DBRead
+	defer func() { DB = origDB; DBRead = origDBRead }()
+
+	err := InitDB()
+	assert.NoError(t, err)
+	defer CloseDB()
+
+	columns := getTableColumns(t, DB, "tts_summaries")
+	assert.Contains(t, columns, "message_id", "tts_summaries should have message_id column")
+	assert.Contains(t, columns, "tts_summary", "tts_summaries should have tts_summary column")
+	assert.NotContains(t, columns, "cache_key", "tts_summaries should NOT have cache_key column (old schema)")
+}
+
 // getIndexes returns a set of index names from sqlite_master.
 func getIndexes(t *testing.T, db *sql.DB) map[string]bool {
 	t.Helper()
@@ -1100,4 +1140,190 @@ func TestSchema_ForwardedPortsMigration_HostColumnFromOldSchema(t *testing.T) {
 		count++
 	}
 	assert.Equal(t, 2, count, "should have 2 rows after migration")
+}
+
+// ---------- Summaries (unified reading summaries) ----------
+
+// setupTestDBForSummaries creates an in-memory SQLite database with the summaries table
+// for testing SaveSummary and GetSummary.
+func setupTestDBForSummaries(t *testing.T) (*sql.DB, func()) {
+	t.Helper()
+	origDB := DB
+	origDBRead := DBRead
+
+	db, err := sql.Open("sqlite", ":memory:")
+	if err != nil {
+		t.Fatalf("failed to open in-memory db: %v", err)
+	}
+	db.SetMaxOpenConns(1)
+	db.Exec("PRAGMA journal_mode=WAL")
+	db.Exec("PRAGMA busy_timeout=5000")
+
+	_, err = db.Exec(`
+		CREATE TABLE IF NOT EXISTS summaries (
+			id INTEGER PRIMARY KEY AUTOINCREMENT,
+			target_type TEXT NOT NULL,
+			target_id   INTEGER NOT NULL,
+			summary     TEXT NOT NULL,
+			created_at  DATETIME DEFAULT CURRENT_TIMESTAMP,
+			UNIQUE(target_type, target_id)
+		);
+	`)
+	if err != nil {
+		t.Fatalf("failed to create tables: %v", err)
+	}
+
+	DB = db
+	DBRead = db
+	teardown := func() {
+		DB = origDB
+		DBRead = origDBRead
+		db.Close()
+	}
+	return db, teardown
+}
+
+func TestGetSummary_NotFound(t *testing.T) {
+	_, teardown := setupTestDBForSummaries(t)
+	defer teardown()
+
+	summary, found := GetSummary("chat_message", 42)
+	assert.Equal(t, "", summary)
+	assert.False(t, found)
+}
+
+func TestSaveSummary_AndGetSummary(t *testing.T) {
+	_, teardown := setupTestDBForSummaries(t)
+	defer teardown()
+
+	err := SaveSummary("chat_message", 123, "This is a summary")
+	assert.NoError(t, err)
+
+	summary, found := GetSummary("chat_message", 123)
+	assert.Equal(t, "This is a summary", summary)
+	assert.True(t, found)
+}
+
+func TestSaveSummary_ShortText(t *testing.T) {
+	_, teardown := setupTestDBForSummaries(t)
+	defer teardown()
+
+	// Short text: save empty string
+	err := SaveSummary("chat_message", 456, "")
+	assert.NoError(t, err)
+
+	summary, found := GetSummary("chat_message", 456)
+	assert.Equal(t, "", summary)
+	assert.True(t, found)
+}
+
+func TestSaveSummary_DifferentTargetTypes(t *testing.T) {
+	_, teardown := setupTestDBForSummaries(t)
+	defer teardown()
+
+	// Same target_id, different target_type → different rows
+	err := SaveSummary("chat_message", 1, "chat summary")
+	assert.NoError(t, err)
+
+	err = SaveSummary("task_execution", 1, "task summary")
+	assert.NoError(t, err)
+
+	chatSummary, chatFound := GetSummary("chat_message", 1)
+	assert.Equal(t, "chat summary", chatSummary)
+	assert.True(t, chatFound)
+
+	taskSummary, taskFound := GetSummary("task_execution", 1)
+	assert.Equal(t, "task summary", taskSummary)
+	assert.True(t, taskFound)
+}
+
+func TestSaveSummary_Upsert(t *testing.T) {
+	_, teardown := setupTestDBForSummaries(t)
+	defer teardown()
+
+	err := SaveSummary("chat_message", 789, "version 1")
+	assert.NoError(t, err)
+
+	err = SaveSummary("chat_message", 789, "version 2")
+	assert.NoError(t, err)
+
+	summary, found := GetSummary("chat_message", 789)
+	assert.Equal(t, "version 2", summary)
+	assert.True(t, found)
+}
+
+// ---------- TTS Summaries (new table with message_id) ----------
+
+// setupTestDBForNewTTSSummaries creates an in-memory SQLite database with the new tts_summaries table
+// for testing GetTTSSummary and SaveTTSSummary with message_id.
+func setupTestDBForNewTTSSummaries(t *testing.T) (*sql.DB, func()) {
+	t.Helper()
+	origDB := DB
+	origDBRead := DBRead
+
+	db, err := sql.Open("sqlite", ":memory:")
+	if err != nil {
+		t.Fatalf("failed to open in-memory db: %v", err)
+	}
+	db.SetMaxOpenConns(1)
+	db.Exec("PRAGMA journal_mode=WAL")
+	db.Exec("PRAGMA busy_timeout=5000")
+
+	_, err = db.Exec(`
+		CREATE TABLE IF NOT EXISTS tts_summaries (
+			id INTEGER PRIMARY KEY AUTOINCREMENT,
+			message_id   INTEGER NOT NULL,
+			tts_summary  TEXT NOT NULL,
+			created_at   DATETIME DEFAULT CURRENT_TIMESTAMP,
+			UNIQUE(message_id)
+		);
+	`)
+	if err != nil {
+		t.Fatalf("failed to create tables: %v", err)
+	}
+
+	DB = db
+	DBRead = db
+	teardown := func() {
+		DB = origDB
+		DBRead = origDBRead
+		db.Close()
+	}
+	return db, teardown
+}
+
+func TestGetTTSSummaryByMessageID_NotFound(t *testing.T) {
+	_, teardown := setupTestDBForNewTTSSummaries(t)
+	defer teardown()
+
+	summary, found := GetTTSSummaryByMessageID(42)
+	assert.Equal(t, "", summary)
+	assert.False(t, found)
+}
+
+func TestSaveTTSSummaryByMessageID_AndGet(t *testing.T) {
+	_, teardown := setupTestDBForNewTTSSummaries(t)
+	defer teardown()
+
+	err := SaveTTSSummaryByMessageID(123, "TTS summary for message 123")
+	assert.NoError(t, err)
+
+	summary, found := GetTTSSummaryByMessageID(123)
+	assert.Equal(t, "TTS summary for message 123", summary)
+	assert.True(t, found)
+}
+
+func TestSaveTTSSummaryByMessageID_Upsert(t *testing.T) {
+	_, teardown := setupTestDBForNewTTSSummaries(t)
+	defer teardown()
+
+	err := SaveTTSSummaryByMessageID(456, "version 1")
+	assert.NoError(t, err)
+
+	err = SaveTTSSummaryByMessageID(456, "version 2")
+	assert.NoError(t, err)
+
+	summary, found := GetTTSSummaryByMessageID(456)
+	assert.Equal(t, "version 2", summary)
+	assert.True(t, found)
 }

--- a/internal/service/database_test.go
+++ b/internal/service/database_test.go
@@ -14,7 +14,7 @@ import (
 )
 
 // setupTestDBForTTS creates an in-memory SQLite database with the tts_summaries table
-// for testing GetTTSSummary and SaveTTSSummary.
+// for testing TTS summary functions.
 func setupTestDBForTTS(t *testing.T) (*sql.DB, func()) {
 	t.Helper()
 	origDB := DB
@@ -30,9 +30,19 @@ func setupTestDBForTTS(t *testing.T) (*sql.DB, func()) {
 
 	_, err = db.Exec(`
 		CREATE TABLE IF NOT EXISTS tts_summaries (
-			cache_key TEXT PRIMARY KEY,
-			summary TEXT NOT NULL,
-			created_at DATETIME DEFAULT CURRENT_TIMESTAMP
+			id INTEGER PRIMARY KEY AUTOINCREMENT,
+			message_id   INTEGER NOT NULL,
+			tts_summary  TEXT NOT NULL,
+			created_at   DATETIME DEFAULT CURRENT_TIMESTAMP,
+			UNIQUE(message_id)
+		);
+		CREATE TABLE IF NOT EXISTS summaries (
+			id INTEGER PRIMARY KEY AUTOINCREMENT,
+			target_type TEXT NOT NULL,
+			target_id   INTEGER NOT NULL,
+			summary     TEXT NOT NULL,
+			created_at  DATETIME DEFAULT CURRENT_TIMESTAMP,
+			UNIQUE(target_type, target_id)
 		);
 		CREATE TABLE IF NOT EXISTS chat_history (
 			id INTEGER PRIMARY KEY AUTOINCREMENT,
@@ -603,13 +613,13 @@ func orphanCleanup(t *testing.T, db *sql.DB, isServerStartup bool) {
 	}
 }
 
-// ---------- TTS Summary cache ----------
+// ---------- TTS Summary cache (message_id-based) ----------
 
 func TestGetTTSSummary_NotFound(t *testing.T) {
 	_, teardown := setupTestDBForTTS(t)
 	defer teardown()
 
-	summary, found := GetTTSSummary("nonexistent-key")
+	summary, found := GetTTSSummaryByMessageID(9999)
 	assert.Equal(t, "", summary)
 	assert.False(t, found)
 }
@@ -618,10 +628,10 @@ func TestGetTTSSummary_Found(t *testing.T) {
 	_, teardown := setupTestDBForTTS(t)
 	defer teardown()
 
-	err := SaveTTSSummary("key-1", "hello world")
+	err := SaveTTSSummaryByMessageID(1, "hello world")
 	assert.NoError(t, err)
 
-	summary, found := GetTTSSummary("key-1")
+	summary, found := GetTTSSummaryByMessageID(1)
 	assert.Equal(t, "hello world", summary)
 	assert.True(t, found)
 }
@@ -630,10 +640,10 @@ func TestGetTTSSummary_FailedEntry(t *testing.T) {
 	_, teardown := setupTestDBForTTS(t)
 	defer teardown()
 
-	err := SaveTTSSummary("key-fail", "raw text")
+	err := SaveTTSSummaryByMessageID(2, "raw text")
 	assert.NoError(t, err)
 
-	summary, found := GetTTSSummary("key-fail")
+	summary, found := GetTTSSummaryByMessageID(2)
 	assert.Equal(t, "raw text", summary)
 	assert.True(t, found)
 }
@@ -642,13 +652,13 @@ func TestSaveTTSSummary_Upsert(t *testing.T) {
 	_, teardown := setupTestDBForTTS(t)
 	defer teardown()
 
-	err := SaveTTSSummary("key-upsert", "version 1")
+	err := SaveTTSSummaryByMessageID(3, "version 1")
 	assert.NoError(t, err)
 
-	err = SaveTTSSummary("key-upsert", "version 2")
+	err = SaveTTSSummaryByMessageID(3, "version 2")
 	assert.NoError(t, err)
 
-	summary, found := GetTTSSummary("key-upsert")
+	summary, found := GetTTSSummaryByMessageID(3)
 	assert.True(t, found)
 	assert.Equal(t, "version 2", summary)
 }
@@ -1326,4 +1336,73 @@ func TestSaveTTSSummaryByMessageID_Upsert(t *testing.T) {
 	summary, found := GetTTSSummaryByMessageID(456)
 	assert.Equal(t, "version 2", summary)
 	assert.True(t, found)
+}
+
+// ---------- InitDB migration: tts_summaries cache_key → message_id ----------
+
+func TestInitDB_TTSSummariesMigrationFromOldSchema(t *testing.T) {
+	tmpDir := t.TempDir()
+	origBinDir := model.BinDir
+	model.BinDir = tmpDir
+	defer func() { model.BinDir = origBinDir }()
+
+	origDB := DB
+	origDBRead := DBRead
+	defer func() { DB = origDB; DBRead = origDBRead }()
+
+	// First: create a DB with the old schema (cache_key column)
+	dbPath := filepath.Join(tmpDir, ".clawbench", "clawbench.db")
+	os.MkdirAll(filepath.Dir(dbPath), 0755)
+
+	db, err := sql.Open("sqlite", dbPath)
+	assert.NoError(t, err)
+	_, err = db.Exec(`
+		CREATE TABLE IF NOT EXISTS tts_summaries (
+			cache_key TEXT PRIMARY KEY,
+			summary TEXT NOT NULL,
+			created_at DATETIME DEFAULT CURRENT_TIMESTAMP
+		);
+	`)
+	assert.NoError(t, err)
+	db.Close()
+
+	// Now call InitDB — should detect cache_key column and migrate
+	err = InitDB()
+	assert.NoError(t, err)
+
+	// Verify new schema: should have message_id column, not cache_key
+	columns := getTableColumns(t, DB, "tts_summaries")
+	assert.Contains(t, columns, "message_id", "tts_summaries should have message_id column after migration")
+	assert.NotContains(t, columns, "cache_key", "tts_summaries should NOT have cache_key column after migration")
+
+	// Verify the new API works
+	err = SaveTTSSummaryByMessageID(100, "post-migration summary")
+	assert.NoError(t, err)
+	summary, found := GetTTSSummaryByMessageID(100)
+	assert.True(t, found)
+	assert.Equal(t, "post-migration summary", summary)
+
+	CloseDB()
+}
+
+func TestInitDB_TTSSummariesFreshInstall(t *testing.T) {
+	tmpDir := t.TempDir()
+	origBinDir := model.BinDir
+	model.BinDir = tmpDir
+	defer func() { model.BinDir = origBinDir }()
+
+	origDB := DB
+	origDBRead := DBRead
+	defer func() { DB = origDB; DBRead = origDBRead }()
+
+	// Fresh install: no tts_summaries table exists yet
+	err := InitDB()
+	assert.NoError(t, err)
+
+	// Verify new schema: should have message_id column
+	columns := getTableColumns(t, DB, "tts_summaries")
+	assert.Contains(t, columns, "message_id", "tts_summaries should have message_id column on fresh install")
+	assert.Contains(t, columns, "tts_summary", "tts_summaries should have tts_summary column on fresh install")
+
+	CloseDB()
 }

--- a/internal/service/scheduler.go
+++ b/internal/service/scheduler.go
@@ -9,7 +9,6 @@ import (
 	"strings"
 	"sync"
 	"time"
-	"unicode/utf8"
 
 	"clawbench/internal/ai"
 	"clawbench/internal/model"
@@ -699,48 +698,10 @@ func (s *Scheduler) executeTask(task *model.ScheduledTask, projectPath string, t
 		slog.String("status", newStatus),
 	)
 
-	// Generate summary asynchronously if task summarizer is configured
-	if s.taskSummarizer != nil {
-		capturedExecID := executionID // capture for goroutine
-		capturedBlocks := blocks      // capture for goroutine
-		go func() {
-			// Use independent context with timeout — do NOT inherit executeTask's
-			// ctx which is cancelled when this function returns.
-			sumCtx, sumCancel := context.WithTimeout(context.Background(), 5*time.Minute)
-			defer sumCancel()
-
-			text := extractTextFromBlocks(capturedBlocks)
-			if utf8.RuneCountInString(text) < summarize.ShortTextThreshold {
-				// Text too short, mark as empty (frontend shows original)
-				if err := UpdateExecutionSummary(capturedExecID, ""); err != nil {
-					slog.Warn("failed to update execution summary (short text)",
-						slog.Int64("exec_id", capturedExecID),
-						slog.String("err", err.Error()),
-					)
-				}
-				return
-			}
-			summary, err := s.taskSummarizer.Summarize(sumCtx, text, "")
-			if err != nil {
-				slog.Warn("task execution summary failed",
-					slog.Int64("task_id", task.ID),
-					slog.Int64("exec_id", capturedExecID),
-					slog.String("err", err.Error()),
-				)
-				return // summary stays NULL, frontend shows original
-			}
-			if err := UpdateExecutionSummary(capturedExecID, summary); err != nil {
-				slog.Warn("failed to update execution summary",
-					slog.Int64("exec_id", capturedExecID),
-					slog.String("err", err.Error()),
-				)
-			}
-			slog.Info("task execution summary completed",
-				slog.Int64("task_id", task.ID),
-				slog.Int64("exec_id", capturedExecID),
-				slog.Int("summary_len", utf8.RuneCountInString(summary)),
-			)
-		}()
+	// Generate summary asynchronously using unified AsyncSummarize
+	if taskSummarizerInstance != nil {
+		projectPath := task.ProjectPath
+		AsyncSummarize("task_execution", executionID, blocks, projectPath, sessionID)
 	}
 }
 
@@ -889,32 +850,6 @@ func MarkExecutionRead(executionID string) error {
 		executionID,
 	)
 	return err
-}
-
-// UpdateExecutionSummary updates the summary column for a task execution.
-// summary is NULL when not yet generated, "" when text was too short,
-// and non-empty when summarization succeeded.
-func UpdateExecutionSummary(executionID int64, summary string) error {
-	_, err := DB.Exec(
-		"UPDATE task_executions SET summary = ? WHERE id = ?",
-		summary, executionID,
-	)
-	return err
-}
-
-// extractTextFromBlocks extracts plain text from ContentBlock array.
-// Only text-type blocks are included; tool_use, thinking, etc. are skipped.
-func extractTextFromBlocks(blocks []model.ContentBlock) string {
-	var buf strings.Builder
-	for _, b := range blocks {
-		if b.Type == "text" && b.Text != "" {
-			if buf.Len() > 0 {
-				buf.WriteString("\n\n")
-			}
-			buf.WriteString(b.Text)
-		}
-	}
-	return buf.String()
 }
 
 // DeleteTaskExecution deletes a single task execution and soft-deletes the

--- a/internal/service/session_runtime.go
+++ b/internal/service/session_runtime.go
@@ -139,6 +139,10 @@ func SetSessionRunning(sessionID string, running bool, skipEvent ...bool) {
 	if len(skipEvent) == 0 || !skipEvent[0] {
 		if !running {
 			EmitSessionEvent(sessionID, "completed", true)
+
+			// Trigger async summarization for chat messages on normal completion
+			// (cancel/disconnect uses skipEvent=true, so this only runs on "completed")
+			triggerChatSummarization(sessionID)
 		} else {
 			EmitSessionEvent(sessionID, "running", false)
 		}
@@ -308,4 +312,62 @@ func SendSessionEvent(sessionID string, event ai.StreamEvent) bool {
 		}
 	}
 	return false
+}
+
+// chatSummaryEnabled controls whether chat message auto-summarization is active.
+// Set during server startup based on config.
+var chatSummaryEnabled = true
+
+// SetChatSummaryEnabled configures whether chat messages are auto-summarized on completion.
+func SetChatSummaryEnabled(enabled bool) {
+	chatSummaryEnabled = enabled
+}
+
+// triggerChatSummarization triggers async summarization for the last assistant
+// message(s) in a session when it completes normally.
+// Skipped for cancelled/disconnected sessions (those use skipEvent=true in SetSessionRunning).
+func triggerChatSummarization(sessionID string) {
+	if !chatSummaryEnabled || taskSummarizerInstance == nil {
+		return
+	}
+
+	// Get the last assistant message for this session
+	messages, err := GetMessagesBySessionID(sessionID)
+	if err != nil || len(messages) == 0 {
+		return
+	}
+
+	// Find the last assistant message
+	var lastAssistant *model.ChatMessage
+	for i := len(messages) - 1; i >= 0; i-- {
+		if messages[i].Role == "assistant" {
+			lastAssistant = &messages[i]
+			break
+		}
+	}
+	if lastAssistant == nil {
+		return
+	}
+
+	// Parse blocks from the assistant content
+	var content struct {
+		Blocks []model.ContentBlock `json:"blocks"`
+	}
+	if err := json.Unmarshal([]byte(lastAssistant.Content), &content); err != nil {
+		return
+	}
+	if len(content.Blocks) == 0 {
+		return
+	}
+
+	// Check if already summarized
+	_, found := GetSummary("chat_message", lastAssistant.ID)
+	if found {
+		return
+	}
+
+	// Get project path for WS event
+	projectPath := GetSessionProjectPath(sessionID)
+
+	AsyncSummarize("chat_message", lastAssistant.ID, content.Blocks, projectPath, sessionID)
 }

--- a/internal/service/summary.go
+++ b/internal/service/summary.go
@@ -1,0 +1,94 @@
+package service
+
+import (
+	"context"
+	"log/slog"
+	"time"
+	"unicode/utf8"
+
+	"clawbench/internal/model"
+	"clawbench/internal/summarize"
+	"clawbench/internal/ws"
+)
+
+// taskSummarizerInstance is the shared TaskSummarizer instance used by
+// both chat message summarization and task execution summarization.
+// Set via SetTaskSummarizerInstance() during server startup.
+var taskSummarizerInstance *summarize.TaskSummarizer
+
+// SetTaskSummarizerInstance sets the global TaskSummarizer instance
+// used for async summarization of both chat messages and task executions.
+func SetTaskSummarizerInstance(s *summarize.TaskSummarizer) {
+	taskSummarizerInstance = s
+}
+
+// AsyncSummarize generates a reading summary asynchronously for a target
+// (chat message or task execution). It runs in a goroutine with an
+// independent context and 5-minute timeout.
+//
+// On completion, the summary is persisted via SaveSummary() and a
+// summary_update WebSocket event is broadcast.
+func AsyncSummarize(targetType string, targetID int64, blocks []model.ContentBlock, projectPath, sessionID string) {
+	if taskSummarizerInstance == nil {
+		return
+	}
+
+	go func() {
+		sumCtx, sumCancel := context.WithTimeout(context.Background(), 5*time.Minute)
+		defer sumCancel()
+
+		text := summarize.ExtractTextFromBlocks(blocks)
+		if utf8.RuneCountInString(text) < summarize.ShortTextThreshold {
+			// Text too short, mark as empty (frontend shows original)
+			if err := SaveSummary(targetType, targetID, ""); err != nil {
+				slog.Warn("failed to save summary (short text)",
+					slog.String("target_type", targetType),
+					slog.Int64("target_id", targetID),
+					slog.String("err", err.Error()),
+				)
+			}
+			return
+		}
+
+		summary, err := taskSummarizerInstance.Summarize(sumCtx, text, "")
+		if err != nil {
+			slog.Warn("summarization failed",
+				slog.String("target_type", targetType),
+				slog.Int64("target_id", targetID),
+				slog.String("err", err.Error()),
+			)
+			return // summary stays non-existent, frontend shows original
+		}
+
+		if err := SaveSummary(targetType, targetID, summary); err != nil {
+			slog.Warn("failed to save summary",
+				slog.String("target_type", targetType),
+				slog.Int64("target_id", targetID),
+				slog.String("err", err.Error()),
+			)
+		}
+
+		slog.Info("summarization completed",
+			slog.String("target_type", targetType),
+			slog.Int64("target_id", targetID),
+			slog.Int("summary_len", utf8.RuneCountInString(summary)),
+		)
+
+		// Broadcast summary_update via WebSocket
+		mgr := ws.GetManager()
+		if mgr != nil {
+			mgr.BroadcastEvent(ws.ServerMessage{
+				Type:  "event",
+				ID:    ws.GenerateEventID(),
+				Event: "summary_update",
+				Data: ws.SummaryUpdateData{
+					TargetType:  targetType,
+					TargetID:    targetID,
+					Summary:     summary,
+					ProjectPath: projectPath,
+					SessionID:   sessionID,
+				},
+			})
+		}
+	}()
+}

--- a/internal/service/summary_test.go
+++ b/internal/service/summary_test.go
@@ -1,0 +1,178 @@
+package service
+
+import (
+	"context"
+	"database/sql"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"clawbench/internal/ai"
+	"clawbench/internal/model"
+	"clawbench/internal/summarize"
+	"clawbench/internal/ws"
+
+	"github.com/stretchr/testify/assert"
+)
+
+// --- AsyncSummarize tests ---
+
+// setupTestDBForAsyncSummary creates an in-memory DB with summaries table
+func setupTestDBForAsyncSummary(t *testing.T) (*sql.DB, func()) {
+	t.Helper()
+	origDB := DB
+	origDBRead := DBRead
+
+	db, err := sql.Open("sqlite", ":memory:")
+	if err != nil {
+		t.Fatalf("failed to open in-memory db: %v", err)
+	}
+	db.SetMaxOpenConns(1)
+	db.Exec("PRAGMA journal_mode=WAL")
+	db.Exec("PRAGMA busy_timeout=5000")
+
+	_, err = db.Exec(`
+		CREATE TABLE IF NOT EXISTS summaries (
+			id INTEGER PRIMARY KEY AUTOINCREMENT,
+			target_type TEXT NOT NULL,
+			target_id   INTEGER NOT NULL,
+			summary     TEXT NOT NULL,
+			created_at  DATETIME DEFAULT CURRENT_TIMESTAMP,
+			UNIQUE(target_type, target_id)
+		);
+	`)
+	if err != nil {
+		t.Fatalf("failed to create tables: %v", err)
+	}
+
+	DB = db
+	DBRead = db
+	teardown := func() {
+		DB = origDB
+		DBRead = origDBRead
+		db.Close()
+	}
+	return db, teardown
+}
+
+// mockAsyncSummarizerBackend is a mock AI backend for AsyncSummarize tests
+type mockAsyncSummarizerBackend struct {
+	streamCh   chan ai.StreamEvent
+	executeErr error
+}
+
+func (m *mockAsyncSummarizerBackend) Name() string { return "mock-async" }
+
+func (m *mockAsyncSummarizerBackend) ExecuteStream(ctx context.Context, req ai.ChatRequest) (<-chan ai.StreamEvent, error) {
+	if m.executeErr != nil {
+		return nil, m.executeErr
+	}
+	return m.streamCh, nil
+}
+
+func TestAsyncSummarize_ShortText(t *testing.T) {
+	_, dbTeardown := setupTestDBForAsyncSummary(t)
+	defer dbTeardown()
+
+	origInstance := taskSummarizerInstance
+	defer func() { taskSummarizerInstance = origInstance }()
+
+	// Create a TaskSummarizer with mock backend
+	ch := make(chan ai.StreamEvent, 1)
+	ch <- ai.StreamEvent{Type: "done"}
+	close(ch)
+	mock := &mockAsyncSummarizerBackend{streamCh: ch}
+	taskSummarizerInstance = &summarize.TaskSummarizer{Backend: mock}
+
+	// Short text block — should save empty summary
+	blocks := []model.ContentBlock{{Type: "text", Text: "短"}}
+
+	var wg sync.WaitGroup
+	wg.Add(1)
+	origBroadcast := ws.GetManager()
+	_ = origBroadcast // We don't test WS here, just DB
+
+	AsyncSummarize("chat_message", 1, blocks, "/test", "session-1")
+
+	// Wait for goroutine to complete
+	time.Sleep(200 * time.Millisecond)
+
+	summary, found := GetSummary("chat_message", 1)
+	assert.True(t, found)
+	assert.Equal(t, "", summary) // short text = empty summary
+}
+
+func TestAsyncSummarize_NormalText(t *testing.T) {
+	_, dbTeardown := setupTestDBForAsyncSummary(t)
+	defer dbTeardown()
+
+	origInstance := taskSummarizerInstance
+	defer func() { taskSummarizerInstance = origInstance }()
+
+	// Create mock backend that returns a summary
+	ch := make(chan ai.StreamEvent, 3)
+	ch <- ai.StreamEvent{Type: "content", Content: "## 精简总结\n\n关键结论。"}
+	ch <- ai.StreamEvent{Type: "done"}
+	close(ch)
+	mock := &mockAsyncSummarizerBackend{streamCh: ch}
+	taskSummarizerInstance = &summarize.TaskSummarizer{Backend: mock}
+
+	// Long text block
+	longText := strings.Repeat("这是一段较长的AI回复内容。", 30)
+	blocks := []model.ContentBlock{{Type: "text", Text: longText}}
+
+	AsyncSummarize("chat_message", 2, blocks, "/test", "session-2")
+
+	// Wait for goroutine to complete
+	time.Sleep(200 * time.Millisecond)
+
+	summary, found := GetSummary("chat_message", 2)
+	assert.True(t, found)
+	assert.Contains(t, summary, "精简总结")
+}
+
+func TestAsyncSummarize_NilSummarizer(t *testing.T) {
+	_, dbTeardown := setupTestDBForAsyncSummary(t)
+	defer dbTeardown()
+
+	origInstance := taskSummarizerInstance
+	defer func() { taskSummarizerInstance = origInstance }()
+
+	// nil summarizer — should return immediately, no goroutine
+	taskSummarizerInstance = nil
+
+	blocks := []model.ContentBlock{{Type: "text", Text: "some text"}}
+
+	// Should not panic or create goroutine
+	AsyncSummarize("chat_message", 3, blocks, "/test", "session-3")
+
+	time.Sleep(100 * time.Millisecond)
+
+	// No summary should be saved
+	_, found := GetSummary("chat_message", 3)
+	assert.False(t, found)
+}
+
+func TestAsyncSummarize_BackendError(t *testing.T) {
+	_, dbTeardown := setupTestDBForAsyncSummary(t)
+	defer dbTeardown()
+
+	origInstance := taskSummarizerInstance
+	defer func() { taskSummarizerInstance = origInstance }()
+
+	// Mock backend that returns error
+	mock := &mockAsyncSummarizerBackend{executeErr: context.DeadlineExceeded}
+	taskSummarizerInstance = &summarize.TaskSummarizer{Backend: mock}
+
+	longText := strings.Repeat("这是一段较长的AI回复内容。", 30)
+	blocks := []model.ContentBlock{{Type: "text", Text: longText}}
+
+	AsyncSummarize("chat_message", 4, blocks, "/test", "session-4")
+
+	time.Sleep(200 * time.Millisecond)
+
+	// No summary saved on error
+	_, found := GetSummary("chat_message", 4)
+	assert.False(t, found)
+}

--- a/internal/summarize/task.go
+++ b/internal/summarize/task.go
@@ -8,6 +8,7 @@ import (
 	"unicode/utf8"
 
 	"clawbench/internal/ai"
+	"clawbench/internal/model"
 )
 
 // taskSummarizePrompt is the system prompt for task execution summarization.
@@ -32,8 +33,8 @@ func TaskSummarizePrompt() string {
 // from input or output — the summary retains formatting for readability.
 type TaskSummarizer struct {
 	// When using an AI CLI backend (claude/codebuddy/gemini etc.):
-	backend ai.AIBackend
-	model   string // model ID override (empty = use backend default)
+	Backend ai.AIBackend // exported for test construction
+	model   string       // model ID override (empty = use backend default)
 
 	// When using an API backend (OpenAI/Anthropic) via pipeline:
 	pipeline *ttsPipeline
@@ -47,7 +48,7 @@ func NewTaskSummarizer(backendType, model string) (*TaskSummarizer, error) {
 		return nil, fmt.Errorf("failed to create AI backend for task summarization: %w", err)
 	}
 	return &TaskSummarizer{
-		backend: backend,
+		Backend: backend,
 		model:   model,
 	}, nil
 }
@@ -95,7 +96,7 @@ func (t *TaskSummarizer) Summarize(ctx context.Context, text string, language st
 		Resume:       false,
 	}
 
-	ch, err := t.backend.ExecuteStream(ctx, req)
+	ch, err := t.Backend.ExecuteStream(ctx, req)
 	if err != nil {
 		return "", fmt.Errorf("task summarization backend failed to start: %w", err)
 	}
@@ -122,4 +123,20 @@ func (t *TaskSummarizer) Summarize(ctx context.Context, text string, language st
 	)
 
 	return result, nil
+}
+
+// ExtractTextFromBlocks extracts plain text from ContentBlock array.
+// Only text-type blocks are included; tool_use, thinking, etc. are skipped.
+// Text blocks are joined with double newlines.
+func ExtractTextFromBlocks(blocks []model.ContentBlock) string {
+	var buf strings.Builder
+	for _, b := range blocks {
+		if b.Type == "text" && b.Text != "" {
+			if buf.Len() > 0 {
+				buf.WriteString("\n\n")
+			}
+			buf.WriteString(b.Text)
+		}
+	}
+	return buf.String()
 }

--- a/internal/summarize/task_test.go
+++ b/internal/summarize/task_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 
 	"clawbench/internal/ai"
+	"clawbench/internal/model"
 
 	"github.com/stretchr/testify/assert"
 )
@@ -15,7 +16,7 @@ import (
 func TestTaskSummarizer_ShortText(t *testing.T) {
 	// Short text should return empty string (no summarization needed)
 	s := &TaskSummarizer{
-		backend: &mockTaskBackend{},
+		Backend: &mockTaskBackend{},
 	}
 
 	result, err := s.Summarize(context.Background(), "短文本", "")
@@ -52,7 +53,7 @@ func TestTaskSummarizer_LongText_ViaBackend(t *testing.T) {
 
 	mock := &mockTaskBackend{streamCh: ch}
 	s := &TaskSummarizer{
-		backend: mock,
+		Backend: mock,
 		model:   "test-model",
 	}
 
@@ -73,7 +74,7 @@ func TestTaskSummarizer_BackendError(t *testing.T) {
 		executeErr: context.DeadlineExceeded,
 	}
 	s := &TaskSummarizer{
-		backend: mock,
+		Backend: mock,
 	}
 
 	longText := strings.Repeat("这是一段较长的AI回复内容。", 30)
@@ -89,7 +90,7 @@ func TestTaskSummarizer_StreamError(t *testing.T) {
 
 	mock := &mockTaskBackend{streamCh: ch}
 	s := &TaskSummarizer{
-		backend: mock,
+		Backend: mock,
 	}
 
 	longText := strings.Repeat("这是一段较长的AI回复内容。", 30)
@@ -105,7 +106,7 @@ func TestTaskSummarizer_EmptyOutput(t *testing.T) {
 
 	mock := &mockTaskBackend{streamCh: ch}
 	s := &TaskSummarizer{
-		backend: mock,
+		Backend: mock,
 	}
 
 	longText := strings.Repeat("这是一段较长的AI回复内容。", 30)
@@ -126,7 +127,7 @@ func TestTaskSummarizer_Truncation(t *testing.T) {
 
 	mock := &mockTaskBackend{streamCh: ch}
 	s := &TaskSummarizer{
-		backend: mock,
+		Backend: mock,
 	}
 
 	longText := strings.Repeat("长文本", 200) // 600 runes
@@ -178,4 +179,53 @@ func TestNewTaskSummarizer_UnsupportedBackend(t *testing.T) {
 	_, err := NewTaskSummarizer("nonexistent_backend_type", "")
 	assert.Error(t, err)
 	assert.Contains(t, err.Error(), "failed to create AI backend")
+}
+
+// --- ExtractTextFromBlocks ---
+
+func TestExtractTextFromBlocks_TextOnly(t *testing.T) {
+	blocks := []model.ContentBlock{
+		{Type: "text", Text: "Hello world"},
+		{Type: "text", Text: "Second paragraph"},
+	}
+	result := ExtractTextFromBlocks(blocks)
+	assert.Equal(t, "Hello world\n\nSecond paragraph", result)
+}
+
+func TestExtractTextFromBlocks_SkipsNonText(t *testing.T) {
+	blocks := []model.ContentBlock{
+		{Type: "text", Text: "Important content"},
+		{Type: "thinking", Text: "internal reasoning"},
+		{Type: "tool_use", Name: "Bash", ID: "1"},
+		{Type: "warning", Text: "some warning"},
+		{Type: "error", Text: "some error"},
+		{Type: "text", Text: "More content"},
+	}
+	result := ExtractTextFromBlocks(blocks)
+	assert.Equal(t, "Important content\n\nMore content", result)
+}
+
+func TestExtractTextFromBlocks_Empty(t *testing.T) {
+	blocks := []model.ContentBlock{}
+	result := ExtractTextFromBlocks(blocks)
+	assert.Equal(t, "", result)
+}
+
+func TestExtractTextFromBlocks_NoTextBlocks(t *testing.T) {
+	blocks := []model.ContentBlock{
+		{Type: "tool_use", Name: "Read", ID: "1"},
+		{Type: "thinking", Text: "hmm"},
+	}
+	result := ExtractTextFromBlocks(blocks)
+	assert.Equal(t, "", result)
+}
+
+func TestExtractTextFromBlocks_EmptyTextSkipped(t *testing.T) {
+	blocks := []model.ContentBlock{
+		{Type: "text", Text: "Content"},
+		{Type: "text", Text: ""}, // empty text should be skipped
+		{Type: "text", Text: "More"},
+	}
+	result := ExtractTextFromBlocks(blocks)
+	assert.Equal(t, "Content\n\nMore", result)
 }

--- a/internal/ws/protocol.go
+++ b/internal/ws/protocol.go
@@ -4,7 +4,7 @@ package ws
 type ServerMessage struct {
 	Type  string `json:"type"`            // "event", "ping"
 	ID    string `json:"id,omitempty"`    // event ID for ack (e.g., "evt_1706000000_1")
-	Event string `json:"event,omitempty"` // "session_update", "task_update", "queue_update"
+	Event string `json:"event,omitempty"` // "session_update", "task_update", "queue_update", "summary_update"
 	Data  any    `json:"data,omitempty"`
 }
 
@@ -40,4 +40,13 @@ type TaskUpdateData struct {
 type QueueUpdateData struct {
 	SessionID string `json:"session_id"`
 	Count     int    `json:"count"`
+}
+
+// SummaryUpdateData is the data payload for "summary_update" events.
+type SummaryUpdateData struct {
+	TargetType  string `json:"targetType"`            // "chat_message" or "task_execution"
+	TargetID    int64  `json:"targetID"`               // chat_history.id or task_executions.id
+	Summary     string `json:"summary"`                // empty = too short, non-empty = summary content
+	ProjectPath string `json:"projectPath,omitempty"`
+	SessionID   string `json:"sessionID,omitempty"`
 }

--- a/web/src/components/chat/ChatMessageItem.vue
+++ b/web/src/components/chat/ChatMessageItem.vue
@@ -16,6 +16,8 @@
         :blockAskQuestions="blockAskQuestions"
         :streaming="msg.streaming"
         :cancelled="msg.cancelled"
+        :summary="msg.summary"
+        :showingSummary="msg.showingSummary"
         :renderTextBlock="renderTextBlock"
         :formatToolInput="formatToolInput"
         :toolCallSummary="toolCallSummary"
@@ -32,6 +34,7 @@
         @task-card-click="$emit('task-card-click', $event)"
         @send-message="$emit('send-message', $event)"
         @render-flush="$emit('render-flush')"
+        @toggle-summary="$emit('toggle-summary', msg.id)"
       />
     </div>
 
@@ -119,7 +122,7 @@ const props = defineProps({
   active: { type: Boolean, default: true },
 })
 
-const emit = defineEmits(['toggle-tool', 'show-tool-detail', 'show-thinking-detail', 'show-metadata', 'file-tag-click', 'expand', 'collapse', 'task-card-click', 'send-message', 'render-flush'])
+const emit = defineEmits(['toggle-tool', 'show-tool-detail', 'show-thinking-detail', 'show-metadata', 'file-tag-click', 'expand', 'collapse', 'task-card-click', 'send-message', 'render-flush', 'toggle-summary'])
 
 const autoSpeech = inject('autoSpeech')
 const layoutRefreshKey = inject('layoutRefreshKey', ref(0))

--- a/web/src/components/chat/ChatMessageItem.vue
+++ b/web/src/components/chat/ChatMessageItem.vue
@@ -59,9 +59,9 @@
     <div v-if="msg.role === 'assistant' && !msg.streaming && (msgText || msg.blocks?.length)" class="chat-meta-bar">
       <span class="chat-meta-info">
         <span v-if="msg.metadata?.wallMs" class="chat-meta-duration">{{ formatDuration(msg.metadata.wallMs) }}</span>
-        <span v-if="msg.createdAt" :class="msg.metadata?.wallMs ? 'chat-meta-sep' : ''">{{ formatMessageTime(msg.createdAt) }}</span>
       </span>
       <div class="chat-meta-actions">
+        <SummaryToggle v-if="msg.summary && !msg.streaming" mode="button" :showing-summary="msg.showingSummary" i18n-prefix="chat.message" @toggle="$emit('toggle-summary', msg.id)" />
         <button v-if="msgText" ref="speakBtnRef" class="chat-info-btn chat-speak-btn" :class="{ active: autoSpeech.isActive(msg.id), loading: autoSpeech.isGeneratingText(msg.id) }" @click.stop="handleSpeak">
           <!-- Generating states: summarizing / synthesizing -->
           <template v-if="autoSpeech.isGeneratingText(msg.id)">
@@ -87,7 +87,6 @@
     <!-- Bottom bar for user messages -->
     <div v-if="msg.role === 'user'" class="chat-meta-bar chat-meta-bar-user">
       <span class="chat-meta-info">
-        <span v-if="msg.createdAt">{{ formatMessageTime(msg.createdAt) }}</span>
       </span>
       <button class="chat-info-btn chat-info-btn-user" @click="$emit('show-metadata', msg)" :title="t('chat.message.viewDetails')">
         <Info :size="14" />
@@ -106,6 +105,7 @@ import { store } from '@/stores/app.ts'
 import { extractSpeakableText } from '@/composables/useAutoSpeech.ts'
 import ContentBlocks from './ContentBlocks.vue'
 import FileAttachmentList from './FileAttachmentList.vue'
+import SummaryToggle from '@/components/common/SummaryToggle.vue'
 
 
 const { t } = useI18n()
@@ -219,7 +219,7 @@ function handleCollapse() {
 const chatRender = inject('chatRender', {})
 const chatSession = inject('chatSession', {})
 
-const { renderTextBlock, formatMessageTime, toolCallSummary, formatToolInput, humanizeCron, repeatLabel, truncate, hasImagesInContent } = chatRender
+const { renderTextBlock, toolCallSummary, formatToolInput, humanizeCron, repeatLabel, truncate, hasImagesInContent } = chatRender
 const { getAgentIcon, getAgentName } = chatSession
 </script>
 

--- a/web/src/components/chat/ChatMessageList.vue
+++ b/web/src/components/chat/ChatMessageList.vue
@@ -58,6 +58,7 @@
       @expand="handleExpand"
       @collapse="handleCollapse"
       @render-flush="emit('render-flush')"
+      @toggle-summary="$emit('toggle-summary', $event)"
     />
     </div>
 
@@ -106,7 +107,7 @@ const props = defineProps({
   active: { type: Boolean, default: true },
 })
 
-const emit = defineEmits(['toggle-tool', 'show-tool-detail', 'show-thinking-detail', 'show-metadata', 'file-tag-click', 'file-open', 'load-more', 'task-card-click', 'send-message', 'remove-pending', 'render-flush'])
+const emit = defineEmits(['toggle-tool', 'show-tool-detail', 'show-thinking-detail', 'show-metadata', 'file-tag-click', 'file-open', 'load-more', 'task-card-click', 'send-message', 'remove-pending', 'render-flush', 'toggle-summary'])
 
 const messagesRef = ref(null)
 const { handleDblClick } = useDoubleClickCopy()

--- a/web/src/components/chat/ChatMetadataModal.vue
+++ b/web/src/components/chat/ChatMetadataModal.vue
@@ -12,7 +12,7 @@
       </div>
       <div v-if="createdAt" class="metadata-item">
         <span class="metadata-label">{{ t('chat.metadata.time') }}</span>
-        <span class="metadata-value">{{ formatDetailTime(createdAt) }}</span>
+        <span class="metadata-value">{{ formatDetailTime(createdAt) }} <span class="metadata-relative-time">{{ formatRelativeTime(createdAt) }}</span></span>
       </div>
       <div v-if="relatedFile" class="metadata-item">
         <span class="metadata-label">{{ t('chat.metadata.relatedFile') }}</span>
@@ -76,7 +76,7 @@ import { Copy } from 'lucide-vue-next'
 import { useI18n } from 'vue-i18n'
 import ModalDialog from '@/components/common/ModalDialog.vue'
 import { useToast } from '@/composables/useToast.ts'
-import { formatDuration } from '@/utils/format.ts'
+import { formatDuration, formatRelativeTime } from '@/utils/format.ts'
 
 const { t } = useI18n()
 
@@ -160,6 +160,12 @@ function copyValue(value, event) {
     font-size: 13px;
     color: var(--text-primary);
     word-break: break-all;
+}
+
+.metadata-relative-time {
+    font-size: 12px;
+    color: var(--text-muted, #9ca3af);
+    margin-left: 6px;
 }
 
 .metadata-session-id {

--- a/web/src/components/chat/ChatPanelContent.vue
+++ b/web/src/components/chat/ChatPanelContent.vue
@@ -27,6 +27,7 @@
       @send-message="handleToolSendMessage"
       @remove-pending="manager.handleRemovePending"
       @render-flush="scrollBottom()"
+      @toggle-summary="handleToggleSummary"
     />
 
     <!-- Session switching overlay — placed here to cover the entire message area -->
@@ -584,6 +585,33 @@ const removeEventHandler = onEvent((event, data) => {
     }
 })
 
+// Handle summary_update from WebSocket (dispatched by useGlobalEvents as custom event)
+function handleSummaryUpdate(e) {
+    const data = (e as CustomEvent).detail
+    if (!data?.targetID) return
+    const msgId = String(data.targetID)
+    const msg = messages.value.find(m => String(m.id) === msgId)
+    if (!msg) return
+    msg.summary = data.summary
+    // Auto-show summary if user hasn't manually toggled
+    if (msg.showingSummary !== true && msg.showingSummary !== false) {
+        // showingSummary was never set (undefined) — auto-set based on summary content
+        msg.showingSummary = data.summary != null && data.summary !== ''
+    } else if (data.summary != null && data.summary !== '') {
+        // If currently showing original and a new summary arrives, auto-switch to summary
+        if (!msg.showingSummary) {
+            msg.showingSummary = true
+        }
+    }
+}
+
+// Toggle summary/original view for a message
+function handleToggleSummary(msgId) {
+    const msg = messages.value.find(m => m.id === msgId)
+    if (!msg) return
+    msg.showingSummary = !msg.showingSummary
+}
+
 // Start one-time session load when component mounts
 onMounted(() => {
     // Request notification permission on mount
@@ -593,6 +621,7 @@ onMounted(() => {
 
     session.loadSessionsOnce()
     document.addEventListener('visibilitychange', session.handleVisibilityChange)
+    window.addEventListener('clawbench-summary-update', handleSummaryUpdate)
 })
 
 // Cleanup preview URLs on unmount
@@ -604,6 +633,7 @@ onUnmounted(() => {
     session.stopMsgCountPolling()
     document.removeEventListener('visibilitychange', session.handleVisibilityChange)
     document.removeEventListener('visibilitychange', manager._visibilityHandler)
+    window.removeEventListener('clawbench-summary-update', handleSummaryUpdate)
     notification.closeAll()
 })
 </script>

--- a/web/src/components/chat/ChatPanelContent.vue
+++ b/web/src/components/chat/ChatPanelContent.vue
@@ -587,7 +587,7 @@ const removeEventHandler = onEvent((event, data) => {
 
 // Handle summary_update from WebSocket (dispatched by useGlobalEvents as custom event)
 function handleSummaryUpdate(e) {
-    const data = (e as CustomEvent).detail
+    const data = e.detail
     if (!data?.targetID) return
     const msgId = String(data.targetID)
     const msg = messages.value.find(m => String(m.id) === msgId)

--- a/web/src/components/chat/ContentBlocks.vue
+++ b/web/src/components/chat/ContentBlocks.vue
@@ -336,20 +336,9 @@ onUnmounted(() => {
   margin-top: 4px;
 }
 
-.summary-banner {
-  text-align: center;
-  font-size: 11px;
-  color: var(--text-muted, #999);
-  background: color-mix(in srgb, var(--text-muted, #999) 6%, transparent);
-  padding: 4px 0;
-  margin-top: 6px;
-  border-radius: 4px;
-  cursor: pointer;
-  user-select: none;
-}
-.summary-banner:hover {
-  background: color-mix(in srgb, var(--text-muted, #999) 10%, transparent);
-}
+
+
+
 
 .chat-error-card {
   display: flex;

--- a/web/src/components/chat/ContentBlocks.vue
+++ b/web/src/components/chat/ContentBlocks.vue
@@ -1,5 +1,11 @@
 <template>
   <div class="content-blocks">
+    <!-- Summary mode: render summary as a single text block -->
+    <template v-if="showingSummary && summary">
+      <div v-html="renderTextBlock(summary, msgId, 0, false)"></div>
+    </template>
+    <!-- Original content mode -->
+    <template v-else>
     <template v-for="(block, bi) in blocks" :key="bi">
       <!-- Thinking block -->
       <div v-if="block.type === 'thinking'" class="chat-thinking" @click.stop="handleThinkingClick(block)">
@@ -82,10 +88,16 @@
       <!-- Text block: streaming uses throttled render to avoid UI freeze -->
       <div v-else-if="block.type === 'text'" v-html="getBlockHtml(bi, block)"></div>
     </template>
+    </template>
     <!-- Loading dots while AI is still streaming (not when cancelled) -->
     <div v-if="streaming && !cancelled" class="placeholder-dots"><span></span><span></span><span></span></div>
     <!-- Cancelled marker -->
     <div v-if="cancelled" class="chat-cancelled-mark">{{ t('chat.contentBlocks.cancelled') }}</div>
+    <!-- Summary toggle banner -->
+    <div v-if="summary && !streaming" class="summary-banner" @click="emit('toggle-summary')">
+      <template v-if="showingSummary">{{ t('chat.contentBlocks.summaryViewOriginal') }}</template>
+      <template v-else>{{ t('chat.contentBlocks.summaryViewSummary') }}</template>
+    </div>
   </div>
 </template>
 
@@ -150,6 +162,8 @@ const props = defineProps({
   blockAskQuestions: { type: Object, default: () => ({}) },
   streaming: { type: Boolean, default: false },
   cancelled: { type: Boolean, default: false },
+  summary: { type: String, default: null },
+  showingSummary: { type: Boolean, default: false },
   // Render functions
   renderTextBlock: { type: Function, required: true },
   formatToolInput: { type: Function, required: true },
@@ -164,7 +178,7 @@ const props = defineProps({
   active: { type: Boolean, default: true },
 })
 
-const emit = defineEmits(['toggle-tool', 'show-tool-detail', 'show-thinking-detail', 'task-card-click', 'send-message', 'render-flush'])
+const emit = defineEmits(['toggle-tool', 'show-tool-detail', 'show-thinking-detail', 'task-card-click', 'send-message', 'render-flush', 'toggle-summary'])
 
 // Key helper: use msgId if available, otherwise msgIndex
 function key(bi) {
@@ -320,6 +334,21 @@ onUnmounted(() => {
   padding: 2px 8px;
   border-radius: 4px;
   margin-top: 4px;
+}
+
+.summary-banner {
+  text-align: center;
+  font-size: 11px;
+  color: var(--text-muted, #999);
+  background: color-mix(in srgb, var(--text-muted, #999) 6%, transparent);
+  padding: 4px 0;
+  margin-top: 6px;
+  border-radius: 4px;
+  cursor: pointer;
+  user-select: none;
+}
+.summary-banner:hover {
+  background: color-mix(in srgb, var(--text-muted, #999) 10%, transparent);
 }
 
 .chat-error-card {

--- a/web/src/components/common/SummaryToggle.vue
+++ b/web/src/components/common/SummaryToggle.vue
@@ -1,0 +1,109 @@
+<template>
+  <!-- Button mode: inline toggle in chat meta bar -->
+  <button v-if="mode === 'button'" class="summary-toggle-btn" @click.stop="$emit('toggle')">
+    <Sparkles v-if="!showingSummary" :size="14" />
+    <FileText v-else :size="14" />
+    <span>{{ showingSummary ? labelOriginal : labelSummary }}</span>
+  </button>
+  <!-- Tab mode: segmented control in task exec detail -->
+  <div v-else class="summary-toggle-bar">
+    <button class="summary-toggle-tab" :class="{ active: showingSummary }" @click="!showingSummary && $emit('toggle')">
+      <Sparkles :size="14" />
+      <span>{{ labelSummary }}</span>
+    </button>
+    <button class="summary-toggle-tab" :class="{ active: !showingSummary }" @click="showingSummary && $emit('toggle')">
+      <FileText :size="14" />
+      <span>{{ labelOriginal }}</span>
+    </button>
+  </div>
+</template>
+
+<script setup>
+import { computed } from 'vue'
+import { Sparkles, FileText } from 'lucide-vue-next'
+import { useI18n } from 'vue-i18n'
+
+const props = defineProps({
+  /** Display mode: 'button' for chat meta bar, 'tab' for task exec detail */
+  mode: { type: String, default: 'button' },
+  /** Whether the summary view is currently shown */
+  showingSummary: { type: Boolean, default: false },
+  /** i18n key prefix for labels (e.g. 'chat.message' or 'task.exec') */
+  i18nPrefix: { type: String, default: 'chat.message' },
+})
+
+defineEmits(['toggle'])
+
+const { t } = useI18n()
+
+// Tab mode uses short labels (tabSummary/tabOriginal), button mode uses action labels (summaryViewSummary/summaryViewOriginal)
+const labelSummary = computed(() => t(`${props.i18nPrefix}.${props.mode === 'tab' ? 'tabSummary' : 'summaryViewSummary'}`))
+const labelOriginal = computed(() => t(`${props.i18nPrefix}.${props.mode === 'tab' ? 'tabOriginal' : 'summaryViewOriginal'}`))
+</script>
+
+<style scoped>
+/* ── Button mode ── */
+.summary-toggle-btn {
+  flex-shrink: 0;
+  min-width: 22px;
+  height: 22px;
+  padding: 0 8px;
+  border: none;
+  background: transparent;
+  color: var(--text-secondary);
+  cursor: pointer;
+  border-radius: 4px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 4px;
+  opacity: 1;
+  transition: opacity 0.2s, background 0.2s;
+  font-size: 11px;
+}
+
+.summary-toggle-btn:hover {
+  background: var(--bg-tertiary);
+}
+
+/* ── Tab mode ── */
+.summary-toggle-bar {
+  display: flex;
+  gap: 4px;
+  margin-bottom: 12px;
+  background: var(--bg-secondary, #f1f5f9);
+  border-radius: 8px;
+  padding: 3px;
+}
+
+.summary-toggle-tab {
+  flex: 1;
+  border: none;
+  background: transparent;
+  color: var(--text-secondary, #6b7280);
+  font-size: 13px;
+  font-weight: 500;
+  padding: 6px 12px;
+  border-radius: 6px;
+  cursor: pointer;
+  transition: all 0.2s ease;
+  text-align: center;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 4px;
+}
+
+.summary-toggle-tab.active {
+  background: var(--bg-tertiary, #e2e8f0);
+  color: var(--text-primary, #1a1a1a);
+  font-weight: 500;
+}
+
+@media (hover: hover) {
+  .summary-toggle-tab:not(.active):hover {
+    color: var(--text-primary, #1a1a1a);
+    background: var(--bg-tertiary, #e2e8f0);
+  }
+}
+</style>

--- a/web/src/components/common/__tests__/SummaryToggle.test.ts
+++ b/web/src/components/common/__tests__/SummaryToggle.test.ts
@@ -1,0 +1,177 @@
+import { describe, expect, it, vi } from 'vitest'
+import { mount } from '@vue/test-utils'
+import SummaryToggle from '@/components/common/SummaryToggle.vue'
+
+// Mock vue-i18n so computed labels resolve
+vi.mock('vue-i18n', () => ({
+  useI18n: () => ({
+    t: (key: string) => {
+      const map: Record<string, string> = {
+        'chat.message.summaryViewSummary': 'View Summary',
+        'chat.message.summaryViewOriginal': 'View Original',
+        'task.exec.tabSummary': 'Summary',
+        'task.exec.tabOriginal': 'Original',
+      }
+      return map[key] ?? key
+    },
+  }),
+}))
+
+describe('SummaryToggle', () => {
+  function mountToggle(props: Record<string, any> = {}) {
+    return mount(SummaryToggle, {
+      props: {
+        mode: 'button',
+        showingSummary: false,
+        i18nPrefix: 'chat.message',
+        ...props,
+      },
+    })
+  }
+
+  // ── Button mode ──
+
+  describe('button mode', () => {
+    it('renders a button element', () => {
+      const wrapper = mountToggle({ mode: 'button' })
+      expect(wrapper.find('.summary-toggle-btn').exists()).toBe(true)
+    })
+
+    it('shows "View Summary" label when showingSummary is false', () => {
+      const wrapper = mountToggle({ mode: 'button', showingSummary: false })
+      expect(wrapper.text()).toContain('View Summary')
+    })
+
+    it('shows "View Original" label when showingSummary is true', () => {
+      const wrapper = mountToggle({ mode: 'button', showingSummary: true })
+      expect(wrapper.text()).toContain('View Original')
+    })
+
+    it('emits toggle when clicked', async () => {
+      const wrapper = mountToggle({ mode: 'button' })
+      await wrapper.find('.summary-toggle-btn').trigger('click')
+      expect(wrapper.emitted('toggle')).toHaveLength(1)
+    })
+
+    it('click propagation is stopped', async () => {
+      const wrapper = mountToggle({ mode: 'button' })
+      // The @click.stop modifier should be on the button
+      const btn = wrapper.find('.summary-toggle-btn')
+      expect(btn.exists()).toBe(true)
+      await btn.trigger('click')
+      expect(wrapper.emitted('toggle')).toHaveLength(1)
+    })
+
+    it('uses chat.message i18n prefix for labels', () => {
+      const wrapper = mountToggle({ mode: 'button', i18nPrefix: 'chat.message' })
+      expect(wrapper.text()).toContain('View Summary')
+    })
+
+    it('toggles label when showingSummary prop changes', async () => {
+      const wrapper = mountToggle({ mode: 'button', showingSummary: false })
+      expect(wrapper.text()).toContain('View Summary')
+
+      await wrapper.setProps({ showingSummary: true })
+      expect(wrapper.text()).toContain('View Original')
+    })
+  })
+
+  // ── Tab mode ──
+
+  describe('tab mode', () => {
+    it('renders tab bar element', () => {
+      const wrapper = mountToggle({ mode: 'tab' })
+      expect(wrapper.find('.summary-toggle-bar').exists()).toBe(true)
+    })
+
+    it('renders two tab buttons', () => {
+      const wrapper = mountToggle({ mode: 'tab' })
+      const tabs = wrapper.findAll('.summary-toggle-tab')
+      expect(tabs).toHaveLength(2)
+    })
+
+    it('marks summary tab as active when showingSummary is true', () => {
+      const wrapper = mountToggle({ mode: 'tab', showingSummary: true })
+      const tabs = wrapper.findAll('.summary-toggle-tab')
+      expect(tabs[0].classes()).toContain('active')
+      expect(tabs[1].classes()).not.toContain('active')
+    })
+
+    it('marks original tab as active when showingSummary is false', () => {
+      const wrapper = mountToggle({ mode: 'tab', showingSummary: false })
+      const tabs = wrapper.findAll('.summary-toggle-tab')
+      expect(tabs[0].classes()).not.toContain('active')
+      expect(tabs[1].classes()).toContain('active')
+    })
+
+    it('shows "Summary" and "Original" tab labels using task.exec prefix', () => {
+      const wrapper = mountToggle({ mode: 'tab', i18nPrefix: 'task.exec' })
+      expect(wrapper.text()).toContain('Summary')
+      expect(wrapper.text()).toContain('Original')
+    })
+
+    it('emits toggle when clicking summary tab while showing original', async () => {
+      const wrapper = mountToggle({ mode: 'tab', showingSummary: false })
+      const tabs = wrapper.findAll('.summary-toggle-tab')
+      // Click the summary tab (first tab) when not showing summary
+      await tabs[0].trigger('click')
+      expect(wrapper.emitted('toggle')).toHaveLength(1)
+    })
+
+    it('does not emit toggle when clicking already-active summary tab', async () => {
+      const wrapper = mountToggle({ mode: 'tab', showingSummary: true })
+      const tabs = wrapper.findAll('.summary-toggle-tab')
+      // Click the summary tab (first tab) when already showing summary
+      await tabs[0].trigger('click')
+      expect(wrapper.emitted('toggle')).toBeUndefined()
+    })
+
+    it('emits toggle when clicking original tab while showing summary', async () => {
+      const wrapper = mountToggle({ mode: 'tab', showingSummary: true })
+      const tabs = wrapper.findAll('.summary-toggle-tab')
+      // Click the original tab (second tab) when showing summary
+      await tabs[1].trigger('click')
+      expect(wrapper.emitted('toggle')).toHaveLength(1)
+    })
+
+    it('does not emit toggle when clicking already-active original tab', async () => {
+      const wrapper = mountToggle({ mode: 'tab', showingSummary: false })
+      const tabs = wrapper.findAll('.summary-toggle-tab')
+      // Click the original tab (second tab) when already showing original
+      await tabs[1].trigger('click')
+      expect(wrapper.emitted('toggle')).toBeUndefined()
+    })
+
+    it('updates active state when showingSummary prop changes', async () => {
+      const wrapper = mountToggle({ mode: 'tab', showingSummary: false })
+      let tabs = wrapper.findAll('.summary-toggle-tab')
+      expect(tabs[1].classes()).toContain('active')
+
+      await wrapper.setProps({ showingSummary: true })
+      tabs = wrapper.findAll('.summary-toggle-tab')
+      expect(tabs[0].classes()).toContain('active')
+      expect(tabs[1].classes()).not.toContain('active')
+    })
+  })
+
+  // ── Default props ──
+
+  describe('default props', () => {
+    it('defaults mode to button', () => {
+      const wrapper = mount(SummaryToggle)
+      expect(wrapper.find('.summary-toggle-btn').exists()).toBe(true)
+    })
+
+    it('defaults showingSummary to false', () => {
+      const wrapper = mount(SummaryToggle)
+      // In button mode, showingSummary=false means "View Summary" label
+      expect(wrapper.text()).toContain('View Summary')
+    })
+
+    it('defaults i18nPrefix to chat.message', () => {
+      const wrapper = mount(SummaryToggle)
+      // With default i18nPrefix, button mode shows summaryViewSummary/summaryViewOriginal keys
+      expect(wrapper.text()).toContain('View Summary')
+    })
+  })
+})

--- a/web/src/components/task/TaskExecDetail.vue
+++ b/web/src/components/task/TaskExecDetail.vue
@@ -11,10 +11,7 @@
     <!-- Scrollable message content -->
     <div class="exec-detail-content" ref="contentRef" @click="handleContentClick">
       <!-- Summary / Original tab bar -->
-      <div v-if="hasSummary" class="exec-tab-bar">
-        <button class="exec-tab-btn" :class="{ active: activeTab === 'summary' }" @click="setTab('summary')">📌 总结</button>
-        <button class="exec-tab-btn" :class="{ active: activeTab === 'original' }" @click="setTab('original')">📄 原文</button>
-      </div>
+      <SummaryToggle v-if="hasSummary" mode="tab" :showing-summary="activeTab === 'summary'" i18n-prefix="task.exec" @toggle="setTab(activeTab === 'summary' ? 'original' : 'summary')" />
       <ChatMessageItem
         v-if="activeMsgData"
         :msg="activeMsgData"
@@ -69,6 +66,7 @@ import TaskBreadcrumb from '@/components/task/TaskBreadcrumb.vue'
 import ChatMessageItem from '@/components/chat/ChatMessageItem.vue'
 import ToolDetailOverlay from '@/components/chat/ToolDetailOverlay.vue'
 import ChatMetadataModal from '@/components/chat/ChatMetadataModal.vue'
+import SummaryToggle from '@/components/common/SummaryToggle.vue'
 import { useChatRender } from '@/composables/useChatRender.ts'
 import { useAgents } from '@/composables/useAgents'
 import { useFilePathAnnotation } from '@/composables/useFilePathAnnotation.ts'
@@ -366,43 +364,6 @@ onUnmounted(() => {
   flex: 1;
   overflow-y: auto;
   padding: 12px 8px;
-}
-
-.exec-tab-bar {
-  display: flex;
-  gap: 4px;
-  margin-bottom: 12px;
-  background: var(--bg-secondary, #f1f5f9);
-  border-radius: 8px;
-  padding: 3px;
-}
-
-.exec-tab-btn {
-  flex: 1;
-  border: none;
-  background: transparent;
-  color: var(--text-secondary, #6b7280);
-  font-size: 13px;
-  font-weight: 500;
-  padding: 6px 12px;
-  border-radius: 6px;
-  cursor: pointer;
-  transition: all 0.2s ease;
-  text-align: center;
-}
-
-.exec-tab-btn.active {
-  background: var(--bg-primary, #ffffff);
-  color: var(--text-primary, #1a1a1a);
-  font-weight: 600;
-  box-shadow: 0 1px 3px rgba(0, 0, 0, 0.08);
-}
-
-@media (hover: hover) {
-  .exec-tab-btn:not(.active):hover {
-    color: var(--text-primary, #1a1a1a);
-    background: var(--bg-tertiary, #e2e8f0);
-  }
 }
 
 .exec-detail-empty {

--- a/web/src/components/task/TaskHistoryTab.vue
+++ b/web/src/components/task/TaskHistoryTab.vue
@@ -28,11 +28,8 @@
               <template v-if="isRunning(exec)">
                 <span class="exec-running-dot"></span>
                 <span class="exec-running-label">{{ t('task.exec.running') }}</span>
-                <span class="exec-relative-time">{{ formatRelativeTime(exec.createdAt) }}</span>
               </template>
               <template v-else>
-                <span class="exec-absolute-time">{{ formatAbsoluteTime(exec.createdAt) }}</span>
-                <span class="exec-relative-time">{{ formatRelativeTime(exec.createdAt) }}</span>
                 <span v-if="isUnreadDisplay(exec)" class="exec-unread-dot"></span>
               </template>
               <span v-if="exec.triggerType === 'manual'" class="exec-trigger-type manual">{{ t('task.exec.manual') }}</span>
@@ -83,7 +80,7 @@ import { useI18n } from 'vue-i18n'
 import { Square, Loader2, History, Trash2, RefreshCw } from 'lucide-vue-next'
 import TaskBreadcrumb from '@/components/task/TaskBreadcrumb.vue'
 import { useTaskHistory } from '@/composables/useTaskHistory.ts'
-import { formatDuration, formatRelativeTime } from '@/utils/format.ts'
+import { formatDuration } from '@/utils/format.ts'
 
 const props = defineProps({
   task: Object,
@@ -136,17 +133,6 @@ function formatTokens(meta) {
   if (meta.inputTokens) parts.push(`${meta.inputTokens.toLocaleString()}↑`)
   if (meta.outputTokens) parts.push(`${meta.outputTokens.toLocaleString()}↓`)
   return parts.join(' ')
-}
-
-function formatAbsoluteTime(createdAt) {
-  const d = new Date(createdAt)
-  const y = d.getFullYear()
-  const mo = String(d.getMonth() + 1).padStart(2, '0')
-  const day = String(d.getDate()).padStart(2, '0')
-  const h = String(d.getHours()).padStart(2, '0')
-  const mi = String(d.getMinutes()).padStart(2, '0')
-  const s = String(d.getSeconds()).padStart(2, '0')
-  return `${y}-${mo}-${day} ${h}:${mi}:${s}`
 }
 
 /** Set up IntersectionObserver for infinite scroll */
@@ -350,20 +336,6 @@ onUnmounted(() => {
   display: flex;
   align-items: center;
   gap: 8px;
-}
-
-.exec-absolute-time {
-  font-size: 13px;
-  color: var(--text-primary, #1a1a1a);
-  font-weight: 600;
-  font-variant-numeric: tabular-nums;
-  white-space: nowrap;
-}
-
-.exec-relative-time {
-  font-size: 12px;
-  color: var(--text-muted, #9ca3af);
-  white-space: nowrap;
 }
 
 /* ── Unread dot (static) ── */

--- a/web/src/composables/__tests__/useAutoSpeech.test.ts
+++ b/web/src/composables/__tests__/useAutoSpeech.test.ts
@@ -1,5 +1,5 @@
-import { describe, expect, it, vi } from 'vitest'
-import { extractSpeakableText } from '@/composables/useAutoSpeech'
+import { describe, expect, it, vi, beforeEach, afterEach } from 'vitest'
+import { extractSpeakableText, useAutoSpeech } from '@/composables/useAutoSpeech'
 
 // Mock useToast since it's used at module level
 vi.mock('@/composables/useToast', () => ({
@@ -237,5 +237,62 @@ describe('extractSpeakableText', () => {
     ]
     const result = extractSpeakableText(blocks)
     expect(result).toBe('Hello')
+  })
+})
+
+// ── TTS generation with messageId ──
+
+describe('useAutoSpeech._speak — TTS body includes messageId', () => {
+  let fetchSpy: ReturnType<typeof vi.fn>
+
+  beforeEach(() => {
+    fetchSpy = vi.fn()
+    globalThis.fetch = fetchSpy
+  })
+
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  it('includes messageId in TTS request body when id is numeric', async () => {
+    // Mock a cached TTS response (simplest path: no EventSource needed)
+    fetchSpy.mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({ cached: true, audioPath: '/tts/test.mp3' }),
+    })
+
+    // Mock Audio constructor to prevent actual playback
+    const mockAudio = { play: vi.fn().mockResolvedValue(undefined), pause: vi.fn() }
+    vi.stubGlobal('Audio', vi.fn(() => mockAudio))
+
+    const { speakText } = useAutoSpeech()
+    await speakText('42', 'Hello world')
+
+    // Verify fetch was called with messageId in the body
+    expect(fetchSpy).toHaveBeenCalledTimes(1)
+    const [url, options] = fetchSpy.mock.calls[0]
+    expect(url).toBe('/api/tts/generate')
+    const body = JSON.parse(options.body)
+    expect(body.text).toBe('Hello world')
+    expect(body.messageId).toBe(42)
+  })
+
+  it('omits messageId when id is not a numeric string', async () => {
+    fetchSpy.mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({ cached: true, audioPath: '/tts/test.mp3' }),
+    })
+
+    const mockAudio = { play: vi.fn().mockResolvedValue(undefined), pause: vi.fn() }
+    vi.stubGlobal('Audio', vi.fn(() => mockAudio))
+
+    const { speakText } = useAutoSpeech()
+    await speakText('abc-123', 'Test text')
+
+    expect(fetchSpy).toHaveBeenCalledTimes(1)
+    const [, options] = fetchSpy.mock.calls[0]
+    const body = JSON.parse(options.body)
+    expect(body.text).toBe('Test text')
+    expect(body.messageId).toBeUndefined()
   })
 })

--- a/web/src/composables/useAutoSpeech.ts
+++ b/web/src/composables/useAutoSpeech.ts
@@ -164,10 +164,13 @@ export function useAutoSpeech() {
 
     try {
       // Step 1: POST to create TTS job (or get cached result)
+      const body: any = { text, language: i18n.global.locale.value }
+      const msgId = parseInt(id, 10)
+      if (!isNaN(msgId)) body.messageId = msgId
       const resp = await fetch('/api/tts/generate', {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ text, language: i18n.global.locale.value }),
+        body: JSON.stringify(body),
         signal: controller.signal,
       })
 

--- a/web/src/composables/useGlobalEvents.ts
+++ b/web/src/composables/useGlobalEvents.ts
@@ -174,6 +174,11 @@ function connect() {
                     handler(msg.event!, msg.data)
                 }
 
+                // Dispatch summary_update as a custom event for ChatPanelContent
+                if (msg.event === 'summary_update' && msg.data?.targetType === 'chat_message') {
+                    window.dispatchEvent(new CustomEvent('clawbench-summary-update', { detail: msg.data }))
+                }
+
                 // Send ack
                 if (msg.id) {
                     send({ type: 'ack', id: msg.id })

--- a/web/src/i18n/locales/en.ts
+++ b/web/src/i18n/locales/en.ts
@@ -146,6 +146,8 @@ export default {
       viewDetails: 'View details',
       speaking: 'Speaking',
       readAloud: 'Read',
+      summaryViewOriginal: 'View Original',
+      summaryViewSummary: 'View Summary',
       deepThinking: 'Thinking',
     },
     speech: {
@@ -371,6 +373,8 @@ export default {
       allExecutionsDeleted: 'All execution records cleared',
       clearAll: 'Clear all',
       completed: 'Execution completed',
+      tabOriginal: 'Original',
+      tabSummary: 'Summary',
     },
   },
   file: {

--- a/web/src/i18n/locales/en.ts
+++ b/web/src/i18n/locales/en.ts
@@ -202,6 +202,8 @@ export default {
       repeat: 'Repeat:',
       prompt: 'Prompt:',
       cancelled: 'Cancelled',
+      summaryViewOriginal: 'AI summarized · View original',
+      summaryViewSummary: 'View summary',
       loading: 'Loading...',
       pause: 'Disable',
       resume: 'Enable',

--- a/web/src/i18n/locales/zh.ts
+++ b/web/src/i18n/locales/zh.ts
@@ -146,6 +146,8 @@ export default {
       viewDetails: '查看详情',
       speaking: '朗读中',
       readAloud: '朗读',
+      summaryViewOriginal: '查看原文',
+      summaryViewSummary: '查看摘要',
       deepThinking: '深度思考',
     },
     speech: {
@@ -371,6 +373,8 @@ export default {
       allExecutionsDeleted: '执行记录已清除',
       clearAll: '清除全部',
       completed: '执行完毕',
+      tabOriginal: '原文',
+      tabSummary: '摘要',
     },
   },
   file: {

--- a/web/src/i18n/locales/zh.ts
+++ b/web/src/i18n/locales/zh.ts
@@ -202,6 +202,8 @@ export default {
       repeat: '重复：',
       prompt: '提示词：',
       cancelled: '已中断',
+      summaryViewOriginal: 'AI 已精简总结 · 查看原文',
+      summaryViewSummary: '查看精简总结',
       loading: '加载中...',
       pause: '禁用',
       resume: '启用',

--- a/web/src/utils/__tests__/chatSessionUtils.test.ts
+++ b/web/src/utils/__tests__/chatSessionUtils.test.ts
@@ -227,6 +227,40 @@ describe('parseMessages', () => {
     // 42 is truthy, so blocks = [{ type: 'text', text: 42 }]
     expect(result[0].blocks).toEqual([{ type: 'text', text: 42 }])
   })
+
+  // ── showingSummary auto-set for assistant messages with summary ──
+
+  it('sets showingSummary=true for assistant messages with non-empty summary', () => {
+    const msgs = [
+      { role: 'assistant', content: JSON.stringify({ blocks: [{ type: 'text', text: 'Hello' }] }), summary: 'A brief summary' },
+    ]
+    const result = parseMessages(msgs, mockParser)
+    expect(result[0].showingSummary).toBe(true)
+  })
+
+  it('sets showingSummary=false for assistant messages with empty summary', () => {
+    const msgs = [
+      { role: 'assistant', content: JSON.stringify({ blocks: [{ type: 'text', text: 'Hello' }] }), summary: '' },
+    ]
+    const result = parseMessages(msgs, mockParser)
+    expect(result[0].showingSummary).toBe(false)
+  })
+
+  it('sets showingSummary=false for assistant messages with null summary', () => {
+    const msgs = [
+      { role: 'assistant', content: JSON.stringify({ blocks: [{ type: 'text', text: 'Hello' }] }), summary: null },
+    ]
+    const result = parseMessages(msgs, mockParser)
+    expect(result[0].showingSummary).toBe(false)
+  })
+
+  it('sets showingSummary=false for assistant messages without summary field', () => {
+    const msgs = [
+      { role: 'assistant', content: JSON.stringify({ blocks: [{ type: 'text', text: 'Hello' }] }) },
+    ]
+    const result = parseMessages(msgs, mockParser)
+    expect(result[0].showingSummary).toBe(false)
+  })
 })
 
 function customParser(content: string) {

--- a/web/src/utils/chatSessionUtils.ts
+++ b/web/src/utils/chatSessionUtils.ts
@@ -28,6 +28,12 @@ export function parseMessages(
       if (metadata) msg.metadata = metadata
       if (cancelled) msg.cancelled = cancelled
       if (msg.streaming) { msg.streaming = true; msg.fromDB = true }
+      // Auto-show summary for messages that have a non-empty summary
+      if (msg.summary != null && msg.summary !== '') {
+        msg.showingSummary = true
+      } else {
+        msg.showingSummary = false
+      }
     } else if (msg.role === 'user' && !msg.blocks) {
       // User messages also use ContentBlocks for unified rendering & auto-collapse
       msg.blocks = msg.content ? [{ type: 'text', text: msg.content }] : []


### PR DESCRIPTION
## Summary

- **feat**: Add chat message auto-summary with unified summaries table
- **refactor**: Extract SummaryToggle.vue as reusable component with button and tab modes
- Replace inline summary banner in ContentBlocks with SummaryToggle button in ChatMessageItem meta bar
- Replace inline tab bar in TaskExecDetail with SummaryToggle tab mode
- Remove absolute/relative time display from TaskHistoryTab (moved to metadata modal)
- Add relative time to ChatMetadataModal for better UX
- Fix ChatPanelContent handleSummaryUpdate type cast (remove CustomEvent wrapper)
- Add i18n keys for summary toggle labels (en/zh)
- **test**: Add 26 new unit tests for CI coverage gate

## Test Coverage
- SummaryToggle: 20 tests (button mode, tab mode, default props, toggle events)
- useAutoSpeech: 2 tests (messageId in TTS request body)
- chatSessionUtils: 4 tests (showingSummary auto-set)
- Both Tier 1 (Project) and Tier 2 (Diff) coverage gates pass with 100% diff coverage