### PR TITLE
feat: 移除上传文件类型限制，允许所有文件类型

### DIFF
--- a/internal/handler/chat_test.go
+++ b/internal/handler/chat_test.go
@@ -876,7 +876,7 @@ func TestUploadFile_WrongMethod(t *testing.T) {
 	assertStatus(t, w, http.StatusMethodNotAllowed)
 }
 
-func TestUploadFile_DangerousExtension(t *testing.T) {
+func TestUploadFile_ExeExtension_Allowed(t *testing.T) {
 	env, teardown := setupTestEnv(t)
 	defer teardown()
 
@@ -892,10 +892,10 @@ func TestUploadFile_DangerousExtension(t *testing.T) {
 	withProjectCookie(req, env.ProjectDir)
 
 	w := callHandler(UploadFile, req)
-	assertStatus(t, w, http.StatusBadRequest)
+	assertOK(t, w)
 }
 
-func TestUploadFile_DangerousBatExtension(t *testing.T) {
+func TestUploadFile_BatExtension_Allowed(t *testing.T) {
 	env, teardown := setupTestEnv(t)
 	defer teardown()
 
@@ -910,7 +910,7 @@ func TestUploadFile_DangerousBatExtension(t *testing.T) {
 	withProjectCookie(req, env.ProjectDir)
 
 	w := callHandler(UploadFile, req)
-	assertStatus(t, w, http.StatusBadRequest)
+	assertOK(t, w)
 }
 
 func TestAccumulateBlock_ErrorEvent(t *testing.T) {

--- a/internal/handler/coverage_new_test.go
+++ b/internal/handler/coverage_new_test.go
@@ -1345,7 +1345,7 @@ func TestUploadFile_NoExtension(t *testing.T) {
 	assert.Equal(t, http.StatusBadRequest, w.Code)
 }
 
-func TestUploadFilePost_DangerousExtensions(t *testing.T) {
+func TestUploadFilePost_AllExtensionsAllowed(t *testing.T) {
 	env, teardown := setupTestEnv(t)
 	defer teardown()
 
@@ -1366,14 +1366,14 @@ func TestUploadFilePost_DangerousExtensions(t *testing.T) {
 			writer := multipart.NewWriter(&buf)
 			part, createErr := writer.CreateFormFile("file", tt.ext)
 			require.NoError(t, createErr)
-			fmt.Fprint(part, "dangerous")
+			fmt.Fprint(part, "content")
 			writer.Close()
 
 			req := httptest.NewRequest(http.MethodPost, "/api/upload/file", &buf)
 			req.Header.Set("Content-Type", writer.FormDataContentType())
 			withProjectCookie(req, env.ProjectDir)
 			w := callHandler(UploadFile, req)
-			assert.Equal(t, http.StatusBadRequest, w.Code)
+			assert.Equal(t, http.StatusOK, w.Code)
 		})
 	}
 }

--- a/internal/handler/upload.go
+++ b/internal/handler/upload.go
@@ -52,19 +52,14 @@ func UploadFile(w http.ResponseWriter, r *http.Request) {
 	}
 	defer file.Close()
 
-	// Validate file extension — reject only hidden files and dangerous extensions
+	// Validate file extension — all file types are allowed.
+	// This is intentional: users upload code, configs, binaries, and arbitrary
+	// project files. We only require a non-empty extension so the file can be
+	// identified and served correctly. Content safety is enforced by the
+	// downstream consumer (AI agent / file viewer), not the upload endpoint.
 	ext := strings.ToLower(filepath.Ext(header.Filename))
 	if ext == "" {
 		writeLocalizedErrorf(w, r, http.StatusBadRequest, "FileMustHaveExtension")
-		return
-	}
-	dangerousExts := map[string]bool{
-		".exe": true, ".bat": true, ".cmd": true, ".com": true,
-		".msi": true, ".scr": true, ".vbs": true, ".js": true,
-		".wsf": true, ".ps1": true,
-	}
-	if dangerousExts[ext] {
-		writeLocalizedErrorf(w, r, http.StatusBadRequest, "FileTypeNotAllowed", map[string]any{"Ext": ext})
 		return
 	}
 

--- a/internal/handler/upload_test.go
+++ b/internal/handler/upload_test.go
@@ -93,15 +93,21 @@ func TestUploadFile_DefaultDir(t *testing.T) {
 		assertStatus(t, w, http.StatusBadRequest)
 	})
 
-	t.Run("DangerousExtension_Returns400", func(t *testing.T) {
+	t.Run("DangerousExtension_Allowed", func(t *testing.T) {
 		env, teardown := setupTestEnv(t)
 		defer teardown()
 
+		// All file types are allowed — users may upload binaries, scripts, etc.
 		req := createMultipartUploadRequest(t, "evil.exe", "MZ", "")
 		withProjectCookie(req, env.ProjectDir)
 
 		w := callHandler(UploadFile, req)
-		assertStatus(t, w, http.StatusBadRequest)
+		assertOK(t, w)
+
+		var result map[string]interface{}
+		json.Unmarshal(w.Body.Bytes(), &result)
+		pathStr := result["path"].(string)
+		assert.Contains(t, filepath.ToSlash(pathStr), ".clawbench/uploads/evil.exe")
 	})
 
 	t.Run("DuplicateFilename_AppendsNumber", func(t *testing.T) {


### PR DESCRIPTION
## 变更内容

移除上传端点的 `dangerousExts` 黑名单（`.exe`、`.bat`、`.js` 等），允许上传所有文件类型。

## 设计理由

- 用户需要上传代码、配置、二进制文件和任意项目文件，黑名单模式会误拦合法文件
- 内容安全由下游消费者（AI agent / 文件查看器）负责，而非上传端点
- 仍保留扩展名非空校验，确保文件可被正确识别和提供服务

## 测试

- 原有 `DangerousExtension_Returns400` 改为 `DangerousExtension_Allowed`，验证 `.exe` 等现在能正常上传
- Go coverage gate: Tier 1 PASS, Tier 2 diff coverage 100%