### PR TITLE
fix: 修复 Review Issues 2026-05-26

### DIFF
--- a/.clawbench/issues/ISS-127.md
+++ b/.clawbench/issues/ISS-127.md
@@ -1,0 +1,22 @@
+---
+id: ISS-127
+status: fixed
+severity: critical
+dimension: P0 - Flow Correctness
+created: 2026-05-22
+files: [internal/service/scheduler.go]
+---
+
+## Description
+`cron.ParseStandard(task.CronExpr)` at scheduler.go:660 re-parses the cron expression without checking the error. The expression was validated at creation time, but if the cron library version changes or the stored expression is somehow corrupted, this could silently produce wrong schedules — tasks simply won't execute.
+
+## Impact
+Missed task executions — a malformed or incompatible cron expression is silently ignored, with no indication that the schedule is broken.
+
+## Suggestion
+Handle the error and log it at error level. Consider also storing the parsed schedule alongside the expression to avoid re-parsing.
+
+## History
+- 2026-05-22: Created by review 2026-05-22
+- 2026-05-23: Suspected resolved (code changed in [internal/service/scheduler.go])
+- 2025-07-24: Verified fixed — added error handling for cron.ParseStandard at scheduler.go:672

--- a/.clawbench/issues/ISS-129.md
+++ b/.clawbench/issues/ISS-129.md
@@ -1,0 +1,22 @@
+---
+id: ISS-129
+status: fixed
+severity: critical
+dimension: P0 - Flow Correctness
+created: 2026-05-22
+files: [internal/ws/manager.go]
+---
+
+## Description
+`title := "AI任务完成"` and `alert := "AI会话已结束"` are hard-coded in Chinese in the JPush notification path, ignoring the i18n system used everywhere else. Non-Chinese users receive Chinese push notifications.
+
+## Impact
+Non-Chinese users receive push notifications in Chinese — poor UX and potential confusion for international users.
+
+## Suggestion
+Use the i18n system or at minimum make these strings configurable via the config file. Consider storing the user's locale preference and passing it to the push notification builder.
+
+## History
+- 2026-05-22: Created by review 2026-05-22
+- 2026-05-23: Suspected resolved (code changed in [internal/ws/manager.go])
+- 2025-07-24: Verified fixed — replaced hardcoded Chinese strings with i18n.T() using LocalizerForLocale(sub.locale)

--- a/.clawbench/issues/ISS-138.md
+++ b/.clawbench/issues/ISS-138.md
@@ -1,0 +1,23 @@
+---
+id: ISS-138
+status: fixed
+severity: critical
+dimension: Flow Correctness
+created: 2026-05-23
+files: [web/src/composables/useChatStream.ts]
+---
+
+## Description
+resume_split SSE event not handled by frontend EventSource listener. When AutoResumeBackend detects ExitPlanMode and auto-resumes, backend sends resume_split event through SSE. Frontend has no addEventListener('resume_split', ...) handler. Subsequent content/thinking events coalesce into pre-split message instead of creating a new assistant message.
+
+## Impact
+Single merged assistant bubble instead of two separate messages as backend intended. The guard() closure holds the old streamingMsg reference, so all post-split content incorrectly appends to the pre-split message.
+
+## Suggestion
+Add resume_split event listener that mirrors queue_consume logic: finalize current streaming message (call _forceCleanupStreamingState), create new assistant placeholder, and re-acquire streamingMsg from reactive array.
+
+## History
+- 2026-05-23: Created by review 2026-05-23
+
+- 2026-05-25: Suspected resolved (code changed in files covered by this review)
+- 2025-07-24: Verified fixed — resume_split event handler exists at useChatStream.ts:263-272, clears streaming message blocks on split

--- a/.clawbench/issues/ISS-180.md
+++ b/.clawbench/issues/ISS-180.md
@@ -1,0 +1,21 @@
+---
+id: ISS-180
+status: fixed
+severity: critical
+dimension: P0 Security
+created: 2026-05-26
+files: [internal/handler/chat.go, internal/handler/chat_stream.go, internal/handler/queue.go]
+---
+
+## Description
+The AIChat POST handler (chat.go:184-449), AIChatStream SSE endpoint (chat_stream.go:14-46), and Queue endpoints (queue.go:17-112) do not verify that the session ID belongs to the requesting project. While CancelChat and ServeChatHistory properly verify session ownership, the primary data paths skip this check.
+
+## Impact
+An authenticated user who switches projects (changing the project cookie) while retaining a chat_session_id from a different project can: (1) send messages and execute AI commands against sessions belonging to another project, (2) read another project's AI responses via SSE stream, (3) inject messages into other projects' session queues, (4) clear other projects' session queues.
+
+## Suggestion
+Add `service.GetSessionProjectPath(sessionID) != projectPath` check after resolving sessionID in AIChat POST, AIChatStream, and all Queue handlers. Return 403 Forbidden on mismatch.
+
+## History
+- 2026-05-26: Created by review 2026-05-26 (Block 1, CRIT-002/003/004)
+- 2025-07-24: Verified fixed — added GetSessionProjectPath ownership check in AIChat POST, AIChatStream, and all Queue handlers

--- a/.clawbench/issues/ISS-188.md
+++ b/.clawbench/issues/ISS-188.md
@@ -1,0 +1,21 @@
+---
+id: ISS-188
+status: fixed
+severity: critical
+dimension: P0 Flow Correctness
+created: 2026-05-26
+files: [internal/service/scheduler.go]
+---
+
+## Description
+`executeTask` never sets the `CLAWBENCH_SCHEDULED=1` environment variable when spawning the CLI backend for scheduled tasks. The anti-recursion mechanism documented in AGENTS.md relies on this env var, and the CLI `task.go` checks it (lines 325, 460). However, the env var is never actually set in the command environment.
+
+## Impact
+If the AI spawns `clawbench task create` via shell during a scheduled execution, the CLI check at line 325 won't fire, allowing recursive task creation. This could lead to unbounded task creation loops.
+
+## Suggestion
+Set `CLAWBENCH_SCHEDULED=1` in the command environment when `chatReq.ScheduledExecution == true`. This likely needs to be done in the `CLIBackend.ExecuteStream` path — add the env var to `cmd.Env` when `chatReq.ScheduledExecution` is true.
+
+## History
+- 2026-05-26: Created by review 2026-05-26 (Block 8, CRIT-005)
+- 2025-07-24: Verified fixed — ScheduledExecution: true set in ChatRequest (scheduler.go:547), CLIBackend.ExecuteStream injects CLAWBENCH_SCHEDULED=1 (cli_backend.go:43-44)

--- a/internal/handler/chat.go
+++ b/internal/handler/chat.go
@@ -83,6 +83,12 @@ func AIChat(w http.ResponseWriter, r *http.Request) {
 				writeLocalizedErrorf(w, r, http.StatusNotFound, "SessionNotFound")
 				return
 			}
+			// Verify the session belongs to the requesting project (ISS-180)
+			// Skip ownership check if session doesn't exist in DB (session auto-created below)
+			if sessionProject := service.GetSessionProjectPath(sessionID); sessionProject != "" && sessionProject != projectPath {
+				writeLocalizedError(w, r, model.Forbidden(nil, "AccessDenied"))
+				return
+			}
 	} else {
 		// No specific session requested — use lightweight query to find the most recent session
 		latestID, latestBackend, err := service.GetLatestSessionID(projectPath)
@@ -210,6 +216,14 @@ func AIChat(w http.ResponseWriter, r *http.Request) {
 	backendName := service.GetSessionBackend(sessionID)
 	if backendName == "" {
 		writeLocalizedErrorf(w, r, http.StatusBadRequest, "SessionBackendNotFound")
+		return
+	}
+
+	// Verify the session belongs to the requesting project (ISS-180)
+	// For POST, sessionID is always from a DB-backed session (auto-created above or from cookie),
+	// so an empty sessionProject means the session doesn't exist — will fail at backendName check.
+	if sessionProject := service.GetSessionProjectPath(sessionID); sessionProject != "" && sessionProject != projectPath {
+		writeLocalizedError(w, r, model.Forbidden(nil, "AccessDenied"))
 		return
 	}
 

--- a/internal/handler/chat_stream.go
+++ b/internal/handler/chat_stream.go
@@ -7,6 +7,7 @@ import (
 	"net/http"
 	"time"
 
+	"clawbench/internal/model"
 	"clawbench/internal/service"
 )
 
@@ -16,7 +17,7 @@ func AIChatStream(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	_, ok := requireProject(w, r)
+	projectPath, ok := requireProject(w, r)
 	if !ok {
 		return
 	}
@@ -27,6 +28,13 @@ func AIChatStream(w http.ResponseWriter, r *http.Request) {
 	}
 	if sessionID == "" {
 		writeLocalizedErrorf(w, r, http.StatusBadRequest, "SessionIdRequired")
+		return
+	}
+
+	// Verify the session belongs to the requesting project (ISS-180)
+	// Skip ownership check if session doesn't exist in DB (not-yet-persisted or in-memory only)
+	if sessionProject := service.GetSessionProjectPath(sessionID); sessionProject != "" && sessionProject != projectPath {
+		writeLocalizedError(w, r, model.Forbidden(nil, "AccessDenied"))
 		return
 	}
 

--- a/internal/handler/chat_stream_test.go
+++ b/internal/handler/chat_stream_test.go
@@ -717,3 +717,22 @@ func TestAIChatStream_ClientDisconnectDuringStream(t *testing.T) {
 	reason := service.GetAndClearCancelReason(sessionID)
 	assert.Equal(t, "disconnect", reason)
 }
+
+// ---------- Session ownership validation (ISS-180) ----------
+
+func TestAIChatStream_SessionBelongsToDifferentProject(t *testing.T) {
+	env, teardown := setupTestEnv(t)
+	defer teardown()
+
+	// Create a session that belongs to a different project
+	otherProject := "/other-project"
+	sessionID, err := service.CreateSession(otherProject, "claude", "Other Session", "claude", "", "default", "chat")
+	require.NoError(t, err)
+
+	// Try to stream that session using the current project's cookie
+	req := newRequest(t, http.MethodGet, "/api/ai/chat/stream?session_id="+sessionID, nil)
+	req = withProjectCookie(req, env.ProjectDir) // different project
+	w := callHandler(AIChatStream, req)
+
+	assertStatus(t, w, http.StatusForbidden)
+}

--- a/internal/handler/chat_test.go
+++ b/internal/handler/chat_test.go
@@ -1519,6 +1519,66 @@ func TestConvertAskQuestionBlocks_ObfuscatedCloseTag(t *testing.T) {
 	}
 }
 
+// ---------- Session ownership validation (ISS-180) — AIChat handler ----------
+
+// TestAIChat_Get_SessionBelongsToDifferentProject verifies that the GET path
+// in AIChat rejects access to a session that belongs to another project.
+func TestAIChat_Get_SessionBelongsToDifferentProject(t *testing.T) {
+	env, teardown := setupTestEnv(t)
+	defer teardown()
+
+	// Create a session that belongs to a different project
+	otherProject := "/other-project-chat-get"
+	sessionID, err := service.CreateSession(otherProject, "claude", "Other Session", "claude", "", "default", "chat")
+	assert.NoError(t, err)
+
+	// GET with a session_id belonging to another project → Forbidden
+	req := newRequest(t, http.MethodGet, "/api/ai/chat?session_id="+sessionID, nil)
+	req = withProjectCookie(req, env.ProjectDir)
+	w := callHandler(AIChat, req)
+
+	assertStatus(t, w, http.StatusForbidden)
+}
+
+// TestAIChat_Get_SessionBelongsToSameProject verifies that the GET path
+// in AIChat allows access to a session that belongs to the requesting project.
+func TestAIChat_Get_SessionBelongsToSameProject(t *testing.T) {
+	env, teardown := setupTestEnv(t)
+	defer teardown()
+
+	// Create a session that belongs to the same project
+	sessionID, err := service.CreateSession(env.ProjectDir, "claude", "Same Session", "claude", "", "default", "chat")
+	assert.NoError(t, err)
+
+	// GET with a session_id belonging to same project → OK
+	req := newRequest(t, http.MethodGet, "/api/ai/chat?session_id="+sessionID, nil)
+	req = withProjectCookie(req, env.ProjectDir)
+	w := callHandler(AIChat, req)
+
+	assert.Equal(t, http.StatusOK, w.Code)
+}
+
+// TestAIChat_Post_SessionBelongsToDifferentProject verifies that the POST path
+// in AIChat rejects access to a session that belongs to another project.
+func TestAIChat_Post_SessionBelongsToDifferentProject(t *testing.T) {
+	env, teardown := setupTestEnv(t)
+	defer teardown()
+
+	// Create a session that belongs to a different project
+	otherProject := "/other-project-chat-post"
+	sessionID, err := service.CreateSession(otherProject, "claude", "Other Session", "claude", "", "default", "chat")
+	assert.NoError(t, err)
+
+	// POST with a session cookie pointing to another project's session → Forbidden
+	body := map[string]any{"message": "hello"}
+	req := newRequest(t, http.MethodPost, "/api/ai/chat", body)
+	req = withProjectCookie(req, env.ProjectDir)
+	req = withSessionCookie(req, sessionID)
+	w := callHandler(AIChat, req)
+
+	assertStatus(t, w, http.StatusForbidden)
+}
+
 // ============================================================================
 // buildChatRequest external session ID tests
 // ============================================================================

--- a/internal/handler/queue.go
+++ b/internal/handler/queue.go
@@ -28,9 +28,21 @@ func QueueHandler(w http.ResponseWriter, r *http.Request) {
 }
 
 func handleQueueEnqueue(w http.ResponseWriter, r *http.Request) {
+	projectPath, ok := requireProject(w, r)
+	if !ok {
+		return
+	}
+
 	sessionID := r.URL.Query().Get("session_id")
 	if sessionID == "" {
 		writeLocalizedErrorf(w, r, http.StatusBadRequest, "SessionIdRequired")
+		return
+	}
+
+	// Verify the session belongs to the requesting project (ISS-180)
+	// Skip ownership check if session doesn't exist in DB (not-yet-persisted or in-memory only)
+	if sessionProject := service.GetSessionProjectPath(sessionID); sessionProject != "" && sessionProject != projectPath {
+		writeLocalizedError(w, r, model.Forbidden(nil, "AccessDenied"))
 		return
 	}
 
@@ -64,9 +76,21 @@ func handleQueueEnqueue(w http.ResponseWriter, r *http.Request) {
 }
 
 func handleQueueGet(w http.ResponseWriter, r *http.Request) {
+	projectPath, ok := requireProject(w, r)
+	if !ok {
+		return
+	}
+
 	sessionID := r.URL.Query().Get("session_id")
 	if sessionID == "" {
 		writeLocalizedErrorf(w, r, http.StatusBadRequest, "SessionIdRequired")
+		return
+	}
+
+	// Verify the session belongs to the requesting project (ISS-180)
+	// Skip ownership check if session doesn't exist in DB (not-yet-persisted or in-memory only)
+	if sessionProject := service.GetSessionProjectPath(sessionID); sessionProject != "" && sessionProject != projectPath {
+		writeLocalizedError(w, r, model.Forbidden(nil, "AccessDenied"))
 		return
 	}
 
@@ -80,9 +104,21 @@ func handleQueueGet(w http.ResponseWriter, r *http.Request) {
 }
 
 func handleQueueDelete(w http.ResponseWriter, r *http.Request) {
+	projectPath, ok := requireProject(w, r)
+	if !ok {
+		return
+	}
+
 	sessionID := r.URL.Query().Get("session_id")
 	if sessionID == "" {
 		writeLocalizedErrorf(w, r, http.StatusBadRequest, "SessionIdRequired")
+		return
+	}
+
+	// Verify the session belongs to the requesting project (ISS-180)
+	// Skip ownership check if session doesn't exist in DB (not-yet-persisted or in-memory only)
+	if sessionProject := service.GetSessionProjectPath(sessionID); sessionProject != "" && sessionProject != projectPath {
+		writeLocalizedError(w, r, model.Forbidden(nil, "AccessDenied"))
 		return
 	}
 

--- a/internal/handler/queue_test.go
+++ b/internal/handler/queue_test.go
@@ -438,10 +438,68 @@ func TestQueueHandler_Delete_SessionBelongsToSameProject(t *testing.T) {
 	service.EnqueueMessage(sessionID, model.QueuedMessage{
 		Text: "msg1", CreatedAt: time.Now().Format(time.RFC3339),
 	})
+	service.EnqueueMessage(sessionID, model.QueuedMessage{
+		Text: "msg2", CreatedAt: time.Now().Format(time.RFC3339),
+	})
 
+	// Test clear all
 	req := newRequest(t, http.MethodDelete, "/api/ai/queue?session_id="+sessionID, nil)
 	req = withProjectCookie(req, env.ProjectDir)
 	w := callHandler(QueueHandler, req)
 
 	assertOK(t, w)
+}
+
+// TestQueueHandler_DeleteByIndex_SessionBelongsToSameProject verifies that
+// delete by index succeeds when the session belongs to the requesting project.
+func TestQueueHandler_DeleteByIndex_SessionBelongsToSameProject(t *testing.T) {
+	env, teardown := setupTestEnv(t)
+	defer teardown()
+
+	sessionID, err := service.CreateSession(env.ProjectDir, "claude", "Same Project Session", "claude", "", "default", "chat")
+	assert.NoError(t, err)
+	defer service.ClearQueue(sessionID)
+
+	service.EnqueueMessage(sessionID, model.QueuedMessage{
+		Text: "msg1", CreatedAt: time.Now().Format(time.RFC3339),
+	})
+	service.EnqueueMessage(sessionID, model.QueuedMessage{
+		Text: "msg2", CreatedAt: time.Now().Format(time.RFC3339),
+	})
+	service.EnqueueMessage(sessionID, model.QueuedMessage{
+		Text: "msg3", CreatedAt: time.Now().Format(time.RFC3339),
+	})
+
+	// Delete item at index 1
+	req := newRequest(t, http.MethodDelete, "/api/ai/queue?session_id="+sessionID+"&index=1", nil)
+	req = withProjectCookie(req, env.ProjectDir)
+	w := callHandler(QueueHandler, req)
+
+	assertOK(t, w)
+	var result map[string]any
+	json.Unmarshal(w.Body.Bytes(), &result)
+	assert.Equal(t, true, result["ok"])
+	queue := result["queue"].([]any)
+	assert.Len(t, queue, 2)
+}
+
+// TestQueueHandler_InvalidIndex_SameProject verifies that delete with invalid
+// index returns 400 when the session belongs to the requesting project.
+func TestQueueHandler_InvalidIndex_SameProject(t *testing.T) {
+	env, teardown := setupTestEnv(t)
+	defer teardown()
+
+	sessionID, err := service.CreateSession(env.ProjectDir, "claude", "Same Project Session", "claude", "", "default", "chat")
+	assert.NoError(t, err)
+	defer service.ClearQueue(sessionID)
+
+	service.EnqueueMessage(sessionID, model.QueuedMessage{
+		Text: "msg1", CreatedAt: time.Now().Format(time.RFC3339),
+	})
+
+	req := newRequest(t, http.MethodDelete, "/api/ai/queue?session_id="+sessionID+"&index=abc", nil)
+	req = withProjectCookie(req, env.ProjectDir)
+	w := callHandler(QueueHandler, req)
+
+	assertStatus(t, w, http.StatusBadRequest)
 }

--- a/internal/handler/queue_test.go
+++ b/internal/handler/queue_test.go
@@ -376,3 +376,72 @@ func TestQueueHandler_Delete_SessionBelongsToDifferentProject(t *testing.T) {
 
 	assertStatus(t, w, http.StatusForbidden)
 }
+
+// TestQueueHandler_Enqueue_SessionBelongsToSameProject verifies that enqueue
+// succeeds when the session belongs to the requesting project (ISS-180).
+func TestQueueHandler_Enqueue_SessionBelongsToSameProject(t *testing.T) {
+	env, teardown := setupTestEnv(t)
+	defer teardown()
+
+	// Create a session that belongs to the same project
+	sessionID, err := service.CreateSession(env.ProjectDir, "claude", "Same Project Session", "claude", "", "default", "chat")
+	assert.NoError(t, err)
+	defer service.ClearQueue(sessionID)
+
+	body := map[string]any{"message": "hello world"}
+	req := newRequest(t, http.MethodPost, "/api/ai/queue?session_id="+sessionID, body)
+	req = withProjectCookie(req, env.ProjectDir)
+	w := callHandler(QueueHandler, req)
+
+	assertOK(t, w)
+	var result map[string]any
+	json.Unmarshal(w.Body.Bytes(), &result)
+	assert.Equal(t, true, result["ok"])
+}
+
+// TestQueueHandler_Get_SessionBelongsToSameProject verifies that get succeeds
+// when the session belongs to the requesting project (ISS-180).
+func TestQueueHandler_Get_SessionBelongsToSameProject(t *testing.T) {
+	env, teardown := setupTestEnv(t)
+	defer teardown()
+
+	sessionID, err := service.CreateSession(env.ProjectDir, "claude", "Same Project Session", "claude", "", "default", "chat")
+	assert.NoError(t, err)
+	defer service.ClearQueue(sessionID)
+
+	service.EnqueueMessage(sessionID, model.QueuedMessage{
+		Text:      "hello",
+		CreatedAt: time.Now().Format(time.RFC3339),
+	})
+
+	req := newRequest(t, http.MethodGet, "/api/ai/queue?session_id="+sessionID, nil)
+	req = withProjectCookie(req, env.ProjectDir)
+	w := callHandler(QueueHandler, req)
+
+	assertOK(t, w)
+	var result map[string]any
+	json.Unmarshal(w.Body.Bytes(), &result)
+	queue := result["queue"].([]any)
+	assert.Len(t, queue, 1)
+}
+
+// TestQueueHandler_Delete_SessionBelongsToSameProject verifies that delete succeeds
+// when the session belongs to the requesting project (ISS-180).
+func TestQueueHandler_Delete_SessionBelongsToSameProject(t *testing.T) {
+	env, teardown := setupTestEnv(t)
+	defer teardown()
+
+	sessionID, err := service.CreateSession(env.ProjectDir, "claude", "Same Project Session", "claude", "", "default", "chat")
+	assert.NoError(t, err)
+	defer service.ClearQueue(sessionID)
+
+	service.EnqueueMessage(sessionID, model.QueuedMessage{
+		Text: "msg1", CreatedAt: time.Now().Format(time.RFC3339),
+	})
+
+	req := newRequest(t, http.MethodDelete, "/api/ai/queue?session_id="+sessionID, nil)
+	req = withProjectCookie(req, env.ProjectDir)
+	w := callHandler(QueueHandler, req)
+
+	assertOK(t, w)
+}

--- a/internal/handler/queue_test.go
+++ b/internal/handler/queue_test.go
@@ -324,3 +324,55 @@ func TestQueueHandler_Enqueue_FilesWithUploads(t *testing.T) {
 	assert.Equal(t, ".clawbench/uploads/img.png", files[0])
 	assert.Equal(t, "src/main.go", files[1])
 }
+
+// ---------- Session ownership validation (ISS-180) ----------
+
+func TestQueueHandler_Enqueue_SessionBelongsToDifferentProject(t *testing.T) {
+	env, teardown := setupTestEnv(t)
+	defer teardown()
+
+	// Create a session that belongs to a different project
+	otherProject := "/other-project"
+	sessionID, err := service.CreateSession(otherProject, "claude", "Other Session", "claude", "", "default", "chat")
+	assert.NoError(t, err)
+	defer service.ClearQueue(sessionID)
+
+	body := map[string]any{"message": "hello world"}
+	req := newRequest(t, http.MethodPost, "/api/ai/queue?session_id="+sessionID, body)
+	req = withProjectCookie(req, env.ProjectDir) // different project
+	w := callHandler(QueueHandler, req)
+
+	assertStatus(t, w, http.StatusForbidden)
+}
+
+func TestQueueHandler_Get_SessionBelongsToDifferentProject(t *testing.T) {
+	env, teardown := setupTestEnv(t)
+	defer teardown()
+
+	// Create a session that belongs to a different project
+	otherProject := "/other-project"
+	sessionID, err := service.CreateSession(otherProject, "claude", "Other Session", "claude", "", "default", "chat")
+	assert.NoError(t, err)
+
+	req := newRequest(t, http.MethodGet, "/api/ai/queue?session_id="+sessionID, nil)
+	req = withProjectCookie(req, env.ProjectDir) // different project
+	w := callHandler(QueueHandler, req)
+
+	assertStatus(t, w, http.StatusForbidden)
+}
+
+func TestQueueHandler_Delete_SessionBelongsToDifferentProject(t *testing.T) {
+	env, teardown := setupTestEnv(t)
+	defer teardown()
+
+	// Create a session that belongs to a different project
+	otherProject := "/other-project"
+	sessionID, err := service.CreateSession(otherProject, "claude", "Other Session", "claude", "", "default", "chat")
+	assert.NoError(t, err)
+
+	req := newRequest(t, http.MethodDelete, "/api/ai/queue?session_id="+sessionID, nil)
+	req = withProjectCookie(req, env.ProjectDir) // different project
+	w := callHandler(QueueHandler, req)
+
+	assertStatus(t, w, http.StatusForbidden)
+}

--- a/internal/handler/queue_test.go
+++ b/internal/handler/queue_test.go
@@ -503,3 +503,54 @@ func TestQueueHandler_InvalidIndex_SameProject(t *testing.T) {
 
 	assertStatus(t, w, http.StatusBadRequest)
 }
+
+// ---------- requireProject failure paths (ISS-180) ----------
+
+// TestQueueHandler_Enqueue_MissingProjectCookie verifies that the enqueue
+// handler rejects requests without a project cookie (requireProject fails).
+func TestQueueHandler_Enqueue_MissingProjectCookie(t *testing.T) {
+	_, teardown := setupTestEnv(t)
+	defer teardown()
+
+	sessionID := "q-enqueue-noproj"
+	defer service.ClearQueue(sessionID)
+
+	body := map[string]any{"message": "hello world"}
+	req := newRequest(t, http.MethodPost, "/api/ai/queue?session_id="+sessionID, body)
+	// Intentionally NOT setting project cookie
+	w := callHandler(QueueHandler, req)
+
+	assertStatus(t, w, http.StatusForbidden)
+}
+
+// TestQueueHandler_Get_MissingProjectCookie verifies that the get handler
+// rejects requests without a project cookie (requireProject fails).
+func TestQueueHandler_Get_MissingProjectCookie(t *testing.T) {
+	_, teardown := setupTestEnv(t)
+	defer teardown()
+
+	sessionID := "q-get-noproj"
+	defer service.ClearQueue(sessionID)
+
+	req := newRequest(t, http.MethodGet, "/api/ai/queue?session_id="+sessionID, nil)
+	// Intentionally NOT setting project cookie
+	w := callHandler(QueueHandler, req)
+
+	assertStatus(t, w, http.StatusForbidden)
+}
+
+// TestQueueHandler_Delete_MissingProjectCookie verifies that the delete handler
+// rejects requests without a project cookie (requireProject fails).
+func TestQueueHandler_Delete_MissingProjectCookie(t *testing.T) {
+	_, teardown := setupTestEnv(t)
+	defer teardown()
+
+	sessionID := "q-del-noproj"
+	defer service.ClearQueue(sessionID)
+
+	req := newRequest(t, http.MethodDelete, "/api/ai/queue?session_id="+sessionID, nil)
+	// Intentionally NOT setting project cookie
+	w := callHandler(QueueHandler, req)
+
+	assertStatus(t, w, http.StatusForbidden)
+}

--- a/internal/i18n/i18n.go
+++ b/internal/i18n/i18n.go
@@ -56,3 +56,9 @@ func T(loc *i18n.Localizer, messageID string, templateData ...map[string]interfa
 	}
 	return msg
 }
+
+// LocalizerForLocale creates a Localizer for a given locale string (e.g., "zh", "en").
+// Used in contexts without an HTTP request (e.g., push notifications).
+func LocalizerForLocale(locale string) *i18n.Localizer {
+	return i18n.NewLocalizer(bundle, locale)
+}

--- a/internal/i18n/i18n_test.go
+++ b/internal/i18n/i18n_test.go
@@ -154,3 +154,39 @@ func TestT_NewSessionN(t *testing.T) {
 	zhLoc := Localizer(zhR)
 	assert.Equal(t, "新会话 3", T(zhLoc, "NewSessionN", map[string]interface{}{"N": 3}))
 }
+
+// ---------- LocalizerForLocale (ISS-129) ----------
+
+func TestLocalizerForLocale_English(t *testing.T) {
+	loc := LocalizerForLocale("en")
+	msg := T(loc, "PushTaskCompleted")
+	assert.Equal(t, "AI Task Completed", msg)
+}
+
+func TestLocalizerForLocale_Chinese(t *testing.T) {
+	loc := LocalizerForLocale("zh")
+	msg := T(loc, "PushTaskCompleted")
+	assert.Equal(t, "AI任务完成", msg)
+}
+
+func TestLocalizerForLocale_EmptyDefaultsToEnglish(t *testing.T) {
+	loc := LocalizerForLocale("")
+	msg := T(loc, "PushSessionEnded")
+	assert.Equal(t, "AI session ended", msg)
+}
+
+func TestLocalizerForLocale_PushNotificationKeys(t *testing.T) {
+	// Verify all push notification i18n keys exist in both languages
+	keys := []string{"PushTaskCompleted", "PushSessionEnded", "PushScheduledTaskDone"}
+	for _, key := range keys {
+		enLoc := LocalizerForLocale("en")
+		enMsg := T(enLoc, key)
+		assert.NotEqual(t, key, enMsg, "English translation missing for push key: %s", key)
+
+		zhLoc := LocalizerForLocale("zh")
+		zhMsg := T(zhLoc, key)
+		assert.NotEqual(t, key, zhMsg, "Chinese translation missing for push key: %s", key)
+
+		t.Logf("%s: en=%q zh=%q", key, enMsg, zhMsg)
+	}
+}

--- a/internal/i18n/locales/active.en.yaml
+++ b/internal/i18n/locales/active.en.yaml
@@ -71,3 +71,6 @@ InvalidModelForAgent: Invalid model for this agent
 InvalidThinkingEffort: Invalid thinking effort level for this agent
 InvalidSHA: Invalid commit SHA format
 InvalidBranchName: Invalid branch name
+PushTaskCompleted: AI Task Completed
+PushSessionEnded: AI session ended
+PushScheduledTaskDone: Scheduled task completed

--- a/internal/i18n/locales/active.zh.yaml
+++ b/internal/i18n/locales/active.zh.yaml
@@ -71,3 +71,6 @@ InvalidModelForAgent: 无效的模型
 InvalidThinkingEffort: 无效的思考深度级别
 InvalidSHA: 无效的提交SHA格式
 InvalidBranchName: 无效的分支名
+PushTaskCompleted: AI任务完成
+PushSessionEnded: AI会话已结束
+PushScheduledTaskDone: 计划任务已完成

--- a/internal/service/scheduler.go
+++ b/internal/service/scheduler.go
@@ -669,11 +669,21 @@ func (s *Scheduler) executeTask(task *model.ScheduledTask, projectPath string, t
 		newStatus = "completed"
 	}
 
-	schedule, _ := cron.ParseStandard(task.CronExpr)
+	schedule, err := cron.ParseStandard(task.CronExpr)
+	if err != nil {
+		slog.Error("failed to parse cron expression for next run calculation",
+			slog.Int64("task_id", task.ID),
+			slog.String("cron_expr", task.CronExpr),
+			slog.String("error", err.Error()))
+		// Fall through: nextRunAt remains nil, task stays active but no next_run_at
+	}
 	var nextRunAt *time.Time
-	if newStatus == "active" {
+	if newStatus == "active" && schedule != nil {
 		nr := schedule.Next(time.Now())
 		nextRunAt = &nr
+	} else if newStatus == "active" && schedule == nil {
+		slog.Error("nil cron schedule, cannot calculate next run",
+			slog.Int64("task_id", task.ID))
 	} else {
 		// Task completed, remove from cron
 		s.mu.Lock()

--- a/internal/service/session_runtime_test.go
+++ b/internal/service/session_runtime_test.go
@@ -949,7 +949,7 @@ func TestEmitSessionEvent_CompletedWithPreview(t *testing.T) {
 	defer ws.SetManagerForTest(nil)
 
 	var writeMu sync.Mutex
-	sub := mgr.Subscribe(nil, &writeMu, "test-client-emit")
+	sub := mgr.Subscribe(nil, &writeMu, "test-client-emit", "")
 	_ = sub
 
 	EmitSessionEvent("session-emit-1", "completed", true)
@@ -982,7 +982,7 @@ func TestEmitSessionEvent_RunningNoPreview(t *testing.T) {
 	defer ws.SetManagerForTest(nil)
 
 	var writeMu sync.Mutex
-	sub := mgr.Subscribe(nil, &writeMu, "test-client-emit2")
+	sub := mgr.Subscribe(nil, &writeMu, "test-client-emit2", "")
 	_ = sub
 
 	EmitSessionEvent("session-emit-2", "running", false)
@@ -1098,7 +1098,7 @@ func TestEmitTaskEvent_WithSessionIDAndProjectPath(t *testing.T) {
 	defer ws.SetManagerForTest(nil)
 
 	var writeMu sync.Mutex
-	sub := mgr.Subscribe(nil, &writeMu, "test-client-task-emit")
+	sub := mgr.Subscribe(nil, &writeMu, "test-client-task-emit", "")
 	_ = sub
 
 	emitTaskEvent("42", "completed", "100", "session-task-1", "/home/user/project", "test task")
@@ -1125,7 +1125,7 @@ func TestEmitTaskEvent_EmptyOptionalFields(t *testing.T) {
 	defer ws.SetManagerForTest(nil)
 
 	var writeMu sync.Mutex
-	sub := mgr.Subscribe(nil, &writeMu, "test-client-task-emit2")
+	sub := mgr.Subscribe(nil, &writeMu, "test-client-task-emit2", "")
 	_ = sub
 
 	emitTaskEvent("43", "failed", "101", "", "", "")
@@ -1280,7 +1280,7 @@ func TestExecuteTask_BackendCreationFailed(t *testing.T) {
 
 	// Subscribe a client to capture events
 	var writeMu sync.Mutex
-	sub := mgr.Subscribe(nil, &writeMu, "test-client-exec")
+	sub := mgr.Subscribe(nil, &writeMu, "test-client-exec", "")
 	_ = sub
 
 	// Execute the task — should fail at backend creation and emit "failed" event

--- a/internal/ws/events.go
+++ b/internal/ws/events.go
@@ -46,8 +46,16 @@ func EventsHandler(w http.ResponseWriter, r *http.Request) {
 		clientID = "default"
 	}
 
+	// Extract user's locale preference for push notification i18n (ISS-129)
+	locale := r.Header.Get("X-Locale")
+	if locale == "" {
+		if c, err := r.Cookie("clawbench-locale"); err == nil {
+			locale = c.Value
+		}
+	}
+
 	var writeMu sync.Mutex
-	sub := mgr.Subscribe(conn, &writeMu, clientID)
+	sub := mgr.Subscribe(conn, &writeMu, clientID, locale)
 	if sub == nil {
 		// Subscription rejected (e.g. limit reached) — conn already closed by Subscribe
 		return

--- a/internal/ws/events_test.go
+++ b/internal/ws/events_test.go
@@ -1,0 +1,132 @@
+package ws
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/coder/websocket"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestEventsHandler_ExtractsLocaleFromHeader verifies that the WebSocket handler
+// extracts the locale from the X-Locale header and stores it in the subscription.
+func TestEventsHandler_ExtractsLocaleFromHeader(t *testing.T) {
+	mgr := newTestManager(nil)
+	origMgr := defaultManager
+	defaultManager = mgr
+	defer func() { defaultManager = origMgr }()
+
+	// Create a test HTTP server that routes to EventsHandler
+	mux := http.NewServeMux()
+	mux.HandleFunc("/api/ai/events/ws", EventsHandler)
+	server := httptest.NewServer(mux)
+	defer server.Close()
+
+	// Connect with X-Locale header
+	wsURL := "ws" + server.URL[4:] + "/api/ai/events/ws?client_id=locale-test"
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	conn, _, err := websocket.Dial(ctx, wsURL, &websocket.DialOptions{
+		HTTPHeader: http.Header{
+			"X-Locale": []string{"zh"},
+		},
+	})
+	require.NoError(t, err, "WebSocket connection should succeed")
+	defer conn.Close(websocket.StatusNormalClosure, "")
+
+	// Verify locale is stored in the subscription
+	time.Sleep(100 * time.Millisecond) // Allow goroutine to process
+	mgr.mu.Lock()
+	sub, ok := mgr.subscriptions["locale-test"]
+	mgr.mu.Unlock()
+	require.True(t, ok, "subscription should exist")
+	sub.mu.Lock()
+	locale := sub.locale
+	sub.mu.Unlock()
+	assert.Equal(t, "zh", locale, "locale should be extracted from X-Locale header")
+
+	// Clean up
+	mgr.DisconnectClient("locale-test")
+}
+
+// TestEventsHandler_ExtractsLocaleFromCookie verifies that the WebSocket handler
+// extracts the locale from the clawbench-locale cookie when X-Locale header is absent.
+func TestEventsHandler_ExtractsLocaleFromCookie(t *testing.T) {
+	mgr := newTestManager(nil)
+	origMgr := defaultManager
+	defaultManager = mgr
+	defer func() { defaultManager = origMgr }()
+
+	mux := http.NewServeMux()
+	mux.HandleFunc("/api/ai/events/ws", EventsHandler)
+	server := httptest.NewServer(mux)
+	defer server.Close()
+
+	// Connect with cookie but no X-Locale header
+	wsURL := "ws" + server.URL[4:] + "/api/ai/events/ws?client_id=locale-cookie"
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	conn, _, err := websocket.Dial(ctx, wsURL, &websocket.DialOptions{
+		HTTPHeader: http.Header{
+			"Cookie": []string{"clawbench-locale=en"},
+		},
+	})
+	require.NoError(t, err, "WebSocket connection should succeed")
+	defer conn.Close(websocket.StatusNormalClosure, "")
+
+	// Verify locale is stored from cookie
+	time.Sleep(100 * time.Millisecond)
+	mgr.mu.Lock()
+	sub, ok := mgr.subscriptions["locale-cookie"]
+	mgr.mu.Unlock()
+	require.True(t, ok, "subscription should exist")
+	sub.mu.Lock()
+	locale := sub.locale
+	sub.mu.Unlock()
+	assert.Equal(t, "en", locale, "locale should be extracted from cookie")
+
+	// Clean up
+	mgr.DisconnectClient("locale-cookie")
+}
+
+// TestEventsHandler_DefaultLocaleWhenNoneProvided verifies that locale defaults
+// to empty string when neither X-Locale header nor cookie is provided.
+func TestEventsHandler_DefaultLocaleWhenNoneProvided(t *testing.T) {
+	mgr := newTestManager(nil)
+	origMgr := defaultManager
+	defaultManager = mgr
+	defer func() { defaultManager = origMgr }()
+
+	mux := http.NewServeMux()
+	mux.HandleFunc("/api/ai/events/ws", EventsHandler)
+	server := httptest.NewServer(mux)
+	defer server.Close()
+
+	wsURL := "ws" + server.URL[4:] + "/api/ai/events/ws?client_id=locale-default"
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	conn, _, err := websocket.Dial(ctx, wsURL, nil)
+	require.NoError(t, err, "WebSocket connection should succeed")
+	defer conn.Close(websocket.StatusNormalClosure, "")
+
+	// Verify locale defaults to empty (English via i18n fallback)
+	time.Sleep(100 * time.Millisecond)
+	mgr.mu.Lock()
+	sub, ok := mgr.subscriptions["locale-default"]
+	mgr.mu.Unlock()
+	require.True(t, ok, "subscription should exist")
+	sub.mu.Lock()
+	locale := sub.locale
+	sub.mu.Unlock()
+	assert.Equal(t, "", locale, "locale should default to empty when not provided")
+
+	// Clean up
+	mgr.DisconnectClient("locale-default")
+}

--- a/internal/ws/manager.go
+++ b/internal/ws/manager.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/coder/websocket"
 
+	"clawbench/internal/i18n"
 	"clawbench/internal/model"
 	"clawbench/internal/push"
 	"unicode/utf8"
@@ -23,6 +24,7 @@ type ClientSubscription struct {
 	writeMu     *sync.Mutex // shared with EventsHandler for serialized writes
 	clientID    string      // identifies the client device (for logging)
 	pushRegID   string      // JPush registration ID (set via WS "register" message)
+	locale      string      // user's preferred locale (for push notification i18n)
 	lastActive  time.Time
 	eventBuffer []ServerMessage
 	bufferStart time.Time
@@ -92,7 +94,7 @@ func GetManager() *Manager {
 
 // Subscribe registers a new WS connection for a client identified by clientID.
 // If a subscription with the same clientID already exists, its connection is replaced.
-func (m *Manager) Subscribe(conn *websocket.Conn, writeMu *sync.Mutex, clientID string) *ClientSubscription {
+func (m *Manager) Subscribe(conn *websocket.Conn, writeMu *sync.Mutex, clientID, locale string) *ClientSubscription {
 	m.mu.Lock()
 
 	// Check subscription limit (existing clientID reconnect is allowed)
@@ -114,6 +116,7 @@ func (m *Manager) Subscribe(conn *websocket.Conn, writeMu *sync.Mutex, clientID 
 	oldConn := sub.conn
 	sub.conn = conn
 	sub.writeMu = writeMu
+	sub.locale = locale
 	sub.lastActive = time.Now()
 	sub.eventBuffer = nil
 	sub.bufferStart = time.Time{}
@@ -303,10 +306,11 @@ func (m *Manager) broadcastToSubscription(key string, msg ServerMessage, deliver
 				extras["project_path"] = d.ProjectPath
 			}
 		}
-		title := "AI任务完成"
-		alert := "AI会话已结束"
+		loc := i18n.LocalizerForLocale(sub.locale)
+		title := i18n.T(loc, "PushTaskCompleted")
+		alert := i18n.T(loc, "PushSessionEnded")
 		if msg.Event == "task_update" {
-			alert = "计划任务已完成"
+			alert = i18n.T(loc, "PushScheduledTaskDone")
 		}
 		// Extract session title and response preview from event data for both
 		// session_update and task_update events, then format the notification:

--- a/internal/ws/manager_test.go
+++ b/internal/ws/manager_test.go
@@ -37,15 +37,32 @@ func TestManager_Subscribe(t *testing.T) {
 	}
 }
 
+func TestManager_Subscribe_StoresLocale(t *testing.T) {
+	mgr := newTestManager(nil)
+	var writeMu sync.Mutex
+
+	sub := mgr.Subscribe(nil, &writeMu, "client-locale", "zh")
+	if sub == nil {
+		t.Fatal("expected non-nil subscription")
+	}
+
+	sub.mu.Lock()
+	locale := sub.locale
+	sub.mu.Unlock()
+	if locale != "zh" {
+		t.Errorf("expected locale %q, got %q", "zh", locale)
+	}
+}
+
 func TestManager_SubscribeReplacesExisting(t *testing.T) {
 	mgr := newTestManager(nil)
 	var writeMu1, writeMu2 sync.Mutex
 
-	sub1 := mgr.Subscribe(nil, &writeMu1, "client-1", "")
+	sub1 := mgr.Subscribe(nil, &writeMu1, "client-1", "en")
 	_ = sub1
 
-	// Second subscribe with same clientID should replace the first
-	sub2 := mgr.Subscribe(nil, &writeMu2, "client-1", "")
+	// Second subscribe with same clientID should replace the first and update locale
+	sub2 := mgr.Subscribe(nil, &writeMu2, "client-1", "zh")
 
 	mgr.mu.Lock()
 	stored := mgr.subscriptions["client-1"]
@@ -53,6 +70,11 @@ func TestManager_SubscribeReplacesExisting(t *testing.T) {
 	if stored != sub2 {
 		t.Error("expected subscription to be replaced")
 	}
+	sub2.mu.Lock()
+	if sub2.locale != "zh" {
+		t.Errorf("expected locale to be updated to %q, got %q", "zh", sub2.locale)
+	}
+	sub2.mu.Unlock()
 }
 
 func TestManager_SubscribeMultipleClients(t *testing.T) {

--- a/internal/ws/manager_test.go
+++ b/internal/ws/manager_test.go
@@ -24,7 +24,7 @@ func TestManager_Subscribe(t *testing.T) {
 	mgr := newTestManager(nil)
 	var writeMu sync.Mutex
 
-	sub := mgr.Subscribe(nil, &writeMu, "client-1")
+	sub := mgr.Subscribe(nil, &writeMu, "client-1", "")
 	if sub == nil {
 		t.Fatal("expected non-nil subscription")
 	}
@@ -41,11 +41,11 @@ func TestManager_SubscribeReplacesExisting(t *testing.T) {
 	mgr := newTestManager(nil)
 	var writeMu1, writeMu2 sync.Mutex
 
-	sub1 := mgr.Subscribe(nil, &writeMu1, "client-1")
+	sub1 := mgr.Subscribe(nil, &writeMu1, "client-1", "")
 	_ = sub1
 
 	// Second subscribe with same clientID should replace the first
-	sub2 := mgr.Subscribe(nil, &writeMu2, "client-1")
+	sub2 := mgr.Subscribe(nil, &writeMu2, "client-1", "")
 
 	mgr.mu.Lock()
 	stored := mgr.subscriptions["client-1"]
@@ -59,8 +59,8 @@ func TestManager_SubscribeMultipleClients(t *testing.T) {
 	mgr := newTestManager(nil)
 	var writeMu1, writeMu2 sync.Mutex
 
-	sub1 := mgr.Subscribe(nil, &writeMu1, "client-1")
-	sub2 := mgr.Subscribe(nil, &writeMu2, "client-2")
+	sub1 := mgr.Subscribe(nil, &writeMu1, "client-1", "")
+	sub2 := mgr.Subscribe(nil, &writeMu2, "client-2", "")
 
 	// Both should exist independently
 	mgr.mu.Lock()
@@ -82,7 +82,7 @@ func TestManager_Unsubscribe(t *testing.T) {
 	mgr := newTestManager(nil)
 	var writeMu sync.Mutex
 
-	mgr.Subscribe(nil, &writeMu, "client-1")
+	mgr.Subscribe(nil, &writeMu, "client-1", "")
 	mgr.DisconnectClient("client-1")
 
 	mgr.mu.Lock()
@@ -104,7 +104,7 @@ func TestManager_RegisterPushID(t *testing.T) {
 	mgr := newTestManager(nil)
 	var writeMu sync.Mutex
 
-	mgr.Subscribe(nil, &writeMu, "client-1")
+	mgr.Subscribe(nil, &writeMu, "client-1", "")
 	mgr.RegisterPushID("test-reg-id", "client-1")
 
 	mgr.mu.Lock()
@@ -124,10 +124,10 @@ func TestManager_RegisterPushID_Dedup(t *testing.T) {
 	var writeMu1, writeMu2 sync.Mutex
 
 	// Two clients, same pushRegID (same device reconnecting)
-	mgr.Subscribe(nil, &writeMu1, "client-1")
+	mgr.Subscribe(nil, &writeMu1, "client-1", "")
 	mgr.RegisterPushID("shared-reg-id", "client-1")
 
-	mgr.Subscribe(nil, &writeMu2, "client-2")
+	mgr.Subscribe(nil, &writeMu2, "client-2", "")
 	mgr.RegisterPushID("shared-reg-id", "client-2")
 
 	// Client-2 should have the regID
@@ -161,7 +161,7 @@ func TestManager_BroadcastEvent_Disconnected(t *testing.T) {
 	mgr := newTestManager(nil)
 	var writeMu sync.Mutex
 
-	mgr.Subscribe(nil, &writeMu, "client-1")
+	mgr.Subscribe(nil, &writeMu, "client-1", "")
 	mgr.DisconnectClient("client-1")
 
 	// Broadcast while disconnected — should buffer
@@ -197,7 +197,7 @@ func TestManager_BroadcastEvent_JPushWhenDisconnected(t *testing.T) {
 	mgr := newTestManager(jpush)
 	var writeMu sync.Mutex
 
-	mgr.Subscribe(nil, &writeMu, "client-1")
+	mgr.Subscribe(nil, &writeMu, "client-1", "")
 	mgr.RegisterPushID("reg-123", "client-1")
 	mgr.DisconnectClient("client-1")
 
@@ -211,7 +211,7 @@ func TestManager_BroadcastEvent_JPushDisabled(t *testing.T) {
 	mgr := newTestManager(nil) // nil jpush = disabled
 	var writeMu sync.Mutex
 
-	mgr.Subscribe(nil, &writeMu, "client-1")
+	mgr.Subscribe(nil, &writeMu, "client-1", "")
 	mgr.RegisterPushID("reg-123", "client-1")
 	mgr.DisconnectClient("client-1")
 
@@ -225,8 +225,8 @@ func TestManager_BroadcastEvent_MultipleClients(t *testing.T) {
 	var writeMu1, writeMu2 sync.Mutex
 
 	// Two clients subscribed
-	mgr.Subscribe(nil, &writeMu1, "client-1")
-	mgr.Subscribe(nil, &writeMu2, "client-2")
+	mgr.Subscribe(nil, &writeMu1, "client-1", "")
+	mgr.Subscribe(nil, &writeMu2, "client-2", "")
 
 	// Disconnect both
 	mgr.DisconnectClient("client-1")
@@ -288,7 +288,7 @@ func TestCleanupStale_NoPushRegID(t *testing.T) {
 	mgr := newTestManager(nil)
 	var writeMu sync.Mutex
 
-	mgr.Subscribe(nil, &writeMu, "client-1")
+	mgr.Subscribe(nil, &writeMu, "client-1", "")
 	mgr.DisconnectClient("client-1")
 
 	// Set bufferStart to just past staleNoPushTimeout — should be cleaned up (no pushRegID)
@@ -313,7 +313,7 @@ func TestCleanupStale_NoPushRegID_RecentNotCleaned(t *testing.T) {
 	mgr := newTestManager(nil)
 	var writeMu sync.Mutex
 
-	mgr.Subscribe(nil, &writeMu, "client-1")
+	mgr.Subscribe(nil, &writeMu, "client-1", "")
 	mgr.DisconnectClient("client-1")
 
 	// Set bufferStart to well before staleNoPushTimeout — should NOT be cleaned up
@@ -338,7 +338,7 @@ func TestCleanupStale_WithPushRegID(t *testing.T) {
 	mgr := newTestManager(nil)
 	var writeMu sync.Mutex
 
-	mgr.Subscribe(nil, &writeMu, "client-1")
+	mgr.Subscribe(nil, &writeMu, "client-1", "")
 	mgr.RegisterPushID("reg-123", "client-1")
 	mgr.DisconnectClient("client-1")
 
@@ -380,7 +380,7 @@ func TestCleanupStale_RecentNotCleaned(t *testing.T) {
 	mgr := newTestManager(nil)
 	var writeMu sync.Mutex
 
-	mgr.Subscribe(nil, &writeMu, "client-1")
+	mgr.Subscribe(nil, &writeMu, "client-1", "")
 	// Not unsubscribing — conn is active, should not be cleaned
 
 	mgr.CleanupStale()
@@ -432,7 +432,7 @@ func TestBroadcastEvent_BufferWindow(t *testing.T) {
 	mgr := newTestManager(nil)
 	var writeMu sync.Mutex
 
-	mgr.Subscribe(nil, &writeMu, "client-1")
+	mgr.Subscribe(nil, &writeMu, "client-1", "")
 	mgr.DisconnectClient("client-1")
 
 	// Within buffer window (10s) — should buffer
@@ -489,7 +489,7 @@ func TestManager_BroadcastEvent_JPushAlert_WithSessionTitle(t *testing.T) {
 
 	mgr := newTestManager(jpush)
 	var writeMu sync.Mutex
-	mgr.Subscribe(nil, &writeMu, "client-1")
+	mgr.Subscribe(nil, &writeMu, "client-1", "")
 	mgr.RegisterPushID("reg-123", "client-1")
 	mgr.DisconnectClient("client-1")
 
@@ -542,7 +542,7 @@ func TestManager_BroadcastEvent_JPushAlert_WithResponsePreview(t *testing.T) {
 
 	mgr := newTestManager(jpush)
 	var writeMu sync.Mutex
-	mgr.Subscribe(nil, &writeMu, "client-1")
+	mgr.Subscribe(nil, &writeMu, "client-1", "")
 	mgr.RegisterPushID("reg-123", "client-1")
 	mgr.DisconnectClient("client-1")
 
@@ -559,8 +559,8 @@ func TestManager_BroadcastEvent_JPushAlert_WithResponsePreview(t *testing.T) {
 	}
 	mgr.BroadcastEvent(msg)
 
-	// Without session title, notification title stays as default
-	if receivedTitle != "AI任务完成" {
+	// Without session title, notification title stays as default (i18n-based, defaults to English)
+	if receivedTitle != "AI Task Completed" {
 		t.Errorf("expected default title, got %q", receivedTitle)
 	}
 	// Short preview should pass through unchanged (under pushAlertMaxRunes)
@@ -595,7 +595,7 @@ func TestManager_BroadcastEvent_JPushAlert_TruncatesLongPreview(t *testing.T) {
 
 	mgr := newTestManager(jpush)
 	var writeMu sync.Mutex
-	mgr.Subscribe(nil, &writeMu, "client-1")
+	mgr.Subscribe(nil, &writeMu, "client-1", "")
 	mgr.RegisterPushID("reg-123", "client-1")
 	mgr.DisconnectClient("client-1")
 
@@ -655,7 +655,7 @@ func TestManager_BroadcastEvent_JPushAlert_WithoutTitleOrPreview(t *testing.T) {
 
 	mgr := newTestManager(jpush)
 	var writeMu sync.Mutex
-	mgr.Subscribe(nil, &writeMu, "client-1")
+	mgr.Subscribe(nil, &writeMu, "client-1", "")
 	mgr.RegisterPushID("reg-123", "client-1")
 	mgr.DisconnectClient("client-1")
 
@@ -671,10 +671,10 @@ func TestManager_BroadcastEvent_JPushAlert_WithoutTitleOrPreview(t *testing.T) {
 	}
 	mgr.BroadcastEvent(msg)
 
-	if receivedTitle != "AI任务完成" {
+	if receivedTitle != "AI Task Completed" {
 		t.Errorf("expected default title, got %q", receivedTitle)
 	}
-	if receivedAlert != "AI会话已结束" {
+	if receivedAlert != "AI session ended" {
 		t.Errorf("expected default alert, got %q", receivedAlert)
 	}
 }
@@ -705,7 +705,7 @@ func TestManager_BroadcastEvent_JPushAlert_TaskUpdate(t *testing.T) {
 
 	mgr := newTestManager(jpush)
 	var writeMu sync.Mutex
-	mgr.Subscribe(nil, &writeMu, "client-1")
+	mgr.Subscribe(nil, &writeMu, "client-1", "")
 	mgr.RegisterPushID("reg-123", "client-1")
 	mgr.DisconnectClient("client-1")
 
@@ -748,7 +748,7 @@ func TestManager_BroadcastEvent_JPushNotSentForRunning(t *testing.T) {
 
 	mgr := newTestManager(jpush)
 	var writeMu sync.Mutex
-	mgr.Subscribe(nil, &writeMu, "client-1")
+	mgr.Subscribe(nil, &writeMu, "client-1", "")
 	mgr.RegisterPushID("reg-123", "client-1")
 	mgr.DisconnectClient("client-1")
 
@@ -795,7 +795,7 @@ func TestManager_BroadcastEvent_JPushSentForCompleted(t *testing.T) {
 
 	mgr := newTestManager(jpush)
 	var writeMu sync.Mutex
-	mgr.Subscribe(nil, &writeMu, "client-1")
+	mgr.Subscribe(nil, &writeMu, "client-1", "")
 	mgr.RegisterPushID("reg-123", "client-1")
 	mgr.DisconnectClient("client-1")
 
@@ -834,7 +834,7 @@ func TestManager_BroadcastEvent_JPushNotSentForTaskRunning(t *testing.T) {
 
 	mgr := newTestManager(jpush)
 	var writeMu sync.Mutex
-	mgr.Subscribe(nil, &writeMu, "client-1")
+	mgr.Subscribe(nil, &writeMu, "client-1", "")
 	mgr.RegisterPushID("reg-123", "client-1")
 	mgr.DisconnectClient("client-1")
 
@@ -873,7 +873,7 @@ func TestManager_BroadcastEvent_JPushSentForCancelled(t *testing.T) {
 
 	mgr := newTestManager(jpush)
 	var writeMu sync.Mutex
-	mgr.Subscribe(nil, &writeMu, "client-1")
+	mgr.Subscribe(nil, &writeMu, "client-1", "")
 	mgr.RegisterPushID("reg-123", "client-1")
 	mgr.DisconnectClient("client-1")
 
@@ -916,13 +916,13 @@ func TestManager_BroadcastEvent_JPushDedupSameRegID(t *testing.T) {
 
 	// Client-1: disconnected, has pushRegID
 	var writeMu1 sync.Mutex
-	mgr.Subscribe(nil, &writeMu1, "client-1")
+	mgr.Subscribe(nil, &writeMu1, "client-1", "")
 	mgr.RegisterPushID("reg-shared", "client-1")
 	mgr.DisconnectClient("client-1")
 
 	// Client-2: disconnected, manually set same pushRegID
 	var writeMu2 sync.Mutex
-	mgr.Subscribe(nil, &writeMu2, "client-2")
+	mgr.Subscribe(nil, &writeMu2, "client-2", "")
 	mgr.DisconnectClient("client-2")
 	mgr.mu.Lock()
 	s2 := mgr.subscriptions["client-2"]
@@ -972,7 +972,7 @@ func TestManager_BroadcastEvent_JPushExtras_SessionWithProjectPath(t *testing.T)
 
 	mgr := newTestManager(jpush)
 	var writeMu sync.Mutex
-	mgr.Subscribe(nil, &writeMu, "client-1")
+	mgr.Subscribe(nil, &writeMu, "client-1", "")
 	mgr.RegisterPushID("reg-123", "client-1")
 	mgr.DisconnectClient("client-1")
 
@@ -1028,7 +1028,7 @@ func TestManager_BroadcastEvent_JPushExtras_TaskWithSessionAndProjectPath(t *tes
 
 	mgr := newTestManager(jpush)
 	var writeMu sync.Mutex
-	mgr.Subscribe(nil, &writeMu, "client-1")
+	mgr.Subscribe(nil, &writeMu, "client-1", "")
 	mgr.RegisterPushID("reg-123", "client-1")
 	mgr.DisconnectClient("client-1")
 
@@ -1081,13 +1081,13 @@ func TestManager_BroadcastEvent_JPushWhenNoWS(t *testing.T) {
 
 	// Client-1: disconnected, has pushRegID
 	var writeMu1 sync.Mutex
-	mgr.Subscribe(nil, &writeMu1, "client-1")
+	mgr.Subscribe(nil, &writeMu1, "client-1", "")
 	mgr.RegisterPushID("reg-123", "client-1")
 	mgr.DisconnectClient("client-1")
 
 	// Client-2: disconnected, same pushRegID (simulating same device)
 	var writeMu2 sync.Mutex
-	mgr.Subscribe(nil, &writeMu2, "client-2")
+	mgr.Subscribe(nil, &writeMu2, "client-2", "")
 	mgr.DisconnectClient("client-2")
 	mgr.mu.Lock()
 	s2 := mgr.subscriptions["client-2"]


### PR DESCRIPTION
修复 Critical Issues: ISS-127, ISS-129, ISS-138, ISS-180, ISS-188

## Changes

### ISS-127 (P0 Flow Correctness)
- Add error handling for `cron.ParseStandard()` in `executeTask` completion path
- Previously, error was silently discarded with `_`, causing potential nil schedule panic

### ISS-129 (P0 Flow Correctness)  
- Replace hardcoded Chinese JPush notification strings with i18n system
- Add `LocalizerForLocale()` function for locale-aware push notifications
- Store user locale in `ClientSubscription` and use it for JPush fallback text
- Add i18n keys: `PushTaskCompleted`, `PushSessionEnded`, `PushScheduledTaskDone`

### ISS-138 (P0 Flow Correctness)
- Verified already fixed — `resume_split` event handler exists in `useChatStream.ts`

### ISS-180 (P0 Security)
- Add `GetSessionProjectPath` ownership validation in `AIChatStream`, all queue handlers, and chat POST handler
- Returns 403 Forbidden when session belongs to a different project
- Skips check for in-memory-only sessions (not yet in DB)

### ISS-188 (P0 Flow Correctness)
- Verified already fixed — `ScheduledExecution` flag is set and `CLAWBENCH_SCHEDULED=1` is injected

## Tests
- Added `TestLocalizerForLocale_*` tests for ISS-129
- Added `TestAIChatStream_SessionBelongsToDifferentProject` test for ISS-180
- Added `TestQueueHandler_*_SessionBelongsToDifferentProject` tests for ISS-180
- Updated WS manager tests for Subscribe signature change and i18n assertions