### PR TITLE
fix: 聊天自动总结加载点残留 + AutoResume Phase 1 消息消失

### DIFF
--- a/web/src/components/chat/ContentBlocks.vue
+++ b/web/src/components/chat/ContentBlocks.vue
@@ -89,8 +89,8 @@
       <div v-else-if="block.type === 'text'" v-html="getBlockHtml(bi, block)"></div>
     </template>
     </template>
-    <!-- Loading dots while AI is still streaming (not when cancelled) -->
-    <div v-if="streaming && !cancelled" class="placeholder-dots"><span></span><span></span><span></span></div>
+    <!-- Loading dots while AI is still streaming (not when cancelled, and not when showing summary) -->
+    <div v-if="streaming && !cancelled && !(showingSummary && summary)" class="placeholder-dots"><span></span><span></span><span></span></div>
     <!-- Cancelled marker -->
     <div v-if="cancelled" class="chat-cancelled-mark">{{ t('chat.contentBlocks.cancelled') }}</div>
   </div>

--- a/web/src/composables/__tests__/useChatStream.test.ts
+++ b/web/src/composables/__tests__/useChatStream.test.ts
@@ -1267,4 +1267,155 @@ describe('useChatStream', () => {
       expect(options.onNotification).toHaveBeenCalled()
     })
   })
+
+  describe('resume_split event (AutoResume)', () => {
+    it('should finalize Phase 1 message and create new Phase 2 streaming message', () => {
+      const options = createOptions()
+      const { connectStream } = useChatStream(options)
+
+      connectStream('test-session-1')
+      const es = getLatestEs()
+      es.simulateOpen()
+
+      // Phase 1: accumulate some content
+      es.simulate('content', { content: 'Phase 1 content' })
+
+      // Verify we have exactly 1 streaming assistant message
+      const streamingBefore = options.messages.value.filter(
+        (m: any) => m.role === 'assistant' && m.streaming
+      )
+      expect(streamingBefore.length).toBe(1)
+      expect(streamingBefore[0].blocks[0].text).toBe('Phase 1 content')
+
+      // Trigger resume_split
+      es.simulate('resume_split', {})
+
+      // Phase 1 message should be finalized (no longer streaming)
+      const finalizedMsg = options.messages.value.find(
+        (m: any) => m.role === 'assistant' && !m.streaming && m.blocks?.some((b: any) => b.text === 'Phase 1 content')
+      )
+      expect(finalizedMsg).toBeDefined()
+      expect(finalizedMsg.streaming).toBeUndefined()
+      expect(finalizedMsg.blocks[0].text).toBe('Phase 1 content')
+
+      // Phase 2: new streaming message should be created
+      const streamingAfter = options.messages.value.filter(
+        (m: any) => m.role === 'assistant' && m.streaming
+      )
+      expect(streamingAfter.length).toBe(1)
+      expect(streamingAfter[0].blocks).toEqual([])
+    })
+
+    it('should route Phase 2 content to the new streaming message', () => {
+      const options = createOptions()
+      const { connectStream } = useChatStream(options)
+
+      connectStream('test-session-1')
+      const es = getLatestEs()
+      es.simulateOpen()
+
+      // Phase 1 content
+      es.simulate('content', { content: 'Phase 1' })
+      es.simulate('resume_split', {})
+
+      // Phase 2 content — should go to the NEW streaming message
+      es.simulate('content', { content: 'Phase 2' })
+
+      // Phase 1 message should NOT have Phase 2 content
+      const phase1Msg = options.messages.value.find(
+        (m: any) => m.role === 'assistant' && !m.streaming && m.blocks?.some((b: any) => b.text === 'Phase 1')
+      )
+      expect(phase1Msg).toBeDefined()
+      expect(phase1Msg.blocks.every((b: any) => !b.text?.includes('Phase 2'))).toBe(true)
+
+      // Phase 2 streaming message should have Phase 2 content
+      const phase2Msg = options.messages.value.find(
+        (m: any) => m.role === 'assistant' && m.streaming
+      )
+      expect(phase2Msg).toBeDefined()
+      expect(phase2Msg.blocks[0].text).toBe('Phase 2')
+    })
+
+    it('should keep Phase 1 content visible (not cleared)', () => {
+      const options = createOptions()
+      const { connectStream } = useChatStream(options)
+
+      connectStream('test-session-1')
+      const es = getLatestEs()
+      es.simulateOpen()
+
+      // Phase 1: add text and tool_use
+      es.simulate('content', { content: 'Before ExitPlanMode' })
+      es.simulate('tool_use', { name: 'ExitPlanMode', id: 'epm-1', input: {} })
+      es.simulate('tool_use', { name: 'ExitPlanMode', id: 'epm-1', done: true })
+
+      // resume_split
+      es.simulate('resume_split', {})
+
+      // Phase 1 message should retain all its blocks
+      const phase1Msg = options.messages.value.find(
+        (m: any) => m.role === 'assistant' && !m.streaming
+      )
+      expect(phase1Msg).toBeDefined()
+      expect(phase1Msg.blocks.length).toBe(2) // text + tool_use
+      expect(phase1Msg.blocks[0].text).toBe('Before ExitPlanMode')
+      expect(phase1Msg.blocks[1].name).toBe('ExitPlanMode')
+    })
+
+    it('should maintain guard validity after resume_split', () => {
+      const options = createOptions()
+      const { connectStream } = useChatStream(options)
+
+      connectStream('test-session-1')
+      const es = getLatestEs()
+      es.simulateOpen()
+
+      es.simulate('content', { content: 'Phase 1' })
+      es.simulate('resume_split', {})
+
+      // After resume_split, Phase 2 streaming message should be in messages array
+      // so guard() still works — content events should be accepted
+      es.simulate('content', { content: ' Phase 2' })
+      es.simulate('thinking', { text: 'thinking...' })
+
+      const phase2Msg = options.messages.value.find(
+        (m: any) => m.role === 'assistant' && m.streaming
+      )
+      expect(phase2Msg).toBeDefined()
+      expect(phase2Msg.blocks.length).toBe(2) // text + thinking
+    })
+
+    it('should create Phase 2 message with correct backend', () => {
+      const options = createOptions()
+      options.currentBackend.value = 'claude-code'
+      const { connectStream } = useChatStream(options)
+
+      connectStream('test-session-1')
+      const es = getLatestEs()
+      es.simulateOpen()
+
+      es.simulate('resume_split', {})
+
+      const phase2Msg = options.messages.value.find(
+        (m: any) => m.role === 'assistant' && m.streaming
+      )
+      expect(phase2Msg).toBeDefined()
+      expect(phase2Msg.backend).toBe('claude-code')
+    })
+
+    it('should call onRenderNeeded on resume_split', () => {
+      const options = createOptions()
+      const { connectStream } = useChatStream(options)
+
+      connectStream('test-session-1')
+      const es = getLatestEs()
+      es.simulateOpen()
+
+      options.onRenderNeeded.mockClear()
+
+      es.simulate('resume_split', {})
+
+      expect(options.onRenderNeeded).toHaveBeenCalled()
+    })
+  })
 })

--- a/web/src/composables/useChatStream.ts
+++ b/web/src/composables/useChatStream.ts
@@ -264,10 +264,25 @@ export function useChatStream(options: UseChatStreamOptions) {
       if (!guard()) return
       resetStreamTimeout()
       // AutoResumeBackend detected ExitPlanMode and will auto-resume.
-      // Clear the streaming message's blocks so that resume content
-      // starts fresh — prevents duplicate rendering of pre-resume
-      // content (Issue #60).
-      streamingMsg.blocks = []
+      // Phase 1 content is already finalized in the DB — keep the current
+      // streamingMsg visible (user sees their Phase 1 reply) and create a
+      // NEW streaming message for Phase 2. This prevents:
+      //   1. Phase 1 content visually disappearing (blocks=[] was too aggressive)
+      //   2. guard() stale-reference issues if loadHistory replaces messages
+      // Finalize the Phase 1 message (remove streaming flag so it stays visible)
+      delete streamingMsg.streaming
+      // Create a new Phase 2 streaming message
+      messages.value.push({
+        role: 'assistant',
+        content: '',
+        blocks: [],
+        streaming: true,
+        createdAt: new Date().toISOString(),
+        backend: currentBackend.value
+      })
+      // Re-acquire from the reactive array so subsequent mutations go through Vue's proxy
+      streamingMsg = messages.value[messages.value.length - 1]
+      onRenderNeeded()
       debouncedRender()
     })
 


### PR DESCRIPTION
## 修复内容

### Bug 1：聊天自动总结后切换到总结视图仍显示加载点

`ContentBlocks.vue` 中的加载点（三个点）条件是 `v-if="streaming && !cancelled"`，在总结/原文两个渲染分支之外独立渲染。当 `summary_update` WS 事件在 `loadHistory` 完成前到达，消息可能同时有 `showingSummary=true` 和 `streaming=true`，导致总结文本和加载点同时显示。

**修复：** 添加 `!(showingSummary && summary)` 守卫条件，当显示总结时隐藏流式加载点。

### Bug 2：AutoResume 流程中 Phase 1 消息消失

`resume_split` 处理器原来执行 `streamingMsg.blocks = []`，将 Phase 1 的所有内容从前端视觉上瞬间清除。同时复用同一个 `streamingMsg` 对象来承载 Phase 2 内容，导致：
1. **视觉消失**：用户看到 AI 回复内容突然清空
2. **guard() 失效**：如果 `loadHistory` 替换了 `messages.value`，`streamingMsg` 引用失效，后续所有 SSE 事件（包括 `done`）被静默丢弃

**修复：** 与后端行为对齐——`resume_split` 时不再清空 blocks，而是：
- 删除 Phase 1 消息的 `streaming` 标志（已完成，保持可见）
- 创建新的 Phase 2 流式消息（`streaming: true`）
- 更新 `streamingMsg` 闭包引用指向新消息

## 测试

新增 6 个 `resume_split` 单元测试，覆盖：
- Phase 1 消息 finalize + Phase 2 新消息创建
- Phase 2 内容路由到新消息
- Phase 1 内容保持可见
- guard() 在 resume_split 后保持有效
- Phase 2 消息的 backend 属性
- onRenderNeeded 回调调用

## 变更文件

- `web/src/components/chat/ContentBlocks.vue` — 加载点 v-if 增加 showingSummary 守卫
- `web/src/composables/useChatStream.ts` — resume_split 创建新消息而非清空 blocks
- `web/src/composables/__tests__/useChatStream.test.ts` — 新增 6 个测试