### PR TITLE
fix(ci): remove install.ps1 from release upload

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -294,7 +294,7 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           TAG=${GITHUB_REF#refs/tags/}
-          gh release upload "$TAG" install.sh install.ps1 --clobber
+          gh release upload "$TAG" install.sh --clobber
 
       - name: Generate release notes
         env:


### PR DESCRIPTION
PR #179 也删除了 install.ps1，但 release.yml 的 upload install scripts 步骤仍在引用它，导致 v0.42.0 release 的 Generate Release Notes job 失败。