### PR TITLE
feat(ci): add Docker image build & push to ghcr.io

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -127,6 +127,11 @@ jobs:
           generate_release_notes: false
           files: pkg-linux/clawbench-linux-amd64.zip
 
+      - uses: actions/upload-artifact@v4
+        with:
+          name: linux-package
+          path: pkg-linux/clawbench/
+
   build-windows:
     name: Build Windows amd64
     needs: build-frontend
@@ -330,9 +335,61 @@ jobs:
           files: |
             android/app/build/outputs/apk/release/clawbench-android.apk
 
+  docker:
+    name: Build & Push Docker Image
+    needs: build-linux
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/download-artifact@v4
+        with:
+          name: linux-package
+          path: pkg-linux/clawbench/
+
+      - name: Prepare Docker build context
+        run: |
+          cp pkg-linux/clawbench/clawbench .
+          cp -r pkg-linux/clawbench/public .
+          mkdir -p docker-staging/pi
+          cp -r pkg-linux/clawbench/.clawbench/pi/* docker-staging/pi/
+          chmod +x ./clawbench
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Extract version from tag
+        id: version
+        run: echo "VERSION=${GITHUB_REF#refs/tags/}" >> "$GITHUB_OUTPUT"
+
+      - name: Build and push Docker image
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          platforms: linux/amd64,linux/arm64
+          push: true
+          tags: |
+            ghcr.io/${{ github.repository }}:latest
+            ghcr.io/${{ github.repository }}:${{ steps.version.outputs.VERSION }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+
   release-notes:
     name: Generate Release Notes
-    needs: [build-linux, build-windows, build-macos-arm64, build-macos-amd64, build-android]
+    needs: [build-linux, build-windows, build-macos-arm64, build-macos-amd64, build-android, docker]
     runs-on: ubuntu-latest
     permissions:
       contents: write

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,13 +1,15 @@
 # ClawBench runtime image — runs the pre-built binary
 #
-# Prerequisites: run ./build.sh first (and ./build.sh --with-pi for setup wizard)
-#
-# Build & run (one step):
+# Build locally:
 #   ./scripts/docker-build.sh
 #
 # Or manually:
 #   docker build -t clawbench .
-#   docker run -p 20300:20300 -v clawbench-data:/data clawbench
+#   docker run -p 20000:20000 -v clawbench-data:/data clawbench
+#
+# Pull from GitHub Container Registry:
+#   docker pull ghcr.io/clawbench-dev/clawbench:latest
+#   docker run -d -p 20000:20000 -v clawbench-data:/data ghcr.io/clawbench-dev/clawbench:latest
 
 FROM ubuntu:24.04
 
@@ -25,13 +27,14 @@ COPY clawbench .
 COPY public/ ./public/
 
 # Copy Pi binary for setup wizard
-# Uses a staging directory created by scripts/docker-build.sh
+# Local build: scripts/docker-build.sh populates docker-staging/
+# CI build: release workflow populates docker-staging/ from build-linux artifact
 # If the staging dir is empty, COPY still succeeds (copies empty layer)
 COPY docker-staging/ .clawbench/
 
 # Data directory (mounted as volume for persistence)
 RUN mkdir -p /data/.clawbench
 
-EXPOSE 20300
+EXPOSE 20000
 
-ENTRYPOINT ["./clawbench", "--port", "20300", "--data-dir", "/data/.clawbench"]
+ENTRYPOINT ["./clawbench", "--port", "20000", "--data-dir", "/data/.clawbench"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,10 +1,6 @@
-# Pure test environment for ClawBench setup wizard
+# ClawBench Docker deployment
 #
-# Prerequisites:
-#   1. Build the project:  ./build.sh --with-pi
-#      (--with-pi downloads the Pi binary needed for the setup wizard)
-#
-# Usage:
+# Quick start:
 #   ./scripts/docker-build.sh           # one-step: prepare + build + run
 #   docker compose up -d                # start (after first build)
 #   docker compose down                 # stop (data preserved in volume)
@@ -12,18 +8,19 @@
 #   docker compose up -d --build        # rebuild image after code changes
 #   docker compose logs -f              # follow logs
 #
-# Access: http://localhost:20300
+# Access: http://localhost:20000
 # Password: auto-generated on first start, saved to /data/.clawbench/auto-password
-#           View with: docker exec clawbench-test cat /data/.clawbench/auto-password
+#           View with: docker exec clawbench cat /data/.clawbench/auto-password
 
 services:
   clawbench:
     build:
       context: .
       dockerfile: Dockerfile
-    container_name: clawbench-test
+    container_name: clawbench
+    image: ghcr.io/clawbench-dev/clawbench:latest
     ports:
-      - "20300:20300"
+      - "20000:20000"
     volumes:
       - clawbench-data:/data
     restart: unless-stopped

--- a/scripts/docker-build.sh
+++ b/scripts/docker-build.sh
@@ -1,15 +1,15 @@
 #!/usr/bin/env bash
 set -e
 
-# One-step Docker build & run for ClawBench testing
+# One-step Docker build & run for ClawBench
 #
 # Usage:
-#   ./scripts/docker-build.sh           # build + run (port 20300)
+#   ./scripts/docker-build.sh           # build + run (port 20000)
 #   ./scripts/docker-build.sh --stop    # stop and remove container
 #   ./scripts/docker-build.sh --clean   # stop + remove container + volume
 
-PORT=20300
-NAME="clawbench-test"
+PORT=20000
+NAME="clawbench"
 
 # Stop existing container
 if docker ps -a --format '{{.Names}}' | grep -q "^${NAME}$"; then
@@ -34,7 +34,7 @@ fi
 echo "Building binary..."
 ./build.sh --with-pi
 
-# Prepare staging directory for Pi binary (optional)
+# Prepare staging directory for Pi binary
 rm -rf docker-staging
 mkdir -p docker-staging/pi
 if [ -d ".clawbench/pi" ] && [ -f ".clawbench/pi/pi" ]; then


### PR DESCRIPTION
## What

Add Docker image build and publish to GitHub Container Registry as part of the release workflow.

## Changes

**release.yml** — new `docker` job:
- Downloads Linux package artifact from `build-linux`
- Builds multi-arch (`linux/amd64` + `linux/arm64`) Docker image via Buildx + QEMU
- Pushes to `ghcr.io/clawbench-dev/clawbench` with two tags:
  - Version tag: `v0.42.0`
  - `latest`
- Uses `GITHUB_TOKEN` for auth — no extra secrets needed
- `release-notes` job now waits for `docker` to complete

**Dockerfile** — port 20300 → 20000 (project default)

**docker-compose.yml** — port 20000, container name `clawbench`, image `ghcr.io/clawbench-dev/clawbench:latest`

**scripts/docker-build.sh** — port and container name updated

## User experience after merge

```bash
# Pull and run — zero setup needed
docker pull ghcr.io/clawbench-dev/clawbench:latest
docker run -d -p 20000:20000 -v clawbench-data:/data ghcr.io/clawbench-dev/clawbench:latest

# Get auto-generated password
docker exec clawbench cat /data/.clawbench/auto-password

# Open browser
http://localhost:20000
# → Setup Wizard appears, configure LLM provider and start chatting
```