### PR TITLE
fix: 修复 Review Issues (ISS-245, ISS-246, ISS-248) — SSE 事件处理竞态

### DIFF
--- a/web/src/composables/__tests__/useChatStream.test.ts
+++ b/web/src/composables/__tests__/useChatStream.test.ts
@@ -1406,6 +1406,177 @@ describe('useChatStream', () => {
     })
   })
 
+  describe('ISS-246: done handler checks guard() before modifying state', () => {
+    it('should not modify loading state when session changed before done', async () => {
+      const options = createOptions()
+      const { connectStream } = useChatStream(options)
+
+      options.loading.value = true
+      connectStream('test-session-1')
+      const es = getLatestEs()
+      es.simulateOpen()
+
+      // Change session — guard should reject the done event
+      options.currentSessionId.value = 'different-session'
+
+      es.simulate('done', {})
+
+      // The stale EventSource should be closed, but loading state should NOT
+      // be set to false for the new session (it belongs to the old session)
+      expect(es.readyState).toBe(MockEventSource.CLOSED)
+      // loading remains true because guard() rejected the event
+      expect(options.loading.value).toBe(true)
+      // onLoadHistory should NOT be called for the wrong session
+      expect(options.onLoadHistory).not.toHaveBeenCalled()
+    })
+
+    it('should not call onMessage or onStreamEnd when guard fails on done', async () => {
+      const options = createOptions()
+      const { connectStream } = useChatStream(options)
+
+      options.loading.value = true
+      connectStream('test-session-1')
+      const es = getLatestEs()
+      es.simulateOpen()
+
+      // Remove the streaming message — guard fails
+      const idx = options.messages.value.findIndex(
+        (m: any) => m.role === 'assistant' && m.streaming
+      )
+      options.messages.value.splice(idx, 1)
+
+      es.simulate('done', {})
+
+      expect(options.onMessage).not.toHaveBeenCalled()
+      expect(options.onStreamEnd).not.toHaveBeenCalled()
+    })
+  })
+
+  describe('ISS-245/ISS-278: cancelled handler checks guard() before disconnectStream', () => {
+    it('should not close new session EventSource when cancelled arrives for old session', () => {
+      const options = createOptions()
+      const stream = useChatStream(options)
+
+      options.loading.value = true
+      stream.connectStream('test-session-1')
+      const es1 = getLatestEs()
+      es1.simulateOpen()
+
+      // Simulate session switch — user opens a new session
+      options.currentSessionId.value = 'session-2'
+      options.loading.value = true
+      stream.connectStream('session-2')
+      const es2 = getLatestEs()
+      es2.simulateOpen()
+
+      // The old EventSource (es1) fires a stale 'cancelled' event
+      es1.simulate('cancelled', {})
+
+      // The new session's EventSource should NOT be affected
+      expect(es2.readyState).toBe(MockEventSource.OPEN)
+      // loading should remain true for the new session
+      expect(options.loading.value).toBe(true)
+      // onStreamEnd should NOT be called for the stale event
+      expect(options.onStreamEnd).not.toHaveBeenCalledWith('cancelled')
+    })
+
+    it('should still close the stale EventSource on cancelled when guard fails', () => {
+      const options = createOptions()
+      const { connectStream } = useChatStream(options)
+
+      options.loading.value = true
+      connectStream('test-session-1')
+      const es = getLatestEs()
+      es.simulateOpen()
+
+      // Change session ID
+      options.currentSessionId.value = 'different-session'
+
+      es.simulate('cancelled', {})
+
+      // The stale EventSource should be closed (cleanup)
+      expect(es.readyState).toBe(MockEventSource.CLOSED)
+    })
+
+    it('should mark streamingMsg as cancelled when guard passes', () => {
+      const options = createOptions()
+      const { connectStream } = useChatStream(options)
+
+      options.loading.value = true
+      connectStream('test-session-1')
+      const es = getLatestEs()
+      es.simulateOpen()
+
+      es.simulate('cancelled', {})
+
+      // Guard passed — streamingMsg should be marked as cancelled
+      const assistantMsg = options.messages.value.find(
+        (m: any) => m.role === 'assistant'
+      )
+      expect(assistantMsg.cancelled).toBe(true)
+      expect(options.loading.value).toBe(false)
+      expect(options.onStreamEnd).toHaveBeenCalledWith('cancelled')
+    })
+  })
+
+  describe('ISS-248/ISS-279: onerror distinguishes recoverable vs non-recoverable errors', () => {
+    it('should attempt reconnect for transient errors (readyState != CLOSED)', () => {
+      const options = createOptions()
+      const { connectStream } = useChatStream(options)
+
+      options.loading.value = true
+      connectStream('test-session-1')
+      const es = getLatestEs()
+      // Simulate OPEN state — transient error (e.g., network blip)
+      es.readyState = MockEventSource.OPEN
+
+      // Clear any previous calls to forceCleanupStreamingState from other tests
+      ;(forceCleanupStreamingState as any).mockClear?.()
+
+      es.simulateError()
+
+      // Since the error was recoverable (readyState != CLOSED), the stream
+      // should attempt reconnection rather than falling back to polling
+      // We verify by checking that forceCleanupStreamingState was NOT called
+      // (it would be called for non-recoverable errors before polling)
+      expect(forceCleanupStreamingState).not.toHaveBeenCalled()
+    })
+
+    it('should fall back to polling for non-recoverable errors (readyState = CLOSED)', () => {
+      const options = createOptions()
+      const { connectStream } = useChatStream(options)
+
+      options.loading.value = true
+      connectStream('test-session-1')
+      const es = getLatestEs()
+      // Simulate CLOSED state — permanent failure (e.g., 404, server shutdown)
+      es.readyState = MockEventSource.CLOSED
+
+      es.simulateError()
+
+      // Non-recoverable: should fall back to polling
+      expect(forceCleanupStreamingState).toHaveBeenCalled()
+    })
+
+    it('should not attempt reconnect when readyState is CLOSED even if loading and sessionId exist', () => {
+      const options = createOptions()
+      const { connectStream } = useChatStream(options)
+
+      options.loading.value = true
+      connectStream('test-session-1')
+      const es = getLatestEs()
+      es.readyState = MockEventSource.CLOSED
+
+      const esCountBeforeError = mockEsInstances.length
+
+      es.simulateError()
+
+      // No new EventSource should be created (no reconnect attempt for fatal errors)
+      // Only the initial one from connectStream should exist
+      expect(mockEsInstances.length).toBe(esCountBeforeError)
+    })
+  })
+
   describe('resume_split event (AutoResume)', () => {
     it('should finalize Phase 1 message and create new Phase 2 streaming message', () => {
       const options = createOptions()

--- a/web/src/composables/useChatStream.ts
+++ b/web/src/composables/useChatStream.ts
@@ -257,6 +257,11 @@ export function useChatStream(options: UseChatStreamOptions) {
 
     eventSource = new EventSource(`/api/ai/chat/stream?session_id=${encodeURIComponent(sessionId)}`, { withCredentials: true })
 
+    // Capture reference to THIS EventSource instance so event handlers can
+    // safely close only the stale connection without affecting a new session's
+    // EventSource (the `eventSource` variable may be reassigned by connectStream).
+    const esRef = eventSource
+
     // Start stream timeout
     resetStreamTimeout()
 
@@ -410,6 +415,15 @@ export function useChatStream(options: UseChatStreamOptions) {
     })
 
     eventSource.addEventListener('done', () => {
+      // ISS-246: check guard() BEFORE touching shared state — if session
+      // changed, this event belongs to a stale connection and must be ignored.
+      if (!guard()) {
+        // Close only the stale EventSource that fired this event, not the
+        // shared `eventSource` variable which may point to a new session.
+        esRef.close()
+        reconnect.reset()
+        return
+      }
       if (streamTimeout) { clearTimeout(streamTimeout); streamTimeout = null }
       clearToolUseTimeouts()
       disconnectStream()
@@ -440,8 +454,18 @@ export function useChatStream(options: UseChatStreamOptions) {
 
     eventSource.addEventListener('cancelled', () => {
       if (streamTimeout) { clearTimeout(streamTimeout); streamTimeout = null }
+      // ISS-245/ISS-278: check guard() BEFORE disconnectStream().
+      // disconnectStream() closes the shared `eventSource` variable which may
+      // have been reassigned to a new session's EventSource. If the session
+      // changed, this cancelled event is stale — close only THIS EventSource
+      // instance (not the shared variable) and skip state mutations.
+      if (!guard()) {
+        // Close only the stale EventSource that fired this event, not the
+        // shared `eventSource` variable which may point to a new session.
+        esRef.close()
+        return
+      }
       disconnectStream()
-      if (!guard()) return
       streamingMsg.cancelled = true
       // If no content was received, add error block so the UI shows the error card instead of loading dots
       if ((!streamingMsg.blocks || streamingMsg.blocks.length === 0) && !streamingMsg.content) {
@@ -556,14 +580,21 @@ export function useChatStream(options: UseChatStreamOptions) {
     })
 
     eventSource.onerror = () => {
-      // SSE connection error — reconnect if session is still active
+      // SSE connection error — distinguish recoverable vs non-recoverable.
+      // ISS-248/ISS-279: Use EventSource readyState to detect fatal errors.
+      // CONNECTING (0) / OPEN (1) = transient, safe to reconnect.
+      // CLOSED (2) = permanent failure (e.g. 404, server shutdown), fall back.
       if (streamTimeout) { clearTimeout(streamTimeout); streamTimeout = null }
+      // Use esRef (captured at connectStream time) to check readyState,
+      // since `eventSource` may have been reassigned by a new session.
+      const wasRecoverable = esRef.readyState !== EventSource.CLOSED
       disconnectStream()
-      if (currentSessionId.value && loading.value && reconnect.shouldReconnect()) {
-        // AI session likely still running on backend, reconnect SSE
+      if (wasRecoverable && currentSessionId.value && loading.value && reconnect.shouldReconnect()) {
+        // Transient error (network blip, server restart) — reconnect SSE
         reconnect.scheduleReconnect()
       } else {
-        // Too many attempts or session inactive — fall back to polling
+        // Non-recoverable error (404, 403, server shutdown) or max retries —
+        // fall back to polling which will detect the terminal state
         reconnect.reset() // Clear reconnect state before falling back to polling
         forceCleanupStreamingState()
         pollUntilDone()


### PR DESCRIPTION
修复 Critical Issues: ISS-245, ISS-246, ISS-248, ISS-278, ISS-279

## 修复内容

### ISS-245/ISS-278: cancelled handler 调用顺序
- **问题**: `cancelled` 事件处理器在 `guard()` 之前调用 `disconnectStream()`，可能关闭新 session 的 EventSource
- **修复**: 先检查 `guard()`，如果 session 已切换，仅关闭 stale 的 EventSource 实例（通过 `esRef`），不影响新 session

### ISS-246: done handler 缺少 guard() 检查
- **问题**: `done` 事件处理器不检查 `guard()`，旧 session 的 done 事件会污染新 session 的 loading 状态
- **修复**: 在 done handler 开头添加 `guard()` 检查，guard 失败时仅关闭 stale ES 并重置 reconnect

### ISS-248/ISS-279: onerror 不区分错误类型
- **问题**: `onerror` 不区分可恢复/不可恢复错误，401/403 等致命错误也会无限重连
- **修复**: 检查 `EventSource.readyState`，CLOSED 状态直接回退到轮询，非 CLOSED 状态才尝试重连

### 通用改进
- 引入 `esRef` 捕获当前 EventSource 实例引用，避免 stale 事件处理器操作新 session 的 EventSource

## 测试
- 新增 8 个测试用例覆盖三个修复场景
- 所有 3336 个前端测试通过
- Go build 和测试全部通过