### PR TITLE
fix: #166 文件路径标注打开不存在的文件时，文件管理器不应同步到不存在的目录

### DIFF
--- a/web/src/components/__tests__/terminalVisibility.test.ts
+++ b/web/src/components/__tests__/terminalVisibility.test.ts
@@ -279,7 +279,7 @@ describe('FileManagerContent — syncToCurrentFile with error state', () => {
     })
   }
 
-  it('isInSync is false when currentFile has an error', async () => {
+  it('syncButtonDisabled is true when currentFile has an error', async () => {
     const wrapper = mountComponent({
       path: 'src/deleted/File.ts',
       name: 'File.ts',
@@ -287,16 +287,37 @@ describe('FileManagerContent — syncToCurrentFile with error state', () => {
     })
     await nextTick()
 
-    // The sync button in the "more" dropdown should be disabled
-    // Open the more menu first
-    const moreBtn = wrapper.findAll('.toolbar-btn').find(b => b.attributes('title') === undefined || b.text().includes(''))
-    // We check that the component's isInSync computed returns false
-    // by verifying the sync button is disabled
-    // Since the button is in a dropdown, we need to open it first
-    // Instead, test the logic more directly by emitting navigateDir
-    // and checking it does NOT fire when file has error
-    const emitted = wrapper.emitted('navigateDir')
-    expect(emitted).toBeUndefined()
+    // Access the computed property directly via vm
+    expect(wrapper.vm.syncButtonDisabled).toBe(true)
+  })
+
+  it('syncButtonDisabled is true when no currentFile', async () => {
+    const wrapper = mountComponent(null)
+    await nextTick()
+
+    expect(wrapper.vm.syncButtonDisabled).toBe(true)
+  })
+
+  it('syncButtonDisabled is false when currentFile has no error', async () => {
+    const wrapper = mountComponent({
+      path: 'src/main.go',
+      name: 'main.go',
+      content: 'package main',
+    })
+    await nextTick()
+
+    expect(wrapper.vm.syncButtonDisabled).toBe(false)
+  })
+
+  it('isInSync is false when currentFile has error', async () => {
+    const wrapper = mountComponent({
+      path: 'src/deleted/File.ts',
+      name: 'File.ts',
+      error: 'File not found',
+    })
+    await nextTick()
+
+    expect(wrapper.vm.isInSync).toBe(false)
   })
 
   it('does not emit navigateDir from syncToCurrentFile when currentFile has error', async () => {
@@ -307,46 +328,11 @@ describe('FileManagerContent — syncToCurrentFile with error state', () => {
     })
     await nextTick()
 
-    // Open more menu to access sync button
-    const moreBtns = wrapper.findAll('.toolbar-dropdown-wrap .toolbar-btn')
-    const moreBtn = moreBtns[moreBtns.length - 1] // last one is "more"
-    await moreBtn.trigger('click')
+    // Call syncToCurrentFile directly
+    wrapper.vm.syncToCurrentFile()
     await nextTick()
 
-    // Find the sync button in the dropdown
-    const syncBtn = wrapper.findAll('.toolbar-dropdown-item').find(
-      el => el.text().includes('同步'),
-    )
-    if (syncBtn) {
-      // The button should be disabled due to currentFile.error
-      expect(syncBtn.attributes('disabled')).toBeDefined()
-      // Even if we try to click it, navigateDir should not be emitted
-      await syncBtn.trigger('click')
-      await nextTick()
-      expect(wrapper.emitted('navigateDir')).toBeUndefined()
-    }
-  })
-
-  it('sync button is disabled when currentFile has error', async () => {
-    const wrapper = mountComponent({
-      path: 'src/deleted/File.ts',
-      name: 'File.ts',
-      error: 'File not found',
-    })
-    await nextTick()
-
-    // Open more menu
-    const moreBtns = wrapper.findAll('.toolbar-dropdown-wrap .toolbar-btn')
-    const moreBtn = moreBtns[moreBtns.length - 1]
-    await moreBtn.trigger('click')
-    await nextTick()
-
-    const syncBtn = wrapper.findAll('.toolbar-dropdown-item').find(
-      el => el.text().includes('同步'),
-    )
-    if (syncBtn) {
-      expect(syncBtn.attributes('disabled')).toBeDefined()
-    }
+    expect(wrapper.emitted('navigateDir')).toBeUndefined()
   })
 })
 

--- a/web/src/components/__tests__/terminalVisibility.test.ts
+++ b/web/src/components/__tests__/terminalVisibility.test.ts
@@ -247,6 +247,110 @@ describe('overflowTabs — terminal exclusion logic', () => {
 })
 
 // ============================================================
+// Part 4: syncToCurrentFile / isInSync with currentFile.error (issue #166)
+// ============================================================
+
+describe('FileManagerContent — syncToCurrentFile with error state', () => {
+  beforeEach(() => {
+    mockTerminalRuntimeEnabled.value = true
+    document.querySelectorAll('.context-menu').forEach(el => el.remove())
+    document.querySelectorAll('.ctx-overlay').forEach(el => el.remove())
+  })
+
+  function mountComponent(currentFile: any = null) {
+    return mount(FileManagerContent, {
+      props: {
+        entries: [],
+        currentDir: 'src',
+        currentFile,
+        showHidden: false,
+        sortField: '',
+        sortDir: '',
+        dirLoading: false,
+      },
+      attachTo: document.body,
+      global: {
+        plugins: [i18n],
+        stubs: {
+          SearchInput: true,
+          DirBreadcrumb: true,
+        },
+      },
+    })
+  }
+
+  it('isInSync is false when currentFile has an error', async () => {
+    const wrapper = mountComponent({
+      path: 'src/deleted/File.ts',
+      name: 'File.ts',
+      error: 'File not found',
+    })
+    await nextTick()
+
+    // The sync button in the "more" dropdown should be disabled
+    // Open the more menu first
+    const moreBtn = wrapper.findAll('.toolbar-btn').find(b => b.attributes('title') === undefined || b.text().includes(''))
+    // We check that the component's isInSync computed returns false
+    // by verifying the sync button is disabled
+    // Since the button is in a dropdown, we need to open it first
+    // Instead, test the logic more directly by emitting navigateDir
+    // and checking it does NOT fire when file has error
+    const emitted = wrapper.emitted('navigateDir')
+    expect(emitted).toBeUndefined()
+  })
+
+  it('does not emit navigateDir from syncToCurrentFile when currentFile has error', async () => {
+    const wrapper = mountComponent({
+      path: 'src/deleted/File.ts',
+      name: 'File.ts',
+      error: 'File not found',
+    })
+    await nextTick()
+
+    // Open more menu to access sync button
+    const moreBtns = wrapper.findAll('.toolbar-dropdown-wrap .toolbar-btn')
+    const moreBtn = moreBtns[moreBtns.length - 1] // last one is "more"
+    await moreBtn.trigger('click')
+    await nextTick()
+
+    // Find the sync button in the dropdown
+    const syncBtn = wrapper.findAll('.toolbar-dropdown-item').find(
+      el => el.text().includes('同步'),
+    )
+    if (syncBtn) {
+      // The button should be disabled due to currentFile.error
+      expect(syncBtn.attributes('disabled')).toBeDefined()
+      // Even if we try to click it, navigateDir should not be emitted
+      await syncBtn.trigger('click')
+      await nextTick()
+      expect(wrapper.emitted('navigateDir')).toBeUndefined()
+    }
+  })
+
+  it('sync button is disabled when currentFile has error', async () => {
+    const wrapper = mountComponent({
+      path: 'src/deleted/File.ts',
+      name: 'File.ts',
+      error: 'File not found',
+    })
+    await nextTick()
+
+    // Open more menu
+    const moreBtns = wrapper.findAll('.toolbar-dropdown-wrap .toolbar-btn')
+    const moreBtn = moreBtns[moreBtns.length - 1]
+    await moreBtn.trigger('click')
+    await nextTick()
+
+    const syncBtn = wrapper.findAll('.toolbar-dropdown-item').find(
+      el => el.text().includes('同步'),
+    )
+    if (syncBtn) {
+      expect(syncBtn.attributes('disabled')).toBeDefined()
+    }
+  })
+})
+
+// ============================================================
 // Part 3: isTerminalDisabled computed logic (runtime-based)
 // ============================================================
 

--- a/web/src/components/file/FileManagerContent.vue
+++ b/web/src/components/file/FileManagerContent.vue
@@ -54,7 +54,7 @@
               <Upload :size="14" />
               <span>{{ t('file.uploadHere') }}</span>
             </button>
-            <button class="toolbar-dropdown-item" :disabled="!currentFile?.path" @click="syncToCurrentFile(); moreMenuOpen = false">
+            <button class="toolbar-dropdown-item" :disabled="!currentFile?.path || !!currentFile?.error" @click="syncToCurrentFile(); moreMenuOpen = false">
               <ArrowRightLeft :size="14" />
               <span>{{ t('file.syncToCurrentDir') }}</span>
             </button>
@@ -422,11 +422,16 @@ onUnmounted(() => document.removeEventListener('click', closeDropdowns))
 // Sync button: navigate to the directory of the currently opened file
 const isInSync = computed(() => {
     if (!props.currentFile?.path) return false
+    // Don't consider "in sync" if the file has an error (e.g. doesn't exist)
+    if (props.currentFile.error) return false
     return dirName(props.currentFile.path) === props.currentDir
 })
 
 function syncToCurrentFile() {
     if (!props.currentFile?.path) return
+    // Don't sync if the file has an error (e.g. doesn't exist) —
+    // navigating to its directory may lead to a non-existent path (issue #166)
+    if (props.currentFile.error) return
     const targetDir = dirName(props.currentFile.path)
     if (targetDir === props.currentDir) {
         if (toast) toast.show(t('file.alreadyInDir'), { icon: '📍', type: 'success', duration: 1500 })

--- a/web/src/components/file/FileManagerContent.vue
+++ b/web/src/components/file/FileManagerContent.vue
@@ -54,7 +54,7 @@
               <Upload :size="14" />
               <span>{{ t('file.uploadHere') }}</span>
             </button>
-            <button class="toolbar-dropdown-item" :disabled="!currentFile?.path || !!currentFile?.error" @click="syncToCurrentFile(); moreMenuOpen = false">
+            <button class="toolbar-dropdown-item" :disabled="syncButtonDisabled" @click="syncToCurrentFile(); moreMenuOpen = false">
               <ArrowRightLeft :size="14" />
               <span>{{ t('file.syncToCurrentDir') }}</span>
             </button>
@@ -426,6 +426,9 @@ const isInSync = computed(() => {
     if (props.currentFile.error) return false
     return dirName(props.currentFile.path) === props.currentDir
 })
+
+// Sync button disabled state: no file selected or file has error (issue #166)
+const syncButtonDisabled = computed(() => !props.currentFile?.path || !!props.currentFile?.error)
 
 function syncToCurrentFile() {
     if (!props.currentFile?.path) return

--- a/web/src/composables/__tests__/useFilePathAnnotation.test.ts
+++ b/web/src/composables/__tests__/useFilePathAnnotation.test.ts
@@ -7,6 +7,7 @@ import {
   annotateFilePaths,
   verifyFilePaths,
   clearVerifiedCache,
+  openFilePath,
 } from '@/composables/useFilePathAnnotation'
 
 // Mock escapeHtml from html utils
@@ -21,7 +22,11 @@ vi.mock('@/utils/path', () => ({
 
 // Mock store
 vi.mock('@/stores/app', () => ({
-  store: { state: { projectRoot: '/home/user/project' } },
+  store: {
+    state: { projectRoot: '/home/user/project' },
+    selectFile: vi.fn(),
+    navigateToDir: vi.fn(),
+  },
 }))
 
 // Mock useLocale
@@ -1032,6 +1037,102 @@ describe('verifyFilePaths', () => {
     // The body should contain deduplicated paths
     const body = JSON.parse(mockFetch.mock.calls[0][1].body)
     expect(body.paths).toEqual(['dup.go'])
+
+    vi.unstubAllGlobals()
+  })
+})
+
+// --- openFilePath ---
+
+describe('openFilePath', () => {
+  let mockSelectFile: ReturnType<typeof vi.fn>
+  let mockNavigateToDir: ReturnType<typeof vi.fn>
+
+  beforeEach(async () => {
+    clearVerifiedCache()
+    const { store } = await import('@/stores/app')
+    mockSelectFile = store.selectFile as ReturnType<typeof vi.fn>
+    mockNavigateToDir = store.navigateToDir as ReturnType<typeof vi.fn>
+    mockSelectFile.mockClear()
+    mockNavigateToDir.mockClear()
+  })
+
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  it('navigates to directory when path is a directory', async () => {
+    const mockFetch = vi.fn().mockResolvedValue({ ok: true })
+    vi.stubGlobal('fetch', mockFetch)
+
+    const mockDispatchEvent = vi.fn()
+    const origDispatch = window.dispatchEvent
+    window.dispatchEvent = mockDispatchEvent
+
+    await openFilePath('src')
+
+    expect(mockFetch).toHaveBeenCalledTimes(1)
+    expect(mockFetch.mock.calls[0][0]).toContain('/api/dir?path=')
+    expect(mockNavigateToDir).toHaveBeenCalledWith('src')
+    expect(mockDispatchEvent).toHaveBeenCalled()
+
+    window.dispatchEvent = origDispatch
+    vi.unstubAllGlobals()
+  })
+
+  it('selects file when path exists as a file', async () => {
+    // First fetch: /api/dir check → not ok (not a directory)
+    // Second fetch: /api/file/batch-exists → file exists
+    const mockFetch = vi.fn()
+      .mockResolvedValueOnce({ ok: false }) // /api/dir
+      .mockResolvedValueOnce({ ok: true, json: () => Promise.resolve({ results: { 'src/main.go': 'file' } }) }) // batch-exists
+
+    vi.stubGlobal('fetch', mockFetch)
+
+    await openFilePath('src/main.go')
+
+    expect(mockSelectFile).toHaveBeenCalledWith('src/main.go')
+
+    vi.unstubAllGlobals()
+  })
+
+  it('shows toast and does not select file when path does not exist', async () => {
+    // First fetch: /api/dir check → not ok (not a directory)
+    // Second fetch: /api/file/batch-exists → path doesn't exist
+    const mockFetch = vi.fn()
+      .mockResolvedValueOnce({ ok: false }) // /api/dir
+      .mockResolvedValueOnce({ ok: true, json: () => Promise.resolve({ results: { 'src/deleted/File.ts': 'none' } }) }) // batch-exists
+
+    vi.stubGlobal('fetch', mockFetch)
+
+    // Mock useToast
+    const mockShow = vi.fn()
+    vi.doMock('@/composables/useToast', () => ({
+      useToast: () => ({ show: mockShow }),
+    }))
+
+    await openFilePath('src/deleted/File.ts')
+
+    // selectFile should NOT be called for non-existent file
+    expect(mockSelectFile).not.toHaveBeenCalled()
+
+    vi.unstubAllGlobals()
+    vi.doUnmock('@/composables/useToast')
+  })
+
+  it('falls through to selectFile when batch-exists check fails (network error)', async () => {
+    // First fetch: /api/dir check → not ok
+    // Second fetch: /api/file/batch-exists → network error
+    const mockFetch = vi.fn()
+      .mockResolvedValueOnce({ ok: false }) // /api/dir
+      .mockRejectedValueOnce(new Error('Network error')) // batch-exists
+
+    vi.stubGlobal('fetch', mockFetch)
+
+    await openFilePath('src/main.go')
+
+    // Best-effort: selectFile should still be called
+    expect(mockSelectFile).toHaveBeenCalledWith('src/main.go')
 
     vi.unstubAllGlobals()
   })

--- a/web/src/composables/useFilePathAnnotation.ts
+++ b/web/src/composables/useFilePathAnnotation.ts
@@ -408,6 +408,8 @@ export function resolveRelativePath(href: string, baseDir: string): string {
  * Open a file or directory path.
  * If the path is a directory, navigates to it and opens the file manager.
  * If it's a file, selects it in the store.
+ * If the file doesn't exist, shows a toast and does not navigate to a potentially
+ * non-existent directory (fixes issue #166).
  */
 export async function openFilePath(resolvedPath: string): Promise<void> {
     // Check if path is a directory
@@ -420,6 +422,30 @@ export async function openFilePath(resolvedPath: string): Promise<void> {
         }
     } catch {
         // Ignore, fall through to open as file
+    }
+
+    // Before selecting the file, verify it actually exists.
+    // If it doesn't exist, avoid setting currentFile (which would trigger
+    // syncToCurrentFile to navigate to a non-existent directory).
+    try {
+        const resp = await fetch(`/api/file/batch-exists`, {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify({ paths: [resolvedPath] }),
+        })
+        if (resp.ok) {
+            const data = await resp.json() as { results: Record<string, string> }
+            const type = data.results?.[resolvedPath]
+            if (type !== 'file' && type !== 'dir') {
+                // File doesn't exist — show toast and abort
+                const { useToast } = await import('@/composables/useToast')
+                const { gt } = await import('@/composables/useLocale')
+                useToast().show(gt('file.toast.fileNotFound'), { type: 'error', icon: '⚠️', duration: 2000 })
+                return
+            }
+        }
+    } catch {
+        // Batch-exists check failed — proceed with selectFile as best-effort
     }
 
     store.selectFile(resolvedPath)

--- a/web/src/i18n/locales/en.ts
+++ b/web/src/i18n/locales/en.ts
@@ -454,6 +454,7 @@ export default {
       switchProjectFailed: 'Switch project failed: {error}',
       switchProjectFailedShort: 'Switch project failed',
       dirLoadFailed: 'Directory not found or inaccessible',
+      fileNotFound: 'File not found',
       archiving: 'Packing {n} items...',
       archiveDone: 'Download ready',
       archiveFailed: 'Pack failed',

--- a/web/src/i18n/locales/zh.ts
+++ b/web/src/i18n/locales/zh.ts
@@ -454,6 +454,7 @@ export default {
       switchProjectFailed: '切换项目失败: {error}',
       switchProjectFailedShort: '切换项目失败',
       dirLoadFailed: '目录不存在或无法访问',
+      fileNotFound: '文件不存在',
       archiving: '正在打包 {n} 个文件...',
       archiveDone: '打包下载完成',
       archiveFailed: '打包失败',


### PR DESCRIPTION
修复 #166

## 修复内容

当聊天消息中的文件路径标注指向一个不存在的文件时，点击打开按钮后，文件管理器会尝试同步到该文件所在的目录。如果该目录也不存在，会导致文件管理器导航到一个无效路径。

### 修改

1. **`useFilePathAnnotation.ts` — `openFilePath()`**：在调用 `selectFile()` 之前，先通过 `/api/file/batch-exists` API 验证文件是否存在。如果文件不存在，显示 toast 提示（"文件不存在"）并终止，不设置 `currentFile`，避免同步逻辑触发。

2. **`FileManagerContent.vue` — `syncToCurrentFile()` / `isInSync`**：在 `currentFile.error` 存在时跳过同步操作和同步状态判断，防止导航到不存在的目录。同步到当前目录按钮也在文件有 error 时禁用。

3. **i18n**：新增 `file.toast.fileNotFound` 翻译（en: "File not found", zh: "文件不存在"）。

## 测试

- 新增 `openFilePath` 单元测试：目录路径导航、文件存在时选中、文件不存在时提示且不选中、网络错误时 best-effort 回退
- 已有 136 个 useFilePathAnnotation 测试全部通过
- 全部 3323 个前端测试通过
- Go 后端全部测试通过

Fixes #166