### PR TITLE
fix(ci): fix Windows Pi download - zip has no pi/ subdirectory

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -161,9 +161,8 @@ jobs:
           New-Item -ItemType Directory -Force -Path .clawbench\pi
           $tmpZip = "$env:TEMP\pi-download.zip"
           Invoke-WebRequest -Uri $PI_URL -OutFile $tmpZip
-          Expand-Archive -Path $tmpZip -DestinationPath "$env:TEMP\pi-download" -Force
-          Copy-Item -Recurse "$env:TEMP\pi-download\pi\*" ".clawbench\pi\" -Force
-          Remove-Item $tmpZip, "$env:TEMP\pi-download" -Recurse -Force
+          Expand-Archive -Path $tmpZip -DestinationPath .clawbench\pi -Force
+          Remove-Item $tmpZip -Force
           Set-Content -Path ".clawbench\pi\VERSION" -Value $env:PI_VERSION
           Write-Host "Pi v${env:PI_VERSION} downloaded"
 


### PR DESCRIPTION
Pi Windows zip extracts files directly to root (pi.exe, export-html/, native/), unlike Linux/macOS tar.gz which wraps everything in a pi/ directory. The previous code tried to copy from a non-existent `pi/` subdirectory in the temp extraction path. Fix: directly extract to `.clawbench/pi/` instead of using an intermediate temp directory.