### PR TITLE
fix: auto-update thinking detail overlay during streaming

### DIFF
--- a/web/src/components/chat/ChatPanelContent.vue
+++ b/web/src/components/chat/ChatPanelContent.vue
@@ -198,6 +198,9 @@ const toolDetailOverlay = ref({
   status: '',
   done: true,
 })
+// Active thinking overlay: tracks which block is being shown so we can reactively update
+const activeThinkingOverlay = ref(null) // { msgId, blockIdx } or null
+let thinkingRenderTimer = null
 const toast = useToast()
 const notification = useNotification()
 const autoSpeech = useAutoSpeech()
@@ -396,6 +399,35 @@ watch(() => props.active, async (val) => {
   }
 }, { immediate: true })
 
+// Reactively update thinking overlay content as block.text changes during streaming
+watch(
+  () => {
+    if (!activeThinkingOverlay.value || !toolDetailOverlay.value.show) return null
+    const block = findThinkingBlock(activeThinkingOverlay.value)
+    return block ? block.text : null
+  },
+  (text) => {
+    if (text === null) return
+    // Debounce: avoid re-rendering markdown on every SSE event
+    if (thinkingRenderTimer) clearTimeout(thinkingRenderTimer)
+    thinkingRenderTimer = setTimeout(() => {
+      toolDetailOverlay.value = {
+        ...toolDetailOverlay.value,
+        inputHtml: `<div class="thinking-overlay-md">${renderMarkdown(text)}</div>`,
+        done: !loading.value, // Mark done when session completes
+      }
+    }, 300)
+  }
+)
+
+// Clean up thinking overlay state when overlay closes
+watch(() => toolDetailOverlay.value.show, (show) => {
+  if (!show) {
+    activeThinkingOverlay.value = null
+    if (thinkingRenderTimer) { clearTimeout(thinkingRenderTimer); thinkingRenderTimer = null }
+  }
+})
+
 async function handleShowAgentSelector() {
   await agentsComposable.loadAgents()
   // If only one agent exists, skip the selector and create directly
@@ -559,16 +591,31 @@ function handleShowToolDetail(block) {
   }
 }
 
-function handleShowThinkingDetail({ text }) {
+function handleShowThinkingDetail({ text, msgId, blockIdx }) {
+  // Store identifiers for reactive lookup (survives messages array replacement on loadHistory)
+  activeThinkingOverlay.value = { msgId: String(msgId), blockIdx }
+
+  // Initial render
+  const block = findThinkingBlock(activeThinkingOverlay.value)
+  const currentText = block ? block.text : text // fallback to snapshot if lookup fails
+
   toolDetailOverlay.value = {
     show: true,
     name: 'DeepThink',
     summary: '',
-    inputHtml: `<div class="thinking-overlay-md">${renderMarkdown(text)}</div>`,
+    inputHtml: `<div class="thinking-overlay-md">${renderMarkdown(currentText)}</div>`,
     outputHtml: '',
     status: '',
-    done: true,
+    done: !loading.value, // Will update to true when streaming ends
   }
+}
+
+/** Look up the thinking block from the live messages array by msgId + blockIdx */
+function findThinkingBlock({ msgId, blockIdx }) {
+  const msg = messages.value.find(m => String(m.id) === msgId)
+  if (!msg || !msg.blocks) return null
+  const block = msg.blocks[blockIdx]
+  return (block && block.type === 'thinking') ? block : null
 }
 
 function handleFileOpenInOverlay(filePath) {
@@ -622,6 +669,7 @@ onUnmounted(() => {
     stream.disconnectStream()
     stream.stopPolling()
     session.stopMsgCountPolling()
+    if (thinkingRenderTimer) { clearTimeout(thinkingRenderTimer); thinkingRenderTimer = null }
     document.removeEventListener('visibilitychange', session.handleVisibilityChange)
     document.removeEventListener('visibilitychange', manager._visibilityHandler)
     window.removeEventListener('clawbench-summary-update', handleSummaryUpdate)

--- a/web/src/components/chat/ContentBlocks.vue
+++ b/web/src/components/chat/ContentBlocks.vue
@@ -8,7 +8,7 @@
     <template v-else>
     <template v-for="(block, bi) in blocks" :key="bi">
       <!-- Thinking block -->
-      <div v-if="block.type === 'thinking'" class="chat-thinking" @click.stop="handleThinkingClick(block)">
+      <div v-if="block.type === 'thinking'" class="chat-thinking" @click.stop="handleThinkingClick(block, bi)">
         <div class="thinking-header">
           <Brain :size="12" />
           <span class="thinking-label">{{ t('chat.message.deepThinking') }}</span>
@@ -198,8 +198,8 @@ function scheduledTaskKeys(bi) {
   return scheduledTaskKeysUtil(taskKeyIndex.value, bi)
 }
 
-function handleThinkingClick(block) {
-  emit('show-thinking-detail', { text: block.text })
+function handleThinkingClick(block, bi) {
+  emit('show-thinking-detail', { text: block.text, msgId: props.msgId, blockIdx: bi })
 }
 
 /** Click inside expanded tool-detail: dispatch to tool action handlers first, then fall through to generic behavior. */


### PR DESCRIPTION
Closes #156

## Problem
When clicking "深度思考" to view thinking content, the overlay shows a snapshot at click time. As more thinking content streams in, the overlay doesn't update — the user must close and reopen it.

## Root Cause
`handleShowThinkingDetail` captures `block.text` as a static string, renders it once via `renderMarkdown()`, and stores the HTML in `toolDetailOverlay.inputHtml`. No reactive binding exists between the source block and the overlay.

## Fix
- Store `{ msgId, blockIdx }` identifiers instead of a text snapshot
- Use a `watch` with 300ms debounce to reactively re-render `inputHtml` as `block.text` changes
- ID-based lookup via `messages.value.find()` survives `loadHistory()` replacing the messages array
- Clean up state when overlay closes or component unmounts

## Changes
- `ContentBlocks.vue`: Pass `bi` index and `msgId` in thinking click handler
- `ChatPanelContent.vue`: Add reactive thinking overlay state, debounced watch, and cleanup