### PR TITLE
feat(ci): auto-set ghcr.io package visibility to public

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -389,6 +389,25 @@ jobs:
           cache-from: type=gha
           cache-to: type=gha,mode=max
 
+      - name: Set package visibility to public
+        if: always()
+        continue-on-error: true
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          ORG="${GITHUB_REPOSITORY_OWNER}"
+          # Try org-level endpoint first, then user-level
+          if ! gh api --method PATCH \
+            -H "Accept: application/vnd.github+json" \
+            "/orgs/${ORG}/packages/container/clawbench" \
+            -f visibility=public 2>/dev/null; then
+            gh api --method PATCH \
+              -H "Accept: application/vnd.github+json" \
+              /user/packages/container/clawbench \
+              -f visibility=public 2>/dev/null || \
+              echo "⚠ Could not set package visibility via API — set manually at https://github.com/orgs/${ORG}/packages/container/clawbench/settings"
+          fi
+
   release-notes:
     name: Generate Release Notes
     needs: [build-linux, build-windows, build-macos-arm64, build-macos-amd64, build-android, docker]


### PR DESCRIPTION
## 问题
Docker 镜像推送到 ghcr.io 后默认为 private，需要手动到 GitHub Web UI 改为 public。GitHub 没有提供官方 API 来修改 package 可见性。

## 方案
1. 已删除之前 private 的旧包（org + user namespace）
2. 在 docker job 末尾增加  步骤，通过 `gh api` 尝试 PATCH 可见性
3. 设置 `continue-on-error: true` 和 `if: always()`，即使 API 不可用也不阻塞发布
4. 如果 API 方式不行（GitHub 可能未开放此 endpoint），则打印手动操作链接

## 验证
由于仓库是 public 的，删除旧包后下次 CI 发布时新包应该自动继承 public 可见性。此步骤作为双保险。