### PR TITLE
fix: Pi/DeepSeek 模型发现 — 添加 provider 前缀 & 修复 stderr 输出

### DIFF
--- a/config/agents/pi.yaml
+++ b/config/agents/pi.yaml
@@ -1,7 +1,8 @@
+backend: pi
+icon: "\U0001F967"
 id: pi
 name: Pi
-icon: 🥧
+preferred_model: minimax-cn/MiniMax-M2.7
 specialty: 极简编程智能体 — 4 工具核心 + 多模型支持
-backend: pi
 system_prompt: |
-  You are a versatile assistant powered by Pi, capable of handling code, documentation, operations, research, and various tasks.
+    You are a versatile assistant powered by Pi, capable of handling code, documentation, operations, research, and various tasks.

--- a/internal/ai/deepseek.go
+++ b/internal/ai/deepseek.go
@@ -1,5 +1,7 @@
 package ai
 
+import "strings"
+
 // deepseekBackend is the CLIBackend instance for DeepSeek TUI CLI.
 var deepseekBackend = &CLIBackend{
 	name:           "deepseek",
@@ -41,9 +43,15 @@ func buildDeepSeekStreamArgs(req ChatRequest) []string {
 		args = append(args, "--system-prompt", req.SystemPrompt)
 	}
 
-	// Model override
+	// Model override — DeepSeek CLI expects a plain model ID (e.g. "deepseek-v4-pro"),
+	// but ClawBench stores model IDs as "provider/model" (e.g. "deepseek/deepseek-v4-pro").
+	// Strip the provider prefix before passing to the CLI.
 	if req.Model != "" {
-		args = append(args, "--model", req.Model)
+		if idx := strings.LastIndex(req.Model, "/"); idx >= 0 {
+			args = append(args, "--model", req.Model[idx+1:])
+		} else {
+			args = append(args, "--model", req.Model)
+		}
 	}
 
 	// Prompt is the last positional argument

--- a/internal/ai/deepseek_stream_test.go
+++ b/internal/ai/deepseek_stream_test.go
@@ -247,6 +247,61 @@ func TestBuildDeepSeekStreamArgsWithModel(t *testing.T) {
 	}
 }
 
+func TestBuildDeepSeekStreamArgsWithProviderModel(t *testing.T) {
+	// When model ID includes provider prefix (e.g. "deepseek/deepseek-v4-pro"),
+	// the provider prefix should be stripped before passing to the CLI.
+	req := ChatRequest{
+		Prompt: "hello",
+		Model:  "deepseek/deepseek-v4-pro",
+	}
+	args := buildDeepSeekStreamArgs(req)
+
+	found := false
+	for i, arg := range args {
+		if arg == "--model" && i+1 < len(args) && args[i+1] == "deepseek-v4-pro" {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Errorf("expected --model deepseek-v4-pro (stripped provider) in args: %v", args)
+	}
+}
+
+func TestBuildDeepSeekStreamArgsWithProviderModel_NestedSlashes(t *testing.T) {
+	// Edge case: model ID with multiple slashes — should strip up to the last slash
+	req := ChatRequest{
+		Prompt: "hello",
+		Model:  "a/b/deepseek-v4-flash",
+	}
+	args := buildDeepSeekStreamArgs(req)
+
+	found := false
+	for i, arg := range args {
+		if arg == "--model" && i+1 < len(args) && args[i+1] == "deepseek-v4-flash" {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Errorf("expected --model deepseek-v4-flash (stripped all provider prefixes) in args: %v", args)
+	}
+}
+
+func TestBuildDeepSeekStreamArgsWithNoModel(t *testing.T) {
+	// When no model is specified, --model flag should not appear
+	req := ChatRequest{
+		Prompt: "hello",
+	}
+	args := buildDeepSeekStreamArgs(req)
+
+	for i, arg := range args {
+		if arg == "--model" {
+			t.Errorf("unexpected --model flag in args when no model specified: %v", args[i:])
+		}
+	}
+}
+
 func TestBuildDeepSeekStreamArgsWithResume(t *testing.T) {
 	req := ChatRequest{
 		Prompt:   "continue",

--- a/internal/model/discovery.go
+++ b/internal/model/discovery.go
@@ -60,7 +60,7 @@ var BackendRegistry = []BackendSpec{
 	{ID: "deepseek", Backend: "deepseek", DefaultCmd: "deepseek", Name: "DeepSeek", Icon: "🔍", Specialty: "DeepSeek 推理与编码",
 		ListModelsCmd: []string{"models"}, ParseModels: ParseDeepSeekModels},
 	{ID: "pi", Backend: "pi", DefaultCmd: "pi", Name: "Pi", Icon: "🥧", Specialty: "极简编程智能体",
-		ListModelsCmd: []string{"--list-models"}, ParseModels: ParsePiModels,
+		DiscoverModelsFunc: DiscoverPiModels,
 		ThinkingEffortLevels: []string{"off", "minimal", "low", "medium", "high", "xhigh"}},
 }
 
@@ -679,7 +679,8 @@ var deepseekDefaultRe = regexp.MustCompile(`Available models \(default:\s*(\S+)\
 //	  deepseek-v4-flash (deepseek)
 //	* deepseek-v4-pro (deepseek)
 //
-// Only models from the "deepseek" provider are included (other providers are third-party replicas).
+// The Name field includes the provider prefix for disambiguation (e.g., "deepseek/deepseek-v4-pro"),
+// consistent with Pi and OpenCode model naming.
 func ParseDeepSeekModels(output string) []AgentModel {
 	// Extract default model name from header
 	var defaultModel string
@@ -702,9 +703,10 @@ func ParseDeepSeekModels(output string) []AgentModel {
 			continue
 		}
 
+		fullID := provider + "/" + modelID
 		models = append(models, AgentModel{
-			ID:      modelID,
-			Name:    modelID,
+			ID:      fullID,
+			Name:    fullID,
 			Default: isDefault,
 		})
 	}
@@ -775,10 +777,34 @@ func ParsePiModels(output string) []AgentModel {
 		fullID := provider + "/" + modelID
 		models = append(models, AgentModel{
 			ID:      fullID,
-			Name:    modelID,
+			Name:    fullID,
 			Default: len(models) == 0,
 		})
 	}
+	return models
+}
+
+// DiscoverPiModels discovers Pi model IDs by running `pi --list-models` and parsing the output.
+// Pi outputs the model table to stderr (not stdout), so we must capture both streams.
+func DiscoverPiModels() []AgentModel {
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	cmd := exec.CommandContext(ctx, "pi", "--list-models")
+	// Pi outputs the model table to stderr; use CombinedOutput to capture both.
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		slog.Debug("pi model discovery: command failed", "error", err)
+		return nil
+	}
+
+	models := ParsePiModels(string(out))
+	if len(models) == 0 {
+		slog.Debug("pi model discovery: no models parsed")
+		return nil
+	}
+
+	slog.Info("pi model discovery succeeded", "models", len(models))
 	return models
 }
 

--- a/internal/model/discovery_test.go
+++ b/internal/model/discovery_test.go
@@ -275,9 +275,11 @@ func TestParseDeepSeekModels_RealOutput(t *testing.T) {
 	models := model.ParseDeepSeekModels(output)
 	require.Len(t, models, 2, "should only include deepseek provider models, not third-party")
 
-	assert.Equal(t, "deepseek-v4-flash", models[0].ID)
+	assert.Equal(t, "deepseek/deepseek-v4-flash", models[0].ID)
+	assert.Equal(t, "deepseek/deepseek-v4-flash", models[0].Name)
 	assert.False(t, models[0].Default, "flash is not the default")
-	assert.Equal(t, "deepseek-v4-pro", models[1].ID)
+	assert.Equal(t, "deepseek/deepseek-v4-pro", models[1].ID)
+	assert.Equal(t, "deepseek/deepseek-v4-pro", models[1].Name)
 	assert.True(t, models[1].Default, "pro is the default (marked with *)")
 }
 
@@ -308,6 +310,35 @@ func TestParseDeepSeekModels_DefaultFromHeader(t *testing.T) {
 	require.Len(t, models, 2)
 	assert.False(t, models[0].Default)
 	assert.True(t, models[1].Default, "should match default from header")
+}
+
+func TestParseDeepSeekModels_ProviderPrefixInIDAndName(t *testing.T) {
+	// Verify that provider prefix is included in both ID and Name
+	output := `Available models (default: deepseek-v4-pro)
+* deepseek-v4-pro (deepseek)
+  deepseek-v4-flash (deepseek)
+`
+	models := model.ParseDeepSeekModels(output)
+	require.Len(t, models, 2)
+
+	assert.Equal(t, "deepseek/deepseek-v4-pro", models[0].ID)
+	assert.Equal(t, "deepseek/deepseek-v4-pro", models[0].Name)
+	assert.True(t, models[0].Default)
+
+	assert.Equal(t, "deepseek/deepseek-v4-flash", models[1].ID)
+	assert.Equal(t, "deepseek/deepseek-v4-flash", models[1].Name)
+}
+
+func TestParseDeepSeekModels_ThirdPartyProviderFiltered(t *testing.T) {
+	// Non-deepseek providers should be filtered out
+	output := `Available models (default: deepseek-v4-pro)
+  deepseek-v4-pro (deepseek)
+  deepseek-v4-pro (nvidia-nim)
+  gpt-4.1 (openai)
+`
+	models := model.ParseDeepSeekModels(output)
+	require.Len(t, models, 1)
+	assert.Equal(t, "deepseek/deepseek-v4-pro", models[0].ID)
 }
 
 func TestParseOpenCodeModels_RealOutput(t *testing.T) {
@@ -379,9 +410,9 @@ func TestBackendRegistry_ModelDiscoveryConfig(t *testing.T) {
 	assert.NotEmpty(t, specs["deepseek"].ListModelsCmd, "deepseek should have ListModelsCmd")
 	assert.NotNil(t, specs["deepseek"].ParseModels, "deepseek should have ParseModels")
 
-	// pi should have model discovery
-	assert.NotEmpty(t, specs["pi"].ListModelsCmd, "pi should have ListModelsCmd")
-	assert.NotNil(t, specs["pi"].ParseModels, "pi should have ParseModels")
+	// pi should have model discovery via DiscoverModelsFunc (outputs to stderr, not stdout)
+	assert.NotNil(t, specs["pi"].DiscoverModelsFunc, "pi should have DiscoverModelsFunc")
+	assert.Empty(t, specs["pi"].ListModelsCmd, "pi should not have ListModelsCmd")
 
 	// claude should have model discovery via DiscoverModelsFunc (binary strings scanning)
 	assert.NotNil(t, specs["claude"].DiscoverModelsFunc, "claude should have DiscoverModelsFunc")
@@ -485,10 +516,10 @@ minimax         MiniMax-M2.7                204.8K   131.1K   yes       no`
 	models := model.ParsePiModels(output)
 	require.Len(t, models, 4)
 	assert.Equal(t, "anthropic/claude-sonnet-4-6", models[0].ID)
-	assert.Equal(t, "claude-sonnet-4-6", models[0].Name)
+	assert.Equal(t, "anthropic/claude-sonnet-4-6", models[0].Name)
 	assert.True(t, models[0].Default, "first model should be default")
 	assert.Equal(t, "minimax/MiniMax-M2.7", models[3].ID)
-	assert.Equal(t, "MiniMax-M2.7", models[3].Name)
+	assert.Equal(t, "minimax/MiniMax-M2.7", models[3].Name)
 }
 
 func TestParsePiModels_EmptyOutput(t *testing.T) {
@@ -1529,6 +1560,146 @@ models: []
 	data, err := os.ReadFile(filepath.Join(agentsDir, "test-existing.yaml"))
 	require.NoError(t, err)
 	assert.Contains(t, string(data), "Test Existing")
+}
+
+// --- Test 18: DiscoverPiModels with fake CLI ---
+
+func TestDiscoverPiModels_FakeCLI_Success(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("Skipping on Windows — fake CLI scripts not executable")
+	}
+
+	tmpDir := t.TempDir()
+	binDir := filepath.Join(tmpDir, "bin")
+	require.NoError(t, os.MkdirAll(binDir, 0755))
+
+	// Create a fake "pi" script that outputs model table to stderr (like real Pi)
+	fakeCLI := filepath.Join(binDir, "pi")
+	script := `#!/bin/sh
+cat >&2 <<'EOF'
+provider        model                       context  max-out  thinking  images
+anthropic       claude-sonnet-4-6           1M       64K      yes       yes
+minimax         MiniMax-M2.7                204.8K   131.1K   yes       no
+minimax-cn      MiniMax-M2.7                204.8K   131.1K   yes       no
+EOF
+`
+	require.NoError(t, os.WriteFile(fakeCLI, []byte(script), 0755))
+
+	origPath := os.Getenv("PATH")
+	require.NoError(t, os.Setenv("PATH", binDir+string(os.PathListSeparator)+origPath))
+	t.Cleanup(func() { os.Setenv("PATH", origPath) })
+
+	models := model.DiscoverPiModels()
+	require.Len(t, models, 3)
+	assert.Equal(t, "anthropic/claude-sonnet-4-6", models[0].ID)
+	assert.Equal(t, "anthropic/claude-sonnet-4-6", models[0].Name)
+	assert.True(t, models[0].Default)
+	assert.Equal(t, "minimax/MiniMax-M2.7", models[1].ID)
+	assert.Equal(t, "minimax/MiniMax-M2.7", models[1].Name)
+	assert.Equal(t, "minimax-cn/MiniMax-M2.7", models[2].ID)
+	assert.Equal(t, "minimax-cn/MiniMax-M2.7", models[2].Name)
+}
+
+func TestDiscoverPiModels_FakeCLI_EmptyOutput(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("Skipping on Windows — fake CLI scripts not executable")
+	}
+
+	tmpDir := t.TempDir()
+	binDir := filepath.Join(tmpDir, "bin")
+	require.NoError(t, os.MkdirAll(binDir, 0755))
+
+	// Create a fake "pi" script that outputs only the header (no model data)
+	fakeCLI := filepath.Join(binDir, "pi")
+	script := `#!/bin/sh
+cat >&2 <<'EOF'
+provider        model                       context  max-out  thinking  images
+EOF
+`
+	require.NoError(t, os.WriteFile(fakeCLI, []byte(script), 0755))
+
+	origPath := os.Getenv("PATH")
+	require.NoError(t, os.Setenv("PATH", binDir+string(os.PathListSeparator)+origPath))
+	t.Cleanup(func() { os.Setenv("PATH", origPath) })
+
+	models := model.DiscoverPiModels()
+	assert.Nil(t, models, "should return nil when no models parsed from output")
+}
+
+func TestDiscoverPiModels_FakeCLI_CommandFails(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("Skipping on Windows — fake CLI scripts not executable")
+	}
+
+	tmpDir := t.TempDir()
+	binDir := filepath.Join(tmpDir, "bin")
+	require.NoError(t, os.MkdirAll(binDir, 0755))
+
+	// Create a fake "pi" script that exits with non-zero code
+	fakeCLI := filepath.Join(binDir, "pi")
+	require.NoError(t, os.WriteFile(fakeCLI, []byte("#!/bin/sh\nexit 1\n"), 0755))
+
+	origPath := os.Getenv("PATH")
+	require.NoError(t, os.Setenv("PATH", binDir+string(os.PathListSeparator)+origPath))
+	t.Cleanup(func() { os.Setenv("PATH", origPath) })
+
+	models := model.DiscoverPiModels()
+	assert.Nil(t, models, "should return nil when pi command fails")
+}
+
+func TestDiscoverPiModels_NotOnPATH(t *testing.T) {
+	// Ensure PATH doesn't contain a "pi" binary
+	origPath := os.Getenv("PATH")
+	require.NoError(t, os.Setenv("PATH", t.TempDir()))
+	t.Cleanup(func() { os.Setenv("PATH", origPath) })
+
+	models := model.DiscoverPiModels()
+	assert.Nil(t, models, "should return nil when pi is not on PATH")
+}
+
+func TestDiscoverPiModels_FakeCLI_OutputToStdout(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("Skipping on Windows — fake CLI scripts not executable")
+	}
+
+	tmpDir := t.TempDir()
+	binDir := filepath.Join(tmpDir, "bin")
+	require.NoError(t, os.MkdirAll(binDir, 0755))
+
+	// Create a fake "pi" script that outputs to stdout (like the old behavior)
+	fakeCLI := filepath.Join(binDir, "pi")
+	script := `#!/bin/sh
+cat <<'EOF'
+provider        model                       context  max-out  thinking  images
+anthropic       claude-sonnet-4-6           1M       64K      yes       yes
+EOF
+`
+	require.NoError(t, os.WriteFile(fakeCLI, []byte(script), 0755))
+
+	origPath := os.Getenv("PATH")
+	require.NoError(t, os.Setenv("PATH", binDir+string(os.PathListSeparator)+origPath))
+	t.Cleanup(func() { os.Setenv("PATH", origPath) })
+
+	// CombinedOutput captures both stdout and stderr, so stdout output works too
+	models := model.DiscoverPiModels()
+	require.Len(t, models, 1)
+	assert.Equal(t, "anthropic/claude-sonnet-4-6", models[0].ID)
+}
+
+// --- Test 19: ParsePiModels additional edge cases ---
+
+func TestParsePiModels_DuplicateModelName(t *testing.T) {
+	// When two providers have the same model name, they should be distinguishable
+	output := `provider        model                       context  max-out  thinking  images
+minimax         MiniMax-M2.7                204.8K   131.1K   yes       no
+minimax-cn      MiniMax-M2.7                204.8K   131.1K   yes       no
+`
+	models := model.ParsePiModels(output)
+	require.Len(t, models, 2)
+	assert.Equal(t, "minimax/MiniMax-M2.7", models[0].ID)
+	assert.Equal(t, "minimax/MiniMax-M2.7", models[0].Name)
+	assert.Equal(t, "minimax-cn/MiniMax-M2.7", models[1].ID)
+	assert.Equal(t, "minimax-cn/MiniMax-M2.7", models[1].Name)
 }
 
 // --- Test 15: ParseCodebuddyModels edge cases ---


### PR DESCRIPTION
## 修改内容

### 1. Pi 模型发现修复：stderr 输出
- **根因**：`pi --list-models` 将模型表格输出到 stderr 而非 stdout，`cmd.Output()` 只捕获 stdout 导致拿到空字符串
- **修复**：将 Pi 从 `ListModelsCmd`+`ParseModels` 改为 `DiscoverModelsFunc`，使用 `cmd.CombinedOutput()` 同时捕获 stdout+stderr

### 2. Pi/DeepSeek 模型名称添加 provider 前缀
- **问题**：不同 provider 有同名模型（如 `minimax/MiniMax-M2.7` vs `minimax-cn/MiniMax-M2.7`），只显示 model ID 无法区分
- **修复**：`ParsePiModels` 和 `ParseDeepSeekModels` 的 Name 字段改为 `provider/model` 格式（与 OpenCode 一致）
- DeepSeek CLI 不接受 `provider/model` 格式的 `--model` 参数，在 `buildDeepSeekStreamArgs` 中用 `strings.LastIndex` 剥离 provider 前缀

### 3. 单元测试补充
- `DiscoverPiModels`：5 个 fake CLI 测试（成功/空输出/命令失败/不在PATH/stdout输出）
- `ParsePiModels`：同名不同 provider 区分测试
- `ParseDeepSeekModels`：provider 前缀测试、第三方 provider 过滤测试
- `buildDeepSeekStreamArgs`：provider 前缀剥离、多级斜杠、无 model 时不传参数

## 涉及文件
- `internal/model/discovery.go` — Pi 改 `DiscoverModelsFunc`；Pi/DeepSeek Name 加 provider 前缀
- `internal/model/discovery_test.go` — Pi/DeepSeek 新测试
- `internal/ai/deepseek.go` — `buildDeepSeekStreamArgs` 剥离 provider 前缀
- `internal/ai/deepseek_stream_test.go` — provider 前缀剥离测试
- `config/agents/pi.yaml` — 配置同步