### PR TITLE
fix: 修复 Review Issues 2026-05-27

### DIFF
--- a/.clawbench/issues/ISS-117.md
+++ b/.clawbench/issues/ISS-117.md
@@ -1,0 +1,23 @@
+---
+id: ISS-117
+status: fixed
+severity: critical
+dimension: P0 - Security
+created: 2026-05-21
+files: [internal/handler/auth.go]
+---
+
+## Description
+Session token generation uses a weak, hardcoded salt: `sha256(password + "clawbench-salt")`. The salt is publicly visible in source code and deterministic — same password always yields same session token. If the session cookie is leaked, the password can be brute-forced offline.
+
+## Impact
+Weak session token derivation enables offline brute-force attacks if cookie is intercepted. Violates defense-in-depth security principle.
+
+## Suggestion
+Use `crypto/rand` to generate a random session token (e.g., 32-byte hex) on each successful login, stored alongside the bcrypt hash.
+
+## History
+- 2026-05-21: Created by review 2026-05-21
+- 2026-05-23: Suspected resolved (code changed in [internal/handler/auth.go])
+- 2026-05-27: Suspected resolved (code changed in internal/handler/auth.go)
+- 2026-05-27: Verified fixed — session cookie now uses crypto/rand random token (CookieToken) instead of sha256(password+salt)

--- a/.clawbench/issues/ISS-131.md
+++ b/.clawbench/issues/ISS-131.md
@@ -1,0 +1,23 @@
+---
+id: ISS-131
+status: fixed
+severity: critical
+dimension: P0 - Security
+created: 2026-05-22
+files: [internal/handler/auth.go]
+---
+
+## Description
+When `model.SessionToken == ""`, the code generates a session token as `sha256(password + "clawbench-salt")`. This means the session token is deterministic from the password, and the salt is hard-coded in the source code. An attacker who knows the password can compute the session token without logging in.
+
+## Impact
+If someone knows the password, they can pre-compute the session token — the token provides no additional security beyond the password itself. This undermines the purpose of having a separate session token.
+
+## Suggestion
+Use `crypto/rand` to generate a random session token (e.g., 32-byte hex) on each successful login. Store the token alongside the bcrypt hash and compare with `subtle.ConstantTimeCompare` on subsequent requests.
+
+## History
+- 2026-05-22: Created by review 2026-05-22
+- 2026-05-23: Suspected resolved (code changed in [internal/handler/auth.go])
+- 2026-05-27: Suspected resolved (code changed in internal/handler/auth.go)
+- 2026-05-27: Verified fixed — CookieToken generated with crypto/rand, decoupled from password hash

--- a/.clawbench/issues/ISS-179.md
+++ b/.clawbench/issues/ISS-179.md
@@ -1,0 +1,24 @@
+---
+id: ISS-179
+status: fixed
+severity: critical
+dimension: P0 - Security
+created: 2026-05-25
+files: [internal/handler/git.go]
+---
+
+## Description
+
+`isValidGitRefName` regex `^[^ \t\n\r\x00-\x1f-][^ \t\n\r\x00-\x1f]*$` rejects leading `-`, whitespace, and control chars, but allows `\`, `;`, `|`, `$`, backticks, `!` — none of which are valid in git ref names. While `exec.Command` with separate args prevents shell injection, a ref name like `foo;rm` could still cause confusion if git or any future code passes it through a shell.
+
+## Impact
+
+Overly permissive validation could allow unexpected ref names that cause confusing error messages or, in a worst-case scenario, be exploited if code is later changed to use shell execution.
+
+## Suggestion
+
+Tighten the regex to only allow characters valid in git ref names: `^[a-zA-Z0-9./_-]+$` (or use git's own `check-ref-format` rules). At minimum, add `\`, `;`, `|`, `$`, `` ` ``, `!` to the exclusion set.
+
+## History
+- 2026-05-25: Created by review 2026-05-25
+- 2026-05-27: Fixed — tightened regex to `^[a-zA-Z0-9][a-zA-Z0-9./_-]*$` rejecting all shell metacharacters

--- a/.clawbench/issues/ISS-183.md
+++ b/.clawbench/issues/ISS-183.md
@@ -1,0 +1,22 @@
+---
+id: ISS-183
+status: fixed
+severity: critical
+dimension: P0 Security
+created: 2026-05-26
+files: [internal/handler/auth.go]
+---
+
+## Description
+The session token stored in the cookie is `sha256(password + "clawbench-salt")`. This means the cookie IS the SHA-256 hash of the password. An attacker who obtains the cookie (via XSS, network sniffing, or log leak) can replay it as a password — the SHA-256 of the cookie value matches the stored SessionToken.
+
+## Impact
+The cookie is a plaintext-equivalent credential that can be used both as a session token AND as the password itself. Cookie theft = full authentication bypass.
+
+## Suggestion
+Generate the session token independently of the password using `crypto/rand` (32-byte random token). Store the token in the cookie and validate via constant-time compare against a separate stored session token. The session token should not be derivable from the password.
+
+## History
+- 2026-05-26: Created by review 2026-05-26 (Block 5+6, CRIT-001)
+- 2026-05-27: Suspected resolved (code changed in internal/handler/auth.go)
+- 2026-05-27: Verified fixed — CookieToken is now crypto/rand random value, not derivable from password

--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -439,7 +439,7 @@ func main() {
 
 	// Initialize password verification state
 	if sha256Hash := model.ParseSHA256Hash(cfg.Password); sha256Hash != "" {
-		// Password is stored as SHA-256 hash — use directly as SessionToken
+		// Password is stored as SHA-256 hash — use directly for login/SSH verification
 		model.SessionToken = sha256Hash
 		model.PasswordIsSHA256 = true
 		// No bcrypt: the SHA-256 hash IS the verifier for login/SSH
@@ -453,6 +453,19 @@ func main() {
 		if cfg.Password != "" {
 			bcryptHash := generateBcryptHash(cfg.Password)
 			model.PasswordHash = bcryptHash
+		}
+	}
+
+	// Initialize cookie token (cryptographically random, decoupled from password).
+	// Load from disk if available; otherwise generate a new one.
+	// This ensures the cookie value cannot be derived from the password hash.
+	// (ISS-117, ISS-131, ISS-183)
+	if model.SessionToken != "" {
+		if persisted := model.LoadCookieToken(); persisted != "" {
+			model.CookieToken = persisted
+		} else {
+			model.CookieToken = model.GenerateRandomToken(32)
+			model.PersistCookieToken(model.CookieToken)
 		}
 	}
 

--- a/internal/handler/auth.go
+++ b/internal/handler/auth.go
@@ -119,7 +119,7 @@ func (l *loginLimiter) cleanupLoop() {
 // ServeAuthCheck returns 200 if the session cookie is valid, 401 otherwise.
 // Localhost requests are always considered authenticated (same as middleware.Auth).
 func ServeAuthCheck(w http.ResponseWriter, r *http.Request) {
-	if model.SessionToken == "" {
+	if model.SessionToken == "" && model.CookieToken == "" {
 		// No password set, always authenticated
 		w.WriteHeader(http.StatusOK)
 		return
@@ -129,8 +129,15 @@ func ServeAuthCheck(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusOK)
 		return
 	}
+	// Use CookieToken (cryptographically random) if available; fall back
+	// to SessionToken for backward compatibility during migration.
+	// (ISS-117, ISS-131, ISS-183)
+	validateToken := model.CookieToken
+	if validateToken == "" {
+		validateToken = model.SessionToken
+	}
 	token, err := r.Cookie(model.SessionCookie)
-	if err != nil || token == nil || subtle.ConstantTimeCompare([]byte(token.Value), []byte(model.SessionToken)) != 1 {
+	if err != nil || token == nil || subtle.ConstantTimeCompare([]byte(token.Value), []byte(validateToken)) != 1 {
 		writeLocalizedError(w, r, model.Unauthorized(nil))
 		return
 	}
@@ -188,15 +195,19 @@ func ServeLogin(w http.ResponseWriter, r *http.Request) {
 
 		if authenticated {
 			limiter.reset(remoteIP)
-			// Generate session token (SHA-256 of password + salt — used as cookie value, not password hash)
-			sessionToken := model.SessionToken
-			if sessionToken == "" {
-				hash := sha256.Sum256([]byte(body.Password + "clawbench-salt"))
-				sessionToken = hex.EncodeToString(hash[:])
+			// Generate a cryptographically random session token for the cookie.
+			// This decouples the cookie value from the password hash, so that
+			// obtaining the cookie does not reveal or allow computation of the
+			// password hash. (ISS-117, ISS-131, ISS-183)
+			cookieToken := model.CookieToken
+			if cookieToken == "" {
+				cookieToken = model.GenerateRandomToken(32)
+				model.CookieToken = cookieToken
+				model.PersistCookieToken(cookieToken)
 			}
 			http.SetCookie(w, &http.Cookie{
 				Name:     model.SessionCookie,
-				Value:    sessionToken,
+				Value:    cookieToken,
 				Path:     "/",
 				HttpOnly: true,
 				Secure:   r.TLS != nil,

--- a/internal/handler/auth_test.go
+++ b/internal/handler/auth_test.go
@@ -18,8 +18,9 @@ func TestServeAuthCheck(t *testing.T) {
 		env, teardown := setupTestEnv(t)
 		defer teardown()
 
-		// No password set
+		// No password set — both tokens must be empty
 		model.SessionToken = ""
+		model.CookieToken = ""
 
 		req := newRequest(t, http.MethodGet, "/api/auth/check", nil)
 		w := callHandler(ServeAuthCheck, req)
@@ -130,14 +131,18 @@ func TestServeLogin(t *testing.T) {
 		assert.Equal(t, http.StatusOK, w.Code)
 		assertJSONField(t, w, "ok", true)
 
-		// Verify cookie is set
+		// Verify cookie is set with the cryptographically random CookieToken
+		// (ISS-117, ISS-131, ISS-183: cookie value must NOT equal the password hash)
 		var foundCookie bool
 		for _, c := range w.Result().Cookies() {
 			if c.Name == model.SessionCookie {
 				foundCookie = true
-				assert.Equal(t, model.SessionToken, c.Value)
+				// Cookie value should be the random CookieToken, not the password-derived SessionToken
+				assert.Equal(t, model.CookieToken, c.Value)
 				assert.Equal(t, "/", c.Path)
 				assert.True(t, c.HttpOnly)
+				// Cookie must differ from the password hash (security: decoupled tokens)
+				assert.NotEqual(t, model.SessionToken, c.Value, "cookie must not equal password hash")
 			}
 		}
 		assert.True(t, foundCookie, "expected session cookie to be set")
@@ -199,6 +204,7 @@ func TestServeLogin(t *testing.T) {
 		defer teardown()
 
 		model.SessionToken = ""
+		model.CookieToken = ""
 		model.PasswordHash = nil
 
 		req := newRequest(t, http.MethodPost, "/login", map[string]string{

--- a/internal/handler/git.go
+++ b/internal/handler/git.go
@@ -22,10 +22,11 @@ import (
 var validGitSHA = regexp.MustCompile(`^[0-9a-f]{6,40}$`)
 
 // isValidGitRefName checks that a git ref name (branch/tag) is safe to pass
-// as a CLI argument. Disallows names starting with "-" (which git would
-// interpret as a flag) and names containing whitespace or control characters.
-// (ISS-151, ISS-152)
-var validGitRefName = regexp.MustCompile(`^[^ \t\n\r\x00-\x1f-][^ \t\n\r\x00-\x1f]*$`)
+// as a CLI argument. Only allows characters valid in git ref names:
+// alphanumeric, dot, slash, underscore, hyphen (not leading).
+// Tightened from the original permissive regex to prevent shell metacharacters
+// like `\`, `;`, `|`, `$`, backticks, `!` from passing validation. (ISS-179)
+var validGitRefName = regexp.MustCompile(`^[a-zA-Z0-9][a-zA-Z0-9./_-]*$`)
 
 // isValidGitSHA returns true if s looks like a valid hex commit SHA.
 // Also accepts "HEAD" which is a safe git ref used for working tree diffs.

--- a/internal/handler/git_test.go
+++ b/internal/handler/git_test.go
@@ -15,6 +15,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"golang.org/x/crypto/bcrypt"
 )
 
 // initGitRepo initializes a real git repo in dir with an initial commit.
@@ -3028,4 +3029,104 @@ func TestServeGitDeleteTag_UploadPackInjection(t *testing.T) {
 
 	w := callHandler(ServeGitTags, req)
 	assertStatus(t, w, http.StatusBadRequest)
+}
+
+// --- ISS-179: Tightened isValidGitRefName regex ---
+
+func TestIsValidGitRefName_ValidNames(t *testing.T) {
+	valid := []string{
+		"main",
+		"feature-x",
+		"feature_x",
+		"release/v1.0",
+		"v1.0",
+		"fix/issue-123",
+		"my-branch",
+		"123branch",
+		"a",
+	}
+	for _, name := range valid {
+		assert.True(t, isValidGitRefName(name), "expected %q to be valid", name)
+	}
+}
+
+func TestIsValidGitRefName_InvalidNames(t *testing.T) {
+	invalid := []string{
+		// Leading dash (flag injection)
+		"-evil",
+		// Shell metacharacters (ISS-179: tightened to reject these)
+		"foo;rm",
+		"foo|bar",
+		"foo$(cmd)",
+		"foo`cmd`",
+		"foo!bar",
+		"foo\\bar",
+		// Whitespace and control characters
+		"foo bar",
+		"foo\tbar",
+		"foo\nbar",
+		// Empty string
+		"",
+	}
+	for _, name := range invalid {
+		assert.False(t, isValidGitRefName(name), "expected %q to be invalid", name)
+	}
+}
+
+// --- ISS-117/131/183: Cookie token decoupled from password hash ---
+
+func TestServeLogin_CookieTokenDiffersFromPasswordHash(t *testing.T) {
+	// After login, the cookie value must NOT equal the password hash (SessionToken).
+	// The cookie value should be a cryptographically random CookieToken instead.
+	_, teardown := setupTestEnv(t)
+	defer teardown()
+
+	model.SessionToken = hashPassword("testpass")
+	bcryptHash, err := bcrypt.GenerateFromPassword([]byte("testpass"), bcrypt.MinCost)
+	require.NoError(t, err)
+	model.PasswordHash = bcryptHash
+
+	req := newRequest(t, http.MethodPost, "/login", map[string]string{
+		"password": "testpass",
+	})
+	w := callHandler(ServeLogin, req)
+
+	assert.Equal(t, http.StatusOK, w.Code)
+
+	// Find the session cookie
+	var cookieValue string
+	for _, c := range w.Result().Cookies() {
+		if c.Name == model.SessionCookie {
+			cookieValue = c.Value
+		}
+	}
+	assert.NotEmpty(t, cookieValue, "expected session cookie to be set")
+	// Cookie must differ from the password hash (SessionToken)
+	assert.NotEqual(t, model.SessionToken, cookieValue,
+		"cookie value must NOT equal the password-derived SessionToken (ISS-117, ISS-131, ISS-183)")
+	// CookieToken must be set and match the cookie
+	assert.NotEmpty(t, model.CookieToken, "CookieToken must be set after login")
+	assert.Equal(t, model.CookieToken, cookieValue, "cookie value must equal CookieToken")
+}
+
+func TestServeAuthCheck_UsesCookieToken(t *testing.T) {
+	// ServeAuthCheck should validate against CookieToken, not SessionToken
+	_, teardown := setupTestEnv(t)
+	defer teardown()
+
+	model.SessionToken = hashPassword("testpass")
+	model.CookieToken = model.GenerateRandomToken(32)
+
+	// Request with CookieToken should succeed
+	req := newRequest(t, http.MethodGet, "/api/auth/check", nil)
+	withAuthCookie(req, model.CookieToken)
+	w := callHandler(ServeAuthCheck, req)
+	assert.Equal(t, http.StatusOK, w.Code)
+
+	// Request with SessionToken (password hash) should fail
+	req2 := newRequest(t, http.MethodGet, "/api/auth/check", nil)
+	withAuthCookie(req2, model.SessionToken)
+	w2 := callHandler(ServeAuthCheck, req2)
+	assert.Equal(t, http.StatusUnauthorized, w2.Code,
+		"password hash should NOT be accepted as cookie value (ISS-117, ISS-131, ISS-183)")
 }

--- a/internal/handler/settings.go
+++ b/internal/handler/settings.go
@@ -1134,9 +1134,19 @@ func ServeConfigPassword(w http.ResponseWriter, r *http.Request) {
 	autoPasswordFile := filepath.Join(model.BinDir, ".clawbench", "auto-password")
 	os.Remove(autoPasswordFile)
 
-	slog.Info("password changed via settings API (restart required)")
+	// Update in-memory auth state so the change takes effect immediately
+	// (ISS-197 partial fix: password change should not require restart for auth)
+	newSHA256Hash := hex.EncodeToString(hash[:])
+	model.SessionToken = newSHA256Hash
+	model.PasswordIsSHA256 = true
+	model.PasswordHash = nil // SHA-256 mode: no bcrypt
+	// Rotate the cookie token so old sessions are invalidated
+	model.CookieToken = model.GenerateRandomToken(32)
+	model.PersistCookieToken(model.CookieToken)
+
+	slog.Info("password changed via settings API (in-memory auth state updated, old sessions invalidated)")
 	writeJSON(w, http.StatusOK, map[string]any{
-		"needs_restart": true,
+		"needs_restart": false, // Auth state updated in-memory; no restart needed for auth
 	})
 }
 

--- a/internal/handler/settings_password_test.go
+++ b/internal/handler/settings_password_test.go
@@ -44,7 +44,7 @@ func TestServeConfigPassword_Success(t *testing.T) {
 
 	var resp map[string]interface{}
 	json.Unmarshal(w.Body.Bytes(), &resp)
-	assert.Equal(t, true, resp["needs_restart"])
+	assert.Equal(t, false, resp["needs_restart"])
 
 	// Verify config.yaml was written with sha256: prefix
 	configData, err := os.ReadFile(filepath.Join(model.BinDir, "config", "config.yaml"))
@@ -154,7 +154,7 @@ func TestServeConfigPassword_SHA256StoredPassword(t *testing.T) {
 
 	var resp map[string]interface{}
 	json.Unmarshal(w.Body.Bytes(), &resp)
-	assert.Equal(t, true, resp["needs_restart"])
+	assert.Equal(t, false, resp["needs_restart"])
 
 	// Verify config.yaml was written with sha256: prefix
 	configData, err := os.ReadFile(filepath.Join(model.BinDir, "config", "config.yaml"))
@@ -258,6 +258,7 @@ func TestServeConfig_Get_HasPassword(t *testing.T) {
 
 	// Without password
 	model.SessionToken = ""
+	model.CookieToken = ""
 	req = newRequest(t, http.MethodGet, "/api/config", nil)
 	withAuthCookie(req, "")
 	w = callHandler(ServeConfig, req)
@@ -308,6 +309,7 @@ func TestServeConfigPassword_NoPasswordHash(t *testing.T) {
 
 	// Simulate no password set (no bcrypt hash, not SHA-256)
 	model.SessionToken = ""
+	model.CookieToken = ""
 	model.PasswordIsSHA256 = false
 	model.PasswordHash = nil
 	model.ConfigInstance = model.Config{}

--- a/internal/handler/testutil_test.go
+++ b/internal/handler/testutil_test.go
@@ -24,11 +24,12 @@ import (
 
 // testEnv holds test environment state for setup/teardown.
 type testEnv struct {
-	ProjectDir string
-	WatchDir   string
-	OrigToken  string
-	OrigWatch  string
-	OrigDB     *sql.DB
+	ProjectDir      string
+	WatchDir        string
+	OrigToken       string
+	OrigCookieToken string
+	OrigWatch       string
+	OrigDB          *sql.DB
 }
 
 // setupTestEnv creates a temporary project directory, initializes an in-memory DB,
@@ -43,6 +44,7 @@ func setupTestEnv(t *testing.T) (*testEnv, func()) {
 
 	// Save original globals
 	origToken := model.SessionToken
+	origCookieToken := model.CookieToken
 	origWatch := model.WatchDir
 	origDB := service.DB
 	origDBRead := service.DBRead
@@ -51,6 +53,7 @@ func setupTestEnv(t *testing.T) (*testEnv, func()) {
 
 	// Set test globals
 	model.SessionToken = ""
+	model.CookieToken = ""
 	model.WatchDir = watchDir
 
 	// Init in-memory SQLite
@@ -189,15 +192,17 @@ func setupTestEnv(t *testing.T) (*testEnv, func()) {
 	model.AgentList = []*model.Agent{model.Agents["codebuddy"], model.Agents["claude"]}
 
 	env := &testEnv{
-		ProjectDir: projectDir,
-		WatchDir:   watchDir,
-		OrigToken:  origToken,
-		OrigWatch:  origWatch,
-		OrigDB:     origDB,
+		ProjectDir:      projectDir,
+		WatchDir:        watchDir,
+		OrigToken:       origToken,
+		OrigCookieToken: origCookieToken,
+		OrigWatch:       origWatch,
+		OrigDB:          origDB,
 	}
 
 	teardown := func() {
 		model.SessionToken = origToken
+		model.CookieToken = origCookieToken
 		model.WatchDir = origWatch
 		model.Agents = origAgents
 		model.AgentList = origAgentList

--- a/internal/middleware/auth.go
+++ b/internal/middleware/auth.go
@@ -26,7 +26,7 @@ func IsLocalhost(r *http.Request) bool {
 func Auth(next http.HandlerFunc) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		// No password configured — open access
-		if model.SessionToken == "" {
+		if model.SessionToken == "" && model.CookieToken == "" {
 			next.ServeHTTP(w, r)
 			return
 		}
@@ -36,8 +36,15 @@ func Auth(next http.HandlerFunc) http.HandlerFunc {
 			return
 		}
 		// Remote — cookie-based auth
+		// Use CookieToken (cryptographically random) if available; fall back
+		// to SessionToken for backward compatibility during migration.
+		// (ISS-117, ISS-131, ISS-183)
+		validateToken := model.CookieToken
+		if validateToken == "" {
+			validateToken = model.SessionToken
+		}
 		token, err := r.Cookie(model.SessionCookie)
-		if err == nil && token != nil && subtle.ConstantTimeCompare([]byte(token.Value), []byte(model.SessionToken)) == 1 {
+		if err == nil && token != nil && subtle.ConstantTimeCompare([]byte(token.Value), []byte(validateToken)) == 1 {
 			next.ServeHTTP(w, r)
 			return
 		}

--- a/internal/middleware/auth_test.go
+++ b/internal/middleware/auth_test.go
@@ -17,10 +17,14 @@ func okHandler(w http.ResponseWriter, r *http.Request) {
 	w.WriteHeader(http.StatusOK)
 }
 
-// withSavedToken saves model.SessionToken, runs f, then restores it.
+// withSavedToken saves model.SessionToken and model.CookieToken, runs f, then restores them.
 func withSavedToken(f func()) {
-	orig := model.SessionToken
-	defer func() { model.SessionToken = orig }()
+	origSession := model.SessionToken
+	origCookie := model.CookieToken
+	defer func() {
+		model.SessionToken = origSession
+		model.CookieToken = origCookie
+	}()
 	f()
 }
 

--- a/internal/model/config.go
+++ b/internal/model/config.go
@@ -1,6 +1,11 @@
 package model
 
-import "strings"
+import (
+	"crypto/rand"
+	"encoding/hex"
+	"os"
+	"strings"
+)
 
 // IsSHA256Password returns true if the password field contains a SHA-256
 // hashed value (prefixed with "sha256:"). These passwords are stored as
@@ -170,7 +175,8 @@ var ConfigInstance Config
 var (
 	BinDir         string // Directory of the running binary
 	WatchDir       string
-	SessionToken   string
+	SessionToken   string // Legacy: stores the password-derived token for "has password" check; NOT used for cookie validation when CookieToken is set
+	CookieToken    string // Cryptographically random session token for cookie validation (ISS-117, ISS-131, ISS-183)
 	PasswordHash   []byte // bcrypt hash for password verification (ISS-003a)
 	PasswordIsSHA256 bool  // true when config.yaml stores password as sha256:<hex>
 	SessionCookie  = "clawbench_session"
@@ -196,3 +202,43 @@ var (
 	// TTS cache limits (set from config, with defaults)
 	TTSMaxCacheFiles int // Default: 100; 0 = unlimited
 )
+
+// GenerateRandomToken creates a cryptographically random hex token of the
+// specified byte length. Used for session cookie tokens to decouple them
+// from password hashes. (ISS-117, ISS-131, ISS-183)
+func GenerateRandomToken(byteLen int) string {
+	b := make([]byte, byteLen)
+	// crypto/rand.Read always fills b or returns an error; panic is appropriate
+	// for a failure this fundamental (system entropy source unavailable).
+	if _, err := rand.Read(b); err != nil {
+		panic("crypto/rand: failed to generate random token: " + err.Error())
+	}
+	return hex.EncodeToString(b)
+}
+
+// PersistCookieToken writes the cookie token to .clawbench/cookie-token so it
+// survives server restarts. The token is not secret (it's validated via
+// constant-time compare), but it should not be readable by other users.
+func PersistCookieToken(token string) {
+	if BinDir == "" {
+		return
+	}
+	path := BinDir + "/.clawbench/cookie-token"
+	if err := os.WriteFile(path, []byte(token), 0600); err != nil {
+		// Non-fatal: cookie will simply not survive restart; user re-logs in.
+		_ = err
+	}
+}
+
+// LoadCookieToken reads the persisted cookie token from .clawbench/cookie-token.
+// Returns empty string if the file does not exist or cannot be read.
+func LoadCookieToken() string {
+	if BinDir == "" {
+		return ""
+	}
+	data, err := os.ReadFile(BinDir + "/.clawbench/cookie-token")
+	if err != nil {
+		return ""
+	}
+	return strings.TrimSpace(string(data))
+}

--- a/internal/model/config.go
+++ b/internal/model/config.go
@@ -223,7 +223,9 @@ func PersistCookieToken(token string) {
 	if BinDir == "" {
 		return
 	}
-	path := BinDir + "/.clawbench/cookie-token"
+	dir := BinDir + "/.clawbench"
+	os.MkdirAll(dir, 0755) // best-effort: if this fails, WriteFile will also fail
+	path := dir + "/cookie-token"
 	if err := os.WriteFile(path, []byte(token), 0600); err != nil {
 		// Non-fatal: cookie will simply not survive restart; user re-logs in.
 		_ = err

--- a/internal/model/config_test.go
+++ b/internal/model/config_test.go
@@ -86,3 +86,81 @@ func TestApplyDefaults_SHA256PasswordRemovesAutoPasswordFile(t *testing.T) {
 	_, err := os.Stat(autoFile)
 	assert.True(t, os.IsNotExist(err), "auto-password file should be removed when SHA-256 password is set")
 }
+
+// --- ISS-117/131/183: GenerateRandomToken, PersistCookieToken, LoadCookieToken ---
+
+func TestGenerateRandomToken_Length(t *testing.T) {
+	token := GenerateRandomToken(32)
+	// 32 bytes = 64 hex chars
+	assert.Len(t, token, 64)
+}
+
+func TestGenerateRandomToken_Uniqueness(t *testing.T) {
+	token1 := GenerateRandomToken(32)
+	token2 := GenerateRandomToken(32)
+	assert.NotEqual(t, token1, token2, "two random tokens should differ")
+}
+
+func TestGenerateRandomToken_HexChars(t *testing.T) {
+	token := GenerateRandomToken(16)
+	for _, c := range token {
+		assert.True(t, (c >= '0' && c <= '9') || (c >= 'a' && c <= 'f'),
+			"token should only contain hex chars, got: %c", c)
+	}
+}
+
+func TestPersistAndLoadCookieToken(t *testing.T) {
+	tmpDir := t.TempDir()
+	origBinDir := BinDir
+	BinDir = tmpDir
+	defer func() { BinDir = origBinDir }()
+
+	token := GenerateRandomToken(32)
+	PersistCookieToken(token)
+
+	loaded := LoadCookieToken()
+	assert.Equal(t, token, loaded)
+}
+
+func TestLoadCookieToken_NoFile(t *testing.T) {
+	tmpDir := t.TempDir()
+	origBinDir := BinDir
+	BinDir = tmpDir
+	defer func() { BinDir = origBinDir }()
+
+	// No file exists yet
+	loaded := LoadCookieToken()
+	assert.Equal(t, "", loaded)
+}
+
+func TestLoadCookieToken_EmptyBinDir(t *testing.T) {
+	origBinDir := BinDir
+	BinDir = ""
+	defer func() { BinDir = origBinDir }()
+
+	loaded := LoadCookieToken()
+	assert.Equal(t, "", loaded, "empty BinDir should return empty token")
+}
+
+func TestPersistCookieToken_EmptyBinDir(t *testing.T) {
+	origBinDir := BinDir
+	BinDir = ""
+	defer func() { BinDir = origBinDir }()
+
+	// Should not panic
+	PersistCookieToken("some-token")
+}
+
+func TestPersistCookieToken_WriteFailure(t *testing.T) {
+	tmpDir := t.TempDir()
+	origBinDir := BinDir
+	BinDir = tmpDir
+	defer func() { BinDir = origBinDir }()
+
+	// Create .clawbench as a read-only file (not a directory) to cause WriteFile to fail
+	clawbenchDir := filepath.Join(tmpDir, ".clawbench")
+	require.NoError(t, os.WriteFile(clawbenchDir, []byte("not-a-dir"), 0600))
+
+	// Should not panic — error is silently ignored
+	PersistCookieToken("some-token")
+}


### PR DESCRIPTION
修复 Critical Issues: ISS-117, ISS-131, ISS-179, ISS-183

## 修复内容

### ISS-179: 收紧 isValidGitRefName 正则
- 从宽松的排除式 `^[^ \t\n\r\x00-\x1f-][^ \t\n\r\x00-\x1f]*$` 改为严格的允许式 `^[a-zA-Z0-9][a-zA-Z0-9./_-]*$`
- 拒绝 ; | $ ` ` ! \\ 等 shell 元字符通过验证

### ISS-117/131/183: Session cookie token 与密码 hash 解耦
- 新增 `model.CookieToken` (crypto/rand 随机 32 字节)
- 登录成功后生成随机 CookieToken 作为 cookie 值
- CookieToken 持久化到 .clawbench/cookie-token
- middleware/auth.go 和 ServeAuthCheck 优先验证 CookieToken
- 密码变更后立即更新 in-memory auth state + 轮换 CookieToken

## 测试
- 新增 TestIsValidGitRefName_ValidNames/InvalidNames
- 新增 TestServeLogin_CookieTokenDiffersFromPasswordHash
- 新增 TestServeAuthCheck_UsesCookieToken
- 全部 go test ./... 通过