### PR TITLE
fix: #155 DuckDB SIGFPE crash on low-memory systems

### DIFF
--- a/internal/handler/rag_api_test.go
+++ b/internal/handler/rag_api_test.go
@@ -331,7 +331,7 @@ func TestServeRAGSession_LocalhostCrossProject(t *testing.T) {
 func setupRAGStore(t *testing.T) *rag.Store {
 	t.Helper()
 	dir := t.TempDir()
-	store, err := rag.NewStore(dir + "/test.duckdb")
+	store, err := rag.NewStore(dir+"/test.duckdb", nil)
 	require.NoError(t, err)
 	t.Cleanup(func() { store.Close() })
 	return store

--- a/internal/model/config.go
+++ b/internal/model/config.go
@@ -122,18 +122,20 @@ type JPushConfig struct {
 // RAGConfig holds configuration for the RAG history memory system.
 // RAG is always enabled. When the embedding API is unavailable, falls back to BM25 full-text search.
 type RAGConfig struct {
-	BaseURL        string `yaml:"base_url"`         // OpenAI-compatible API base URL (default: "http://localhost:11434")
-	Model          string `yaml:"model"`             // Embedding model name (default: "bge-m3")
-	APIKey         string `yaml:"api_key"`           // API key for the embedding service (optional, for cloud providers)
-	OllamaBaseURL  string `yaml:"ollama_base_url"`   // Deprecated: use base_url
-	OllamaModel    string `yaml:"ollama_model"`       // Deprecated: use model
-	ChunkSize      int    `yaml:"chunk_size"`        // Chunk size in tokens (default: 512)
-	ChunkOverlap   int    `yaml:"chunk_overlap"`     // Overlap between chunks in tokens (default: 64)
-	PollInterval   string `yaml:"poll_interval"`     // Indexer poll interval (default: "10s")
-	BatchSize      int    `yaml:"batch_size"`        // Messages per indexer batch (default: 10)
-	SearchLimit    int    `yaml:"search_limit"`      // Default search result limit (default: 5)
-	SearchPoolSize int    `yaml:"search_pool_size"`  // Candidates per search source before RRF fusion (default: 20)
-	RetentionDays  int    `yaml:"retention_days"`    // Soft-deleted data retention days (0=keep forever, default: 90)
+	BaseURL            string `yaml:"base_url"`            // OpenAI-compatible API base URL (default: "http://localhost:11434")
+	Model              string `yaml:"model"`               // Embedding model name (default: "bge-m3")
+	APIKey             string `yaml:"api_key"`             // API key for the embedding service (optional, for cloud providers)
+	OllamaBaseURL      string `yaml:"ollama_base_url"`     // Deprecated: use base_url
+	OllamaModel        string `yaml:"ollama_model"`         // Deprecated: use model
+	ChunkSize          int    `yaml:"chunk_size"`           // Chunk size in tokens (default: 512)
+	ChunkOverlap       int    `yaml:"chunk_overlap"`        // Overlap between chunks in tokens (default: 64)
+	PollInterval       string `yaml:"poll_interval"`        // Indexer poll interval (default: "10s")
+	BatchSize          int    `yaml:"batch_size"`           // Messages per indexer batch (default: 10)
+	SearchLimit        int    `yaml:"search_limit"`         // Default search result limit (default: 5)
+	SearchPoolSize     int    `yaml:"search_pool_size"`     // Candidates per search source before RRF fusion (default: 20)
+	RetentionDays      int    `yaml:"retention_days"`       // Soft-deleted data retention days (0=keep forever, default: 90)
+	DuckDBThreads      int    `yaml:"duckdb_threads"`       // DuckDB thread count (default: 1; prevents SIGFPE on low-memory systems)
+	DuckDBMemoryLimit  string `yaml:"duckdb_memory_limit"`  // DuckDB memory limit (default: "512MB"; prevents SIGFPE on low-memory systems)
 }
 
 // PiperConfig holds configuration for the Piper TTS engine.

--- a/internal/rag/rag.go
+++ b/internal/rag/rag.go
@@ -21,7 +21,7 @@ func Init(cfg model.RAGConfig) error {
 		slog.Warn("rag: gse segmenter not available, Chinese FTS may be limited", slog.String("err", err.Error()))
 	}
 
-	store, err := InitStore()
+	store, err := InitStore(cfg)
 	if err != nil {
 		return fmt.Errorf("init rag store: %w", err)
 	}

--- a/internal/rag/rag_test.go
+++ b/internal/rag/rag_test.go
@@ -317,7 +317,7 @@ func TestStartCleanupWorker_WithRetention(t *testing.T) {
 	model.BinDir = t.TempDir()
 
 	// Need a store for cleanup worker
-	store, err := InitStore()
+	store, err := InitStore(model.RAGConfig{})
 	require.NoError(t, err)
 	GlobalStore = store
 

--- a/internal/rag/store.go
+++ b/internal/rag/store.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"log/slog"
 	"math"
+	"net/url"
 	"os"
 	"path/filepath"
 	"sort"
@@ -21,10 +22,11 @@ import (
 type Store struct {
 	db             *sql.DB
 	dbPath         string
-	embeddingDim   int        // adaptive embedding dimension
-	ftsAvailable   bool       // Whether FTS extension loaded successfully
-	ftsDirty       bool       // Whether FTS index needs rebuild after data changes
-	ftsLastRebuild time.Time  // Last time FTS index was rebuilt (for debounce)
+	duckdbOpts     map[string]string // Connection-time DuckDB options (for recovery re-open)
+	embeddingDim   int               // adaptive embedding dimension
+	ftsAvailable   bool              // Whether FTS extension loaded successfully
+	ftsDirty       bool              // Whether FTS index needs rebuild after data changes
+	ftsLastRebuild time.Time         // Last time FTS index was rebuilt (for debounce)
 }
 
 // Chunk represents a text chunk with its embedding and metadata.
@@ -59,18 +61,36 @@ type SearchHit struct {
 }
 
 // NewStore creates a new DuckDB store at the given path.
-func NewStore(dbPath string) (*Store, error) {
+// DuckDB connection settings (threads, memory_limit) are applied before any
+// query runs to prevent SIGFPE crashes on low-memory systems where DuckDB's
+// internal thread-count computation can divide by zero. (ISS-155)
+func NewStore(dbPath string, duckdbOpts map[string]string) (*Store, error) {
 	// Ensure parent directory exists
 	if err := os.MkdirAll(filepath.Dir(dbPath), 0755); err != nil {
 		return nil, fmt.Errorf("failed to create rag db directory: %w", err)
 	}
 
-	db, err := sql.Open("duckdb", dbPath)
+	// Build DSN with connection-time configuration to prevent SIGFPE on
+	// low-memory systems. DuckDB computes thread count from available memory;
+	// on systems with <4 GB RAM this can yield 0 threads, causing a divide-
+	// by-zero (SIGFPE, sigcode=FPE_INTDIV) inside duckdb_execute_pending.
+	// Setting threads and memory_limit at connection time ensures the values
+	// are applied before any query, including INSTALL/LOAD extensions.
+	dsn := dbPath
+	if len(duckdbOpts) > 0 {
+		params := url.Values{}
+		for k, v := range duckdbOpts {
+			params.Set(k, v)
+		}
+		dsn = dbPath + "?" + params.Encode()
+	}
+
+	db, err := sql.Open("duckdb", dsn)
 	if err != nil {
 		return nil, fmt.Errorf("failed to open duckdb: %w", err)
 	}
 
-	s := &Store{db: db, dbPath: dbPath}
+	s := &Store{db: db, dbPath: dbPath, duckdbOpts: duckdbOpts}
 	if err := s.initSchema(); err != nil {
 		db.Close()
 		return nil, fmt.Errorf("failed to init duckdb schema: %w", err)
@@ -98,9 +118,33 @@ func NewStore(dbPath string) (*Store, error) {
 }
 
 // InitStore creates the RAG store using the standard .clawbench location.
-func InitStore() (*Store, error) {
+// Applies conservative DuckDB resource limits (threads=1, memory_limit=512MB)
+// by default to prevent SIGFPE crashes on low-memory systems. These can be
+// overridden via the RAGConfig duckdb_threads and duckdb_memory_limit fields.
+func InitStore(cfg model.RAGConfig) (*Store, error) {
 	dbPath := filepath.Join(model.BinDir, ".clawbench", "rag.duckdb")
-	return NewStore(dbPath)
+
+	// Default DuckDB connection settings for low-memory safety.
+	opts := map[string]string{
+		"threads":      "1",
+		"memory_limit": "512MB",
+	}
+
+	// Allow user overrides from config
+	if cfg.DuckDBThreads > 0 {
+		opts["threads"] = strconv.Itoa(cfg.DuckDBThreads)
+	}
+	if cfg.DuckDBMemoryLimit != "" {
+		opts["memory_limit"] = cfg.DuckDBMemoryLimit
+	}
+
+	slog.Info("rag: opening DuckDB store",
+		slog.String("path", dbPath),
+		slog.String("threads", opts["threads"]),
+		slog.String("memory_limit", opts["memory_limit"]),
+	)
+
+	return NewStore(dbPath, opts)
 }
 
 func (s *Store) initSchema() error {
@@ -705,7 +749,17 @@ func (s *Store) RecoverFromCorruption() error {
 	if err := os.Remove(s.dbPath); err != nil {
 		return fmt.Errorf("remove corrupted db: %w", err)
 	}
-	db, err := sql.Open("duckdb", s.dbPath)
+	// Re-open with the same DuckDB connection options (threads, memory_limit)
+	// to prevent SIGFPE on low-memory systems.
+	dsn := s.dbPath
+	if len(s.duckdbOpts) > 0 {
+		params := url.Values{}
+		for k, v := range s.duckdbOpts {
+			params.Set(k, v)
+		}
+		dsn = s.dbPath + "?" + params.Encode()
+	}
+	db, err := sql.Open("duckdb", dsn)
 	if err != nil {
 		return fmt.Errorf("reopen duckdb: %w", err)
 	}

--- a/internal/rag/store_test.go
+++ b/internal/rag/store_test.go
@@ -25,7 +25,10 @@ func setupTestStore(t *testing.T) *Store {
 	}
 	dir := t.TempDir()
 	dbPath := filepath.Join(dir, "test.duckdb")
-	store, err := NewStore(dbPath)
+	store, err := NewStore(dbPath, map[string]string{
+		"threads":      "2",
+		"memory_limit": "256MB",
+	})
 	require.NoError(t, err, "NewStore should succeed")
 	t.Cleanup(func() {
 		store.Close()
@@ -85,11 +88,53 @@ func TestNewStore_CreatesDB(t *testing.T) {
 	assert.NotEmpty(t, store.dbPath)
 }
 
+// TestNewStore_DuckDBOpts verifies that DuckDB connection options (threads,
+// memory_limit) are applied correctly. This prevents SIGFPE crashes on
+// low-memory systems where DuckDB's thread-count computation divides by zero.
+func TestNewStore_DuckDBOpts(t *testing.T) {
+	dir := t.TempDir()
+	dbPath := filepath.Join(dir, "test.duckdb")
+
+	store, err := NewStore(dbPath, map[string]string{
+		"threads":      "1",
+		"memory_limit": "256MB",
+	})
+	require.NoError(t, err)
+	t.Cleanup(func() { store.Close() })
+
+	// Verify the store was created with the options
+	assert.NotNil(t, store.db)
+	assert.Equal(t, dbPath, store.dbPath)
+	assert.Equal(t, "1", store.duckdbOpts["threads"])
+	assert.Equal(t, "256MB", store.duckdbOpts["memory_limit"])
+
+	// Verify DuckDB respects the settings by querying current settings
+	var threads int
+	err = store.db.QueryRow("SELECT current_setting('threads')").Scan(&threads)
+	if err == nil {
+		assert.Equal(t, 1, threads, "DuckDB threads should be set to 1")
+	}
+}
+
+// TestNewStore_NilOpts verifies that NewStore works with nil options
+// (backward compatibility — uses DuckDB defaults).
+func TestNewStore_NilOpts(t *testing.T) {
+	dir := t.TempDir()
+	dbPath := filepath.Join(dir, "test.duckdb")
+
+	store, err := NewStore(dbPath, nil)
+	require.NoError(t, err)
+	t.Cleanup(func() { store.Close() })
+
+	assert.NotNil(t, store.db)
+	assert.Nil(t, store.duckdbOpts)
+}
+
 func TestNewStore_CreatesDirectory(t *testing.T) {
 	dir := t.TempDir()
 	nestedDir := filepath.Join(dir, "deep", "nested")
 	dbPath := filepath.Join(nestedDir, "test.duckdb")
-	store, err := NewStore(dbPath)
+	store, err := NewStore(dbPath, nil)
 	require.NoError(t, err)
 	t.Cleanup(func() { store.Close() })
 	assert.NotNil(t, store)
@@ -1000,7 +1045,7 @@ func TestNewStore_FailedSchema(t *testing.T) {
 	// Write garbage to the parent to make it harder to create the DB
 	// This tests the error path indirectly; the real test is that NewStore
 	// returns an error when it can't init schema.
-	store, err := NewStore(dbPath)
+	store, err := NewStore(dbPath, nil)
 	if err != nil {
 		// If it fails, that's the expected error path
 		assert.Nil(t, store)
@@ -1204,7 +1249,10 @@ func TestNewStore_ExistingChunksRebuildsFTS(t *testing.T) {
 	dbPath := store.dbPath
 	store.Close()
 
-	store2, err := NewStore(dbPath)
+	store2, err := NewStore(dbPath, map[string]string{
+		"threads":      "2",
+		"memory_limit": "256MB",
+	})
 	require.NoError(t, err)
 	t.Cleanup(func() { store2.Close() })
 


### PR DESCRIPTION
修复 #155

## 修复内容

DuckDB 在低内存系统（<4GB RAM）上启动时会因线程数计算除零导致 SIGFPE 崩溃，进程直接被操作系统杀死，无法通过 Go 的 recover() 捕获。

**根因**：DuckDB 根据系统可用内存计算线程数，在 2GB 内存的服务器上计算结果为 0，后续以 0 为除数触发整数除零（SIGFPE, sigcode=FPE_INTDIV）。

**修复方案**：在 DuckDB 连接建立时通过 DSN 参数设置 `threads=1` 和 `memory_limit=512MB`，确保在任何查询（包括 INSTALL fts）执行前就限制资源使用，避免除零错误。

- `store.go`: `NewStore()` 接受 `duckdbOpts` 参数，构建带连接参数的 DSN
- `store.go`: `InitStore()` 默认设置 `threads=1`, `memory_limit=512MB`
- `store.go`: `RecoverFromCorruption()` 复用存储的连接参数
- `config.go`: `RAGConfig` 新增 `DuckDBThreads`, `DuckDBMemoryLimit` 可配置字段
- `rag.go`: `Init()` 传递配置到 `InitStore()`

## 测试

- 新增 `TestNewStore_DuckDBOpts`：验证连接参数正确传递并生效
- 新增 `TestNewStore_NilOpts`：验证 nil 参数的向后兼容性
- 所有 Go 测试通过（`go test ./...`）
- 前端测试 3265 通过（3 个预存的 flaky 失败与本修改无关）

Fixes #155