### PR TITLE
feat: quick send placeholder hint + UI polish

### DIFF
--- a/web/src/components/__tests__/chatInputBar.test.ts
+++ b/web/src/components/__tests__/chatInputBar.test.ts
@@ -64,6 +64,7 @@ const i18n = createI18n({
           placeholder: '输入消息…',
           placeholderQueue: '排队消息…',
           placeholderOptional: '添加描述（可选）',
+          placeholderQuickSend: '点击可执行快捷指令 →',
           send: '发送',
           enqueue: '排队',
           quickMenu: '快捷指令',

--- a/web/src/components/chat/ChatInputBar.vue
+++ b/web/src/components/chat/ChatInputBar.vue
@@ -84,7 +84,7 @@
           ref="textareaRef"
           v-model="inputText"
           :disabled="inputDisabled"
-          :placeholder="pendingFiles.length > 0 ? t('chat.input.placeholderOptional') : loading ? t('chat.input.placeholderQueue') : t('chat.input.placeholder')"
+          :placeholder="pendingFiles.length > 0 ? t('chat.input.placeholderOptional') : loading ? t('chat.input.placeholderQueue') : quickSendItems.length > 0 && !hasInputContent ? t('chat.input.placeholderQuickSend') : t('chat.input.placeholder')"
           rows="1"
           @keydown.enter.exact.prevent="$emit('send', inputText.trim())"
           @focus="onTextareaFocus"

--- a/web/src/components/chat/ModelModal.vue
+++ b/web/src/components/chat/ModelModal.vue
@@ -447,7 +447,6 @@ function handleClose() {
 .model-divider {
   height: 1px;
   background: var(--border-color, #e5e5e5);
-  margin: 0 14px;
 }
 
 .model-item,

--- a/web/src/components/common/BottomSheet.vue
+++ b/web/src/components/common/BottomSheet.vue
@@ -107,6 +107,7 @@ defineExpose({
   right: 0;
   top: 0;
   background: var(--bg-secondary, #fff);
+  border-top: 1px solid var(--border-color, #e0e0e0);
   display: flex;
   flex-direction: column;
   overflow: hidden;
@@ -119,6 +120,7 @@ defineExpose({
   height: auto;
   max-height: 50%;
   border-radius: 0;
+  border-top: 1px solid var(--border-color, #e0e0e0);
   box-shadow: 0 -4px 20px rgba(0, 0, 0, 0.15);
 }
 
@@ -241,6 +243,7 @@ defineExpose({
   height: auto;
   max-height: 100%;
   border-radius: 0;
+  border-top: 1px solid var(--border-color, #e0e0e0);
   box-shadow: 0 -4px 20px rgba(0, 0, 0, 0.15);
 }
 

--- a/web/src/components/common/ModalDialog.vue
+++ b/web/src/components/common/ModalDialog.vue
@@ -20,7 +20,7 @@
         <div class="modal-body">
           <slot />
         </div>
-        <div v-if="$slots.footer" class="modal-footer">
+        <div class="modal-footer" :class="{ 'modal-footer-default': !$slots.footer }">
           <slot name="footer" />
         </div>
         <slot name="after" />
@@ -90,13 +90,15 @@ defineExpose({
 
 .modal-dialog {
   background: var(--bg-secondary, #fff);
-  border-radius: 0;
+  border: 1px solid var(--border-color, #e0e0e0);
+  border-radius: 12px;
   width: 100%;
   max-height: 100%;
   height: auto;
   display: flex;
   flex-direction: column;
   overflow: hidden;
+  box-shadow: 0 8px 32px rgba(0, 0, 0, 0.18);
   animation: modal-scaleIn 0.25s cubic-bezier(0.34, 1.56, 0.64, 1);
 }
 
@@ -205,7 +207,15 @@ defineExpose({
   gap: 8px;
   padding: 6px 10px;
   border-top: 1px solid var(--border-color, #e5e5e5);
+  background: color-mix(in srgb, var(--accent-color, #0066cc) 3%, var(--bg-tertiary, #f8f8f8));
   flex-shrink: 0;
   justify-content: flex-end;
+  border-radius: 0 0 12px 12px;
+}
+
+.modal-footer-default {
+  min-height: 8px;
+  padding: 8px 10px;
+  justify-content: center;
 }
 </style>

--- a/web/src/components/session/SessionDrawer.vue
+++ b/web/src/components/session/SessionDrawer.vue
@@ -72,9 +72,6 @@
         </div>
       </button>
     </div>
-    <template #footer>
-      <button class="btn btn-secondary" @click="showAgentSelector = false">{{ t('common.cancel') }}</button>
-    </template>
   </ModalDialog>
 </template>
 
@@ -570,20 +567,6 @@ onUnmounted(() => {
   text-overflow: ellipsis;
   white-space: nowrap;
 }
-
-.btn-secondary {
-  padding: 5px 14px;
-  border: none;
-  border-radius: 4px;
-  font-size: 12px;
-  font-weight: 500;
-  cursor: pointer;
-  background: var(--bg-tertiary, #f0f0f0);
-  color: var(--text-primary, #1a1a1a);
-  transition: background 0.15s;
-}
-
-.btn-secondary:hover { background: #e0e0e0; }
 
 .session-list-sentinel {
   height: 1px;

--- a/web/src/i18n/locales/en.ts
+++ b/web/src/i18n/locales/en.ts
@@ -81,6 +81,7 @@ export default {
       placeholder: 'Type a message...',
       placeholderQueue: 'Type a message to enqueue...',
       placeholderOptional: 'Add description (optional)...',
+      placeholderQuickSend: 'Tap for quick send →',
       send: 'Send',
       enqueue: 'Enqueue',
       quickMenu: 'Quick commands',

--- a/web/src/i18n/locales/zh.ts
+++ b/web/src/i18n/locales/zh.ts
@@ -81,6 +81,7 @@ export default {
       placeholder: '输入消息...',
       placeholderQueue: '输入消息加入队列...',
       placeholderOptional: '添加描述（可选）...',
+      placeholderQuickSend: '点击可执行快捷指令 →',
       send: '发送',
       enqueue: '加入队列',
       quickMenu: '快捷指令',


### PR DESCRIPTION
## Summary

Closes #121

### Quick send placeholder
- When input is empty and quick-send items exist, show placeholder: `点击可执行快捷指令 →` / `Tap for quick send →`
- Queue mode placeholder (`输入消息加入队列...`) remains unchanged
- No extra DOM elements — zero screen space cost vs the previous approach of adding a `<div>` above the input row

### UI polish
- ModalDialog: border + 12px border-radius + shadow + footer background
- BottomSheet: border-top for visual separation
- ModelModal: remove divider horizontal margin
- SessionDrawer: remove unused footer cancel button and styles