### PR TITLE
fix(ci): switch Linux release to dynamic linking

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -89,20 +89,16 @@ jobs:
 
       - name: Build Linux binary
         env:
-          CGO_ENABLED: 0
+          CGO_ENABLED: 1
         run: |
           VERSION=$(git describe --tags --always 2>/dev/null || echo "dev")
-          go build -tags norag -ldflags="-s -w -X clawbench/internal/version.Version=$VERSION" -o clawbench-linux ./cmd/server
-          echo "Built with CGO_ENABLED=0 -tags norag: pure Go, no DuckDB/RAG, no glibc dependency"
+          go build -ldflags="-s -w -X clawbench/internal/version.Version=$VERSION" -o clawbench-linux ./cmd/server
+          echo "Built with CGO_ENABLED=1: dynamically linked, DuckDB/RAG enabled"
 
-      - name: Verify Linux binary is statically linked
+      - name: Verify Linux binary
         run: |
-          if file clawbench-linux | grep -q "statically linked"; then
-            echo "✅ Linux binary is statically linked (no glibc dependency)"
-          else
-            echo "❌ Linux binary is NOT statically linked — glibc version mismatch may occur on older distros"
-            exit 1
-          fi
+          file clawbench-linux
+          ldd clawbench-linux
 
       - name: Package Linux
         run: |


### PR DESCRIPTION
## Problem

Linux release binary was built with `CGO_ENABLED=0 -tags norag` (PR #182) to work around DuckDB SIGSEGV with static glibc. This works but **sacrifices RAG functionality entirely** — DuckDB is excluded at compile time.

## Root Cause

DuckDB (`go-duckdb`) requires CGO and is incompatible with static glibc linking. The binary compiles but crashes at runtime (`_Cfunc_duckdb_execute_pending` SIGSEGV). There is no way to have both DuckDB and static linking.

## Fix

Switch Linux release build back to `CGO_ENABLED=1` dynamic linking:
- DuckDB/RAG works normally
- Binary depends on glibc (Ubuntu 22.04+ glibc 2.35, widely available)
- Remove the static linking verification step (no longer applicable)
- Replace with `file` + `ldd` info output for debugging

The `norag` build tag infrastructure (PR #182) is **kept** — it remains useful for local development in environments without CGO (`./build.sh --no-rag`). Only the release workflow stops using it.

## Changes

- `.github/workflows/release.yml`: Linux build → `CGO_ENABLED=1`, remove `-tags norag`, replace static verification with `file`/`ldd` output