### PR TITLE
fix(ci): remove server.sh/server.ps1 from release packaging

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -109,8 +109,7 @@ jobs:
           cp clawbench-linux pkg-linux/clawbench/clawbench
           cp -r public pkg-linux/clawbench/public
           cp -r config pkg-linux/clawbench/config
-          cp server.sh pkg-linux/clawbench/
-          chmod +x pkg-linux/clawbench/clawbench pkg-linux/clawbench/server.sh
+          chmod +x pkg-linux/clawbench/clawbench
           cd pkg-linux && zip -r clawbench-linux-amd64.zip clawbench/
 
       - uses: softprops/action-gh-release@v2
@@ -150,7 +149,6 @@ jobs:
           Copy-Item clawbench.exe pkg-windows/clawbench/
           Copy-Item -Recurse public pkg-windows/clawbench/public
           Copy-Item -Recurse config pkg-windows/clawbench/config
-          Copy-Item server.ps1 pkg-windows/clawbench/
           Compress-Archive -Path pkg-windows/clawbench -DestinationPath pkg-windows/clawbench-windows-amd64.zip
 
       - uses: softprops/action-gh-release@v2
@@ -189,8 +187,7 @@ jobs:
           cp clawbench-darwin-arm64 pkg-mac-arm64/clawbench/clawbench
           cp -r public pkg-mac-arm64/clawbench/public
           cp -r config pkg-mac-arm64/clawbench/config
-          cp server.sh pkg-mac-arm64/clawbench/
-          chmod +x pkg-mac-arm64/clawbench/clawbench pkg-mac-arm64/clawbench/server.sh
+          chmod +x pkg-mac-arm64/clawbench/clawbench
           cd pkg-mac-arm64 && zip -r clawbench-darwin-arm64.zip clawbench/
 
       - uses: softprops/action-gh-release@v2
@@ -232,8 +229,7 @@ jobs:
           cp clawbench-darwin-amd64 pkg-mac-amd64/clawbench/clawbench
           cp -r public pkg-mac-amd64/clawbench/public
           cp -r config pkg-mac-amd64/clawbench/config
-          cp server.sh pkg-mac-amd64/clawbench/
-          chmod +x pkg-mac-amd64/clawbench/clawbench pkg-mac-amd64/clawbench/server.sh
+          chmod +x pkg-mac-amd64/clawbench/clawbench
           cd pkg-mac-amd64 && zip -r clawbench-darwin-amd64.zip clawbench/
 
       - uses: softprops/action-gh-release@v2


### PR DESCRIPTION
PR #179 删除了 server.sh 和 server.ps1，但 release.yml 打包步骤仍在引用它们，导致 v0.42.0 的 4 个构建 job 全部失败。

## 修复内容
- 从 Linux/macOS 打包步骤移除 `cp server.sh` 和相关 chmod
- 从 Windows 打包步骤移除 `Copy-Item server.ps1`

## 验证
修复后需要重新触发 release 构建以验证。