### PR TITLE
fix: add norag build tag to exclude DuckDB from static Linux binary

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -89,10 +89,11 @@ jobs:
 
       - name: Build Linux binary
         env:
-          CGO_ENABLED: 1
+          CGO_ENABLED: 0
         run: |
           VERSION=$(git describe --tags --always 2>/dev/null || echo "dev")
-          go build -ldflags="-s -w -extldflags '-static' -X clawbench/internal/version.Version=$VERSION" -o clawbench-linux ./cmd/server
+          go build -tags norag -ldflags="-s -w -X clawbench/internal/version.Version=$VERSION" -o clawbench-linux ./cmd/server
+          echo "Built with CGO_ENABLED=0 -tags norag: pure Go, no DuckDB/RAG, no glibc dependency"
 
       - name: Verify Linux binary is statically linked
         run: |

--- a/build.sh
+++ b/build.sh
@@ -10,6 +10,7 @@ TARGET_OS=""
 TARGET_ARCH=""
 BUILD_ANDROID=""
 DOWNLOAD_PI=""
+BUILD_TAGS=""
 for arg in "$@"; do
     case "$arg" in
         --windows)
@@ -38,6 +39,9 @@ for arg in "$@"; do
             ;;
         --with-pi)
             DOWNLOAD_PI=1
+            ;;
+        --no-rag)
+            BUILD_TAGS="norag"
             ;;
     esac
 done
@@ -92,10 +96,10 @@ if command -v go >/dev/null 2>&1; then
         if [ "$TARGET_OS" = "windows" ]; then
             BINARY_NAME="${NAME}.exe"
         fi
-        GOOS=$TARGET_OS GOARCH=$TARGET_ARCH go build -ldflags "$LDFLAGS" -o "$BINARY_NAME" ./cmd/server
+        GOOS=$TARGET_OS GOARCH=$TARGET_ARCH go build -tags "$BUILD_TAGS" -ldflags "$LDFLAGS" -o "$BINARY_NAME" ./cmd/server
         echo "  Cross-compiled: $BINARY_NAME ($TARGET_OS/$TARGET_ARCH)"
     else
-        go build -ldflags "$LDFLAGS" -o "$NAME" ./cmd/server
+        go build -tags "$BUILD_TAGS" -ldflags "$LDFLAGS" -o "$NAME" ./cmd/server
         echo "  Go binary: ./$NAME"
     fi
 else

--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -495,12 +495,15 @@ func main() { //nolint:gocognit,gocyclo // complex startup orchestration
 	}
 	handler.SetSummarizer(ttsSummarizer)
 
-	// Initialize RAG history memory system (always enabled)
-	if err := rag.Init(cfg.RAG); err != nil {
-		slog.Warn("failed to initialize RAG system, search will be limited", slog.String("err", err.Error()))
+	// Initialize RAG history memory system
+	if ragAvailable {
+		if err := rag.Init(cfg.RAG); err != nil {
+			slog.Warn("failed to initialize RAG system, search will be limited", slog.String("err", err.Error()))
+		}
+		defer rag.Shutdown()
+	} else {
+		slog.Info("RAG disabled (built with norag tag)")
 	}
-	// Always defer shutdown — cleanup worker may be running even without RAG
-	defer rag.Shutdown()
 
 	// Determine port before loading skills/agents (skills and agents need {{PORT}})
 	port := cfg.Port
@@ -632,13 +635,15 @@ func main() { //nolint:gocognit,gocyclo // complex startup orchestration
 	}
 
 	// Initialize RAG indexer (needs final port number)
-	if rag.GlobalStore != nil {
+	if ragAvailable && rag.GlobalStore != nil {
 		// Start RAG indexer
 		rag.StartIndexer(cfg.RAG)
 	}
 
 	// Start cleanup worker for soft-deleted data (runs even without RAG)
-	rag.StartCleanupWorker(cfg.RAG)
+	if ragAvailable {
+		rag.StartCleanupWorker(cfg.RAG)
+	}
 
 	// Initialize proxy service (port forwarding) and SSH tunnel server.
 	// ProxyRegistry is only created when SSH tunnel is enabled — it has no

--- a/cmd/server/rag_enabled.go
+++ b/cmd/server/rag_enabled.go
@@ -1,0 +1,5 @@
+//go:build !norag
+
+package main
+
+const ragAvailable = true

--- a/cmd/server/rag_stub.go
+++ b/cmd/server/rag_stub.go
@@ -1,0 +1,5 @@
+//go:build norag
+
+package main
+
+const ragAvailable = false

--- a/internal/handler/rag_api.go
+++ b/internal/handler/rag_api.go
@@ -1,3 +1,5 @@
+//go:build !norag
+
 //nolint:goconst // JSON response field names are domain strings, not config constants
 package handler
 

--- a/internal/handler/rag_api_stub.go
+++ b/internal/handler/rag_api_stub.go
@@ -1,0 +1,19 @@
+//go:build norag
+
+package handler
+
+import (
+	"net/http"
+)
+
+func ServeRAGSearch(w http.ResponseWriter, r *http.Request) {
+	writeLocalizedErrorf(w, r, http.StatusServiceUnavailable, "RAGNotAvailable")
+}
+
+func ServeRAGMessage(w http.ResponseWriter, r *http.Request) {
+	writeLocalizedErrorf(w, r, http.StatusServiceUnavailable, "RAGNotAvailable")
+}
+
+func ServeRAGSession(w http.ResponseWriter, r *http.Request) {
+	writeLocalizedErrorf(w, r, http.StatusServiceUnavailable, "RAGNotAvailable")
+}

--- a/internal/handler/rag_api_test.go
+++ b/internal/handler/rag_api_test.go
@@ -1,3 +1,5 @@
+//go:build !norag
+
 package handler
 
 import (

--- a/internal/rag/chunker.go
+++ b/internal/rag/chunker.go
@@ -1,3 +1,5 @@
+//go:build !norag
+
 package rag
 
 import (

--- a/internal/rag/chunker_test.go
+++ b/internal/rag/chunker_test.go
@@ -1,3 +1,5 @@
+//go:build !norag
+
 package rag
 
 import (

--- a/internal/rag/cleanup.go
+++ b/internal/rag/cleanup.go
@@ -1,3 +1,5 @@
+//go:build !norag
+
 package rag
 
 import (

--- a/internal/rag/cleanup_test.go
+++ b/internal/rag/cleanup_test.go
@@ -1,3 +1,5 @@
+//go:build !norag
+
 package rag
 
 import (

--- a/internal/rag/embedding.go
+++ b/internal/rag/embedding.go
@@ -1,3 +1,5 @@
+//go:build !norag
+
 package rag
 
 import (

--- a/internal/rag/embedding_test.go
+++ b/internal/rag/embedding_test.go
@@ -1,3 +1,5 @@
+//go:build !norag
+
 package rag
 
 import (

--- a/internal/rag/indexer.go
+++ b/internal/rag/indexer.go
@@ -1,3 +1,5 @@
+//go:build !norag
+
 package rag
 
 import (

--- a/internal/rag/indexer_test.go
+++ b/internal/rag/indexer_test.go
@@ -1,3 +1,5 @@
+//go:build !norag
+
 package rag
 
 import (

--- a/internal/rag/rag.go
+++ b/internal/rag/rag.go
@@ -1,3 +1,5 @@
+//go:build !norag
+
 package rag
 
 import (

--- a/internal/rag/rag_test.go
+++ b/internal/rag/rag_test.go
@@ -1,3 +1,5 @@
+//go:build !norag
+
 package rag
 
 import (

--- a/internal/rag/search.go
+++ b/internal/rag/search.go
@@ -1,3 +1,5 @@
+//go:build !norag
+
 package rag
 
 import (

--- a/internal/rag/search_test.go
+++ b/internal/rag/search_test.go
@@ -1,3 +1,5 @@
+//go:build !norag
+
 package rag
 
 import (

--- a/internal/rag/segmenter.go
+++ b/internal/rag/segmenter.go
@@ -1,3 +1,5 @@
+//go:build !norag
+
 package rag
 
 import (

--- a/internal/rag/segmenter_test.go
+++ b/internal/rag/segmenter_test.go
@@ -1,3 +1,5 @@
+//go:build !norag
+
 package rag
 
 import (

--- a/internal/rag/store.go
+++ b/internal/rag/store.go
@@ -1,3 +1,5 @@
+//go:build !norag
+
 package rag
 
 import (

--- a/internal/rag/store_test.go
+++ b/internal/rag/store_test.go
@@ -1,3 +1,5 @@
+//go:build !norag
+
 package rag
 
 import (

--- a/internal/rag/stub_norag.go
+++ b/internal/rag/stub_norag.go
@@ -1,0 +1,129 @@
+//go:build norag
+
+package rag
+
+import (
+	"context"
+	"time"
+
+	"clawbench/internal/model"
+)
+
+// Stub types — no DuckDB dependency when norag build tag is set.
+
+type Store struct{}
+
+type Chunk struct {
+	ID                 int64     `json:"id"`
+	SessionID          string    `json:"session_id"`
+	MessageID          int64     `json:"message_id"`
+	ChunkText          string    `json:"chunk_text"`
+	ChunkTextSegmented string    `json:"chunk_text_segmented"`
+	ChunkIndex         int       `json:"chunk_index"`
+	TokenCount         int       `json:"token_count"`
+	Embedding          []float64 `json:"embedding"`
+	HasEmbedding       bool      `json:"has_embedding"`
+	ProjectPath        string    `json:"project_path"`
+	Backend            string    `json:"backend"`
+	Role               string    `json:"role"`
+	CreatedAt          time.Time `json:"created_at"`
+}
+
+type SearchHit struct {
+	ChunkID      int64     `json:"chunk_id"`
+	ChunkText    string    `json:"chunk_text"`
+	Score        float64   `json:"score"`
+	SessionID    string    `json:"session_id"`
+	SessionTitle string    `json:"session_title"`
+	MessageID    int64     `json:"message_id"`
+	Role         string    `json:"role"`
+	ProjectPath  string    `json:"project_path"`
+	Backend      string    `json:"backend"`
+	CreatedAt    time.Time `json:"created_at"`
+}
+
+type SearchMode string
+
+const (
+	SearchModeHybrid SearchMode = "hybrid"
+	SearchModeVector SearchMode = "vector"
+	SearchModeFTS    SearchMode = "fts"
+)
+
+type SearchParams struct {
+	Query            string `json:"q"`
+	Limit            int    `json:"limit"`
+	ProjectPath      string `json:"project"`
+	Backend          string `json:"backend"`
+	Role             string `json:"role"`
+	SessionID        string `json:"session_id"`
+	ExcludeSessionID string `json:"exclude_session_id"`
+	FromTime         string `json:"from"`
+	ToTime           string `json:"to"`
+}
+
+type SearchResult struct {
+	Results []SearchHit `json:"results"`
+	Total   int         `json:"total"`
+	Mode    SearchMode  `json:"mode"`
+}
+
+type EmbeddingClient struct{}
+
+type Indexer struct{}
+
+type CleanupWorker struct{}
+
+type TextChunk struct {
+	Text       string
+	TokenCount int
+	Index      int
+}
+
+type PendingChunk struct {
+	ID        int64
+	ChunkText string
+}
+
+// Global variables — all nil in norag mode.
+
+var (
+	GlobalStore         *Store
+	GlobalIndexer       *Indexer
+	GlobalEmbedder      *EmbeddingClient
+	GlobalCleanupWorker *CleanupWorker
+)
+
+// Stub functions — all no-ops or safe defaults.
+
+func Init(cfg model.RAGConfig) error { return nil }
+
+func InitStore(cfg model.RAGConfig) (*Store, error) { return nil, nil }
+
+func NewStore(dbPath string, duckdbOpts map[string]string) (*Store, error) { return nil, nil }
+
+func StartIndexer(cfg model.RAGConfig) {}
+
+func StartCleanupWorker(cfg model.RAGConfig) {}
+
+func Shutdown() {}
+
+func EmbedderHealthy() bool { return false }
+
+func SetEmbedderHealthy(healthy bool) {}
+
+func RAGSearch(ctx context.Context, store *Store, embedder *EmbeddingClient, params SearchParams, defaultLimit int, searchPoolSize int) (*SearchResult, error) {
+	return &SearchResult{Results: []SearchHit{}}, nil
+}
+
+func InitSegmenter() error { return nil }
+
+func SegmentText(text string) string { return text }
+
+func ExtractTextFromContent(content, role string) string { return "" }
+
+func ChunkText(text string, chunkSize, chunkOverlap int) []TextChunk { return nil }
+
+func (s *Store) Close() error { return nil }
+
+func (s *Store) ChunkCount() (int, error) { return 0, nil }

--- a/internal/rag/test_helpers_test.go
+++ b/internal/rag/test_helpers_test.go
@@ -1,3 +1,5 @@
+//go:build !norag
+
 package rag
 
 // Shared test constants to avoid goconst duplicates across test files.


### PR DESCRIPTION
## Problem

Release CI builds a statically-linked Linux binary with `CGO_ENABLED=1 -extldflags '-static'`. DuckDB's CGO code is incompatible with static glibc — the binary compiles but crashes with SIGSEGV at `_Cfunc_duckdb_execute_pending` on startup.

`rag.enabled: false` config does NOT help because the `_ "github.com/marcboeker/go-duckdb"` blank import in `store.go` unconditionally links DuckDB CGO code.

## Fix

Add a `norag` build tag that excludes the entire `internal/rag` package and replaces it with no-op stubs. The Linux static release build now uses `CGO_ENABLED=0 -tags norag` for a pure Go static binary (no DuckDB, no glibc dependency, no SIGSEGV).

## Changes

- `internal/rag/stub_norag.go` — no-op stubs for all exported symbols (types, vars, functions)
- `internal/handler/rag_api_stub.go` — 503 responses for RAG API endpoints when norag
- `cmd/server/rag_stub.go` / `rag_enabled.go` — `ragAvailable` const
- All `internal/rag/*.go` files — `//go:build !norag` tag
- `internal/handler/rag_api.go` / `rag_api_test.go` — `//go:build !norag` tag
- `cmd/server/main.go` — guard RAG init/shutdown/indexer with `ragAvailable`
- `.github/workflows/release.yml` — Linux build: `CGO_ENABLED=0 -tags norag`
- `build.sh` — add `--no-rag` flag

## Verification

- ✅ `CGO_ENABLED=0 go build -tags norag` → statically linked binary, starts without SIGSEGV
- ✅ `go build ./cmd/server` → normal build with full RAG (no regression)
- ✅ `go test ./internal/rag/...` → passes
- ✅ `go test -tags norag ./internal/handler/...` → passes
- ✅ `go vet -tags norag ./...` → no errors
- ✅ RAG API returns 503 when built with norag