### PR TITLE
fix(ci): replace failed PATCH API with visibility check + warning

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -389,23 +389,27 @@ jobs:
           cache-from: type=gha
           cache-to: type=gha,mode=max
 
-      - name: Set package visibility to public
+      - name: Check package visibility
         if: always()
         continue-on-error: true
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           ORG="${GITHUB_REPOSITORY_OWNER}"
-          # Try org-level endpoint first, then user-level
-          if ! gh api --method PATCH \
-            -H "Accept: application/vnd.github+json" \
-            "/orgs/${ORG}/packages/container/clawbench" \
-            -f visibility=public 2>/dev/null; then
-            gh api --method PATCH \
-              -H "Accept: application/vnd.github+json" \
-              /user/packages/container/clawbench \
-              -f visibility=public 2>/dev/null || \
-              echo "⚠ Could not set package visibility via API — set manually at https://github.com/orgs/${ORG}/packages/container/clawbench/settings"
+          PKG_SLUG="clawbench"
+          SETTINGS_URL="https://github.com/orgs/${ORG}/packages/container/${PKG_SLUG}/settings"
+          ORG_PACKAGES_URL="https://github.com/orgs/${ORG}/settings/packages"
+
+          # GitHub has no API to change package visibility — this can only be
+          # done via the web UI.  We check and warn if the package is private.
+          VISIBILITY=$(gh api "/orgs/${ORG}/packages/container/${PKG_SLUG}" --jq '.visibility' 2>/dev/null || echo "not_found")
+
+          if [ "$VISIBILITY" = "public" ]; then
+            echo "✅ Package is already public"
+          elif [ "$VISIBILITY" = "private" ]; then
+            echo "::warning::Docker image package is PRIVATE. Users cannot pull without authentication. Fix: ${SETTINGS_URL} → Danger Zone → Change visibility → Public. To make this permanent: ${ORG_PACKAGES_URL} → Package Creation → Public."
+          else
+            echo "::warning::Could not determine package visibility. If it's private, set it to public at: ${SETTINGS_URL}"
           fi
 
   release-notes:


### PR DESCRIPTION
## 背景
PR #189 尝试用 `gh api PATCH` 设置 ghcr.io 包可见性，但 GitHub 不提供此 API endpoint，步骤始终失败。

## 改动
- 将 `Set package visibility to public` 步骤替换为 `Check package visibility`
- 通过 `gh api GET` 检查包可见性状态
- 如果是 private，输出 `::warning::` 提示（会显示在 GitHub Actions summary 中）
- 包含两个关键链接：
  1. **包设置页** — 修改当前包的可见性
  2. **Org Settings → Packages** — 设置 Package Creation 默认为 Public（一劳永逸）

## 根本解决
GitHub 没有提供修改 package 可见性的 API，只有两种方式：
1. **手动**：在包的 Settings → Danger Zone → Change visibility → Public
2. **永久**：Org Settings → Packages → Package Creation → Public（新建的包自动 public）

设置了 Org 默认后，以后每次 release 就不需要手动操作了。