### PR TITLE
feat: structured startup banner with emoji and CJK-aligned borders

### DIFF
--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -29,8 +29,10 @@ import (
 	"clawbench/internal/service"
 	"clawbench/internal/speech"
 	"clawbench/internal/ssh"
+	"clawbench/internal/startup"
 	"clawbench/internal/summarize"
 	"clawbench/internal/terminal"
+	"clawbench/internal/version"
 	"clawbench/internal/ws"
 )
 
@@ -118,6 +120,8 @@ func makeRestartFunc(shutdown func()) func() {
 }
 
 func main() { //nolint:gocognit,gocyclo // complex startup orchestration
+	startTime := time.Now()
+
 	// Root --help handler
 	if len(os.Args) > 1 && (os.Args[1] == "--help" || os.Args[1] == "-h") {
 		fmt.Println("ClawBench - Mobile-first AI workstation")
@@ -379,22 +383,13 @@ func main() { //nolint:gocognit,gocyclo // complex startup orchestration
 	// $SHELL to decide which shell their "Bash tool" uses.
 	platform.SetLoginShell()
 
-	// Print auto-generated password info (ISS-003d: don't log plaintext password)
+	// Auto-generated password info is now shown in the startup banner (below).
+	// ISS-003d: don't log plaintext password to slog.
 	if autoPassword != "" {
 		slog.Info(
 			"auto-generated password (no password configured)",
 			slog.String("file", filepath.Join(model.BinDir, ".clawbench", "auto-password")),
 		)
-		// Print to stdout for foreground mode and shell scripts to capture
-		pwdLine := "  Password: " + autoPassword + "  "
-		top := " ┌" + strings.Repeat("─", len(pwdLine)-2) + "┐"
-		mid := " │" + pwdLine + "│"
-		bot := " └" + strings.Repeat("─", len(pwdLine)-2) + "┘"
-		fmt.Println()
-		fmt.Println(top)
-		fmt.Println(mid)
-		fmt.Println(bot)
-		fmt.Println()
 	}
 
 	// Initialize password verification state
@@ -648,6 +643,7 @@ func main() { //nolint:gocognit,gocyclo // complex startup orchestration
 	// Initialize proxy service (port forwarding) and SSH tunnel server.
 	// ProxyRegistry is only created when SSH tunnel is enabled — it has no
 	// standalone purpose without the SSH tunnel to transport traffic.
+	var sshServerRef *ssh.Server
 	if cfg.PortForward.Enabled {
 		proxyService := service.NewProxyRegistry(port)
 		// Always apply config — empty AllowedPorts means "allow all ports"
@@ -655,14 +651,14 @@ func main() { //nolint:gocognit,gocyclo // complex startup orchestration
 		service.ProxyService = proxyService
 		defer proxyService.Stop()
 
-		sshServer := ssh.NewServer(cfg.PortForward, port, cfg.Password, proxyService)
-		handler.SetSSHServer(sshServer)
+		sshServerRef = ssh.NewServer(cfg.PortForward, port, cfg.Password, proxyService)
+		handler.SetSSHServer(sshServerRef)
 		go func() {
-			if err := sshServer.ListenAndServe(); err != nil {
+			if err := sshServerRef.ListenAndServe(); err != nil {
 				slog.Error("SSH server failed", slog.String("err", err.Error()))
 			}
 		}()
-		defer func() { sshServer.Close() }()
+		defer func() { sshServerRef.Close() }()
 	} else {
 		slog.Info("SSH tunnel and port forwarding disabled by config")
 	}
@@ -713,6 +709,82 @@ func main() { //nolint:gocognit,gocyclo // complex startup orchestration
 		}
 	}
 
+	// Resolve TLS config and scheme before banner.
+	// This also logs the HTTP/TLS mode so those slog lines appear
+	// *before* the banner and don't visually disrupt it.
+	scheme := "http"
+	tlsCertFile := ""
+	tlsKeyFile := ""
+	if cfg.TLS.Enabled {
+		tlsCertFile = cfg.TLS.CertFile
+		if tlsCertFile == "" {
+			tlsCertFile = os.Getenv("CERT_FILE")
+		}
+		tlsKeyFile = cfg.TLS.KeyFile
+		if tlsKeyFile == "" {
+			tlsKeyFile = os.Getenv("KEY_FILE")
+		}
+		if tlsCertFile == "" || tlsKeyFile == "" {
+			slog.Warn("TLS enabled but cert_file and key_file are not configured, falling back to HTTP")
+		} else {
+			scheme = "https"
+			slog.Info("starting with TLS", slog.String("cert", tlsCertFile))
+		}
+	}
+	if scheme == "http" {
+		slog.Info("starting with HTTP")
+	}
+
+	// Start dev HTTP listener before banner (so its slog doesn't disrupt the banner)
+	if devSrv != nil && scheme == "https" {
+		go func() {
+			if err := devSrv.ListenAndServe(); err != nil && err != http.ErrServerClosed {
+				slog.Error("dev listener failed", slog.String("err", err.Error()))
+			}
+		}()
+	}
+
+	// --- Print startup banner (MUST be the last output before HTTP server starts) ---
+	// All subsystem initialization is complete; this is the final summary
+	// shown to the operator before the server begins accepting connections.
+	// Placed here to avoid being visually disrupted by subsequent slog lines.
+
+	// Build agent info list
+	agentInfos := make([]startup.AgentInfo, 0, len(model.AgentList))
+	for _, a := range model.AgentList {
+		agentInfos = append(agentInfos, startup.AgentInfo{
+			Name:   a.Name,
+			Models: len(a.Models),
+		})
+	}
+
+	// Count scheduled tasks
+	taskCount := scheduler.TaskCount()
+
+	// Determine SSH port
+	sshEnabled := cfg.PortForward.Enabled && sshServerRef != nil
+	sshPort := 0
+	if sshEnabled {
+		sshPort = sshServerRef.Port()
+	}
+
+	startup.PrintBanner(startup.BannerConfig{
+		Version:         version.Get(),
+		Scheme:          scheme,
+		Port:            port,
+		LocalIP:         platform.GetOutboundIP(),
+		AutoPassword:    autoPassword,
+		DataDir:         filepath.Join(model.BinDir, ".clawbench"),
+		Agents:          agentInfos,
+		SSHEnabled:      sshEnabled,
+		SSHPort:         sshPort,
+		TTSEngine:       engine,
+		RAGAvailable:    ragAvailable && rag.GlobalStore != nil,
+		TerminalOn:      cfg.Terminal.Enabled,
+		TaskCount:       taskCount,
+		StartupDuration: time.Since(startTime),
+	})
+
 	// Graceful shutdown on SIGINT/SIGTERM
 	ctx, stop := signal.NotifyContext(context.Background(), syscall.SIGINT, syscall.SIGTERM)
 	defer stop()
@@ -732,41 +804,14 @@ func main() { //nolint:gocognit,gocyclo // complex startup orchestration
 		}
 	}()
 
-httpServer:
-	if !cfg.TLS.Enabled {
-		// TLS disabled: plain HTTP
-		slog.Info("starting with HTTP")
-		if err := srv.ListenAndServe(); err != nil && err != http.ErrServerClosed {
+	// Start HTTP server (blocking)
+	if scheme == "https" {
+		if err := srv.ListenAndServeTLS(tlsCertFile, tlsKeyFile); err != nil && err != http.ErrServerClosed {
 			slog.Error("server failed", slog.String("err", err.Error()))
 			os.Exit(1)
 		}
 	} else {
-		// HTTPS with TLS
-		certFile := cfg.TLS.CertFile
-		keyFile := cfg.TLS.KeyFile
-		if certFile == "" {
-			certFile = os.Getenv("CERT_FILE")
-		}
-		if keyFile == "" {
-			keyFile = os.Getenv("KEY_FILE")
-		}
-		if certFile == "" || keyFile == "" {
-			slog.Warn("TLS enabled but cert_file and key_file are not configured, falling back to HTTP")
-			goto httpServer
-		}
-		slog.Info("starting with TLS", slog.String("cert", certFile))
-
-		// Start dev HTTP listener alongside TLS
-		if devSrv != nil {
-			go func() {
-				slog.Info("dev HTTP listener", slog.Int("port", cfg.DevPort))
-				if err := devSrv.ListenAndServe(); err != nil && err != http.ErrServerClosed {
-					slog.Error("dev listener failed", slog.String("err", err.Error()))
-				}
-			}()
-		}
-
-		if err := srv.ListenAndServeTLS(certFile, keyFile); err != nil && err != http.ErrServerClosed {
+		if err := srv.ListenAndServe(); err != nil && err != http.ErrServerClosed {
 			slog.Error("server failed", slog.String("err", err.Error()))
 			os.Exit(1)
 		}

--- a/internal/handler/settings.go
+++ b/internal/handler/settings.go
@@ -14,7 +14,6 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
-	"runtime/debug"
 	"sort"
 	"strings"
 	"sync"
@@ -257,34 +256,9 @@ var validMossNanoBackends = map[string]bool{
 }
 
 // getBuildVersion returns a human-readable version string from build info.
-// When version.Version is set via -ldflags (from git describe), it combines
-// the semantic version with the VCS short SHA, e.g. "v1.0.0 (abc1234)".
-// getBuildVersion returns the version string injected at build time via -ldflags.
-// For release builds (HEAD on a tag), the format is: "v1.0.0"
-// For dev builds, the format is: "v0.30.0-33-ga636beb (2026-05-21 10:30:00)"
-// When not set (bare "go build"), falls back to VCS info or "dev".
+// Delegates to version.Get() which handles ldflags injection and VCS fallback.
 func getBuildVersion() string {
-	if version.Version != "" {
-		return version.Version
-	}
-	// Fallback: no ldflags injected (bare "go build") — use VCS info
-	info, ok := debug.ReadBuildInfo()
-	if !ok {
-		return "dev"
-	}
-	var vcsRev string
-	for _, s := range info.Settings {
-		if s.Key == "vcs.revision" && len(s.Value) >= 7 {
-			vcsRev = s.Value[:7]
-		}
-	}
-	if vcsRev != "" {
-		return vcsRev
-	}
-	if info.Main.Version != "" && info.Main.Version != "(devel)" {
-		return info.Main.Version
-	}
-	return "dev"
+	return version.Get()
 }
 
 // maskAPIKey masks an API key for safe display: first 4 + *** + last 3 chars.

--- a/internal/platform/network.go
+++ b/internal/platform/network.go
@@ -6,15 +6,22 @@ import (
 	"time"
 )
 
-// outboundDialer is the dialer used by GetOutboundIP.
+// outboundDialer is the dialer used by the default dialOutbound implementation.
 // Package-level variable for testability.
 var outboundDialer = net.Dialer{Timeout: 1 * time.Second}
+
+// dialOutbound dials the outbound UDP connection used by GetOutboundIP.
+// Package-level function variable for testability — tests can override to
+// inject connections with custom LocalAddr values.
+var dialOutbound = func() (net.Conn, error) {
+	return outboundDialer.DialContext(context.Background(), "udp", "8.8.8.8:53")
+}
 
 // GetOutboundIP returns the preferred outbound IP address of this machine
 // by attempting a UDP connection to a public DNS server.
 // Returns empty string if the IP cannot be determined.
 func GetOutboundIP() string {
-	conn, err := outboundDialer.DialContext(context.Background(), "udp", "8.8.8.8:53")
+	conn, err := dialOutbound()
 	if err != nil {
 		return ""
 	}

--- a/internal/platform/network.go
+++ b/internal/platform/network.go
@@ -1,0 +1,26 @@
+package platform
+
+import (
+	"net"
+	"time"
+)
+
+// GetOutboundIP returns the preferred outbound IP address of this machine
+// by attempting a UDP connection to a public DNS server.
+// Returns empty string if the IP cannot be determined.
+func GetOutboundIP() string {
+	conn, err := net.DialTimeout("udp", "8.8.8.8:53", 1*time.Second)
+	if err != nil {
+		return ""
+	}
+	defer conn.Close()
+	addr, ok := conn.LocalAddr().(*net.UDPAddr)
+	if !ok {
+		return ""
+	}
+	// Skip loopback addresses
+	if addr.IP.IsLoopback() {
+		return ""
+	}
+	return addr.IP.String()
+}

--- a/internal/platform/network.go
+++ b/internal/platform/network.go
@@ -1,6 +1,7 @@
 package platform
 
 import (
+	"context"
 	"net"
 	"time"
 )
@@ -9,11 +10,12 @@ import (
 // by attempting a UDP connection to a public DNS server.
 // Returns empty string if the IP cannot be determined.
 func GetOutboundIP() string {
-	conn, err := net.DialTimeout("udp", "8.8.8.8:53", 1*time.Second)
+	dialer := net.Dialer{Timeout: 1 * time.Second}
+	conn, err := dialer.DialContext(context.Background(), "udp", "8.8.8.8:53")
 	if err != nil {
 		return ""
 	}
-	defer conn.Close()
+	defer conn.Close() //nolint:errcheck // best-effort close on UDP
 	addr, ok := conn.LocalAddr().(*net.UDPAddr)
 	if !ok {
 		return ""

--- a/internal/platform/network.go
+++ b/internal/platform/network.go
@@ -6,12 +6,15 @@ import (
 	"time"
 )
 
+// outboundDialer is the dialer used by GetOutboundIP.
+// Package-level variable for testability.
+var outboundDialer = net.Dialer{Timeout: 1 * time.Second}
+
 // GetOutboundIP returns the preferred outbound IP address of this machine
 // by attempting a UDP connection to a public DNS server.
 // Returns empty string if the IP cannot be determined.
 func GetOutboundIP() string {
-	dialer := net.Dialer{Timeout: 1 * time.Second}
-	conn, err := dialer.DialContext(context.Background(), "udp", "8.8.8.8:53")
+	conn, err := outboundDialer.DialContext(context.Background(), "udp", "8.8.8.8:53")
 	if err != nil {
 		return ""
 	}

--- a/internal/platform/network_test.go
+++ b/internal/platform/network_test.go
@@ -1,16 +1,29 @@
 package platform
 
 import (
-	"context"
+	"errors"
 	"net"
 	"testing"
 	"time"
 )
 
+// mockConn implements net.Conn for testing LocalAddr behavior.
+type mockConn struct {
+	localAddr net.Addr
+}
+
+func (m *mockConn) Read(b []byte) (n int, err error)   { return 0, net.ErrClosed }
+func (m *mockConn) Write(b []byte) (n int, err error)  { return 0, net.ErrClosed }
+func (m *mockConn) Close() error                       { return nil }
+func (m *mockConn) LocalAddr() net.Addr                { return m.localAddr }
+func (m *mockConn) RemoteAddr() net.Addr               { return nil }
+func (m *mockConn) SetDeadline(t time.Time) error      { return nil }
+func (m *mockConn) SetReadDeadline(t time.Time) error  { return nil }
+func (m *mockConn) SetWriteDeadline(t time.Time) error { return nil }
+
 func TestGetOutboundIP_ReturnsNonLoopback(t *testing.T) {
 	ip := GetOutboundIP()
 	if ip == "" {
-		// May be empty in isolated environments (no network)
 		t.Log("GetOutboundIP() returned empty string (no outbound route available)")
 		return
 	}
@@ -23,70 +36,90 @@ func TestGetOutboundIP_ReturnsNonLoopback(t *testing.T) {
 	}
 }
 
-func TestGetOutboundIP_Format(t *testing.T) {
-	ip := GetOutboundIP()
-	if ip == "" {
-		t.Skip("no outbound IP available in this environment")
-	}
-	// Should be a valid IPv4 or IPv6 address string
-	parsed := net.ParseIP(ip)
-	if parsed == nil {
-		t.Errorf("GetOutboundIP() = %q, not a valid IP address", ip)
-	}
-}
-
 func TestGetOutboundIP_DialError(t *testing.T) {
-	// Replace dialer with one that always fails
-	origDialer := outboundDialer
-	outboundDialer = net.Dialer{Timeout: 1 * time.Nanosecond}
-	defer func() { outboundDialer = origDialer }()
+	orig := dialOutbound
+	defer func() { dialOutbound = orig }()
+
+	dialOutbound = func() (net.Conn, error) {
+		return nil, errors.New("dial error")
+	}
 
 	ip := GetOutboundIP()
-	// With an impossibly short timeout, the dial should fail
-	// and return empty string
 	if ip != "" {
 		t.Errorf("GetOutboundIP() = %q, want empty string on dial error", ip)
 	}
 }
 
-func TestGetOutboundIP_CustomDialer(t *testing.T) {
-	// Test with a real dialer to exercise the success path
-	origDialer := outboundDialer
-	outboundDialer = net.Dialer{Timeout: 2 * time.Second}
-	defer func() { outboundDialer = origDialer }()
+func TestGetOutboundIP_NonUDPAddr(t *testing.T) {
+	orig := dialOutbound
+	defer func() { dialOutbound = orig }()
+
+	// Return a connection whose LocalAddr is a TCPAddr (not *net.UDPAddr)
+	dialOutbound = func() (net.Conn, error) {
+		return &mockConn{localAddr: &net.TCPAddr{IP: net.ParseIP("192.168.1.1"), Port: 1234}}, nil
+	}
+
+	ip := GetOutboundIP()
+	if ip != "" {
+		t.Errorf("GetOutboundIP() = %q, want empty string when LocalAddr is not *net.UDPAddr", ip)
+	}
+}
+
+func TestGetOutboundIP_LoopbackAddr(t *testing.T) {
+	orig := dialOutbound
+	defer func() { dialOutbound = orig }()
+
+	// Return a connection with a loopback UDP address
+	dialOutbound = func() (net.Conn, error) {
+		return &mockConn{localAddr: &net.UDPAddr{IP: net.ParseIP("127.0.0.1"), Port: 1234}}, nil
+	}
+
+	ip := GetOutboundIP()
+	if ip != "" {
+		t.Errorf("GetOutboundIP() = %q, want empty string for loopback address", ip)
+	}
+}
+
+func TestGetOutboundIP_ValidIP(t *testing.T) {
+	orig := dialOutbound
+	defer func() { dialOutbound = orig }()
+
+	// Return a connection with a valid non-loopback UDP address
+	dialOutbound = func() (net.Conn, error) {
+		return &mockConn{localAddr: &net.UDPAddr{IP: net.ParseIP("192.168.1.100"), Port: 12345}}, nil
+	}
+
+	ip := GetOutboundIP()
+	if ip != "192.168.1.100" {
+		t.Errorf("GetOutboundIP() = %q, want %q", ip, "192.168.1.100")
+	}
+}
+
+func TestGetOutboundIP_IPv6Addr(t *testing.T) {
+	orig := dialOutbound
+	defer func() { dialOutbound = orig }()
+
+	dialOutbound = func() (net.Conn, error) {
+		return &mockConn{localAddr: &net.UDPAddr{IP: net.ParseIP("fe80::1"), Port: 12345}}, nil
+	}
 
 	ip := GetOutboundIP()
 	if ip == "" {
-		t.Skip("no outbound IP available in this environment")
-	}
-
-	parsed := net.ParseIP(ip)
-	if parsed == nil {
-		t.Errorf("GetOutboundIP() = %q, not a valid IP address", ip)
-	}
-	if parsed.IsLoopback() {
-		t.Errorf("GetOutboundIP() returned loopback IP %q", ip)
+		t.Errorf("GetOutboundIP() returned empty for IPv6 link-local address")
 	}
 }
 
 func TestGetOutboundIP_ContextCanceled(t *testing.T) {
-	// Use a canceled context to force immediate failure
-	origDialer := outboundDialer
-	defer func() { outboundDialer = origDialer }()
+	orig := dialOutbound
+	defer func() { dialOutbound = orig }()
 
-	ctx, cancel := context.WithCancel(context.Background())
-	cancel() // cancel immediately
-
-	outboundDialer = net.Dialer{Timeout: 5 * time.Second}
-	conn, err := outboundDialer.DialContext(ctx, "udp", "8.8.8.8:53")
-	if err == nil {
-		conn.Close()
-		// If dial succeeded despite canceled context, skip
-		t.Skip("dial succeeded despite canceled context")
+	// Simulate a canceled context by returning an error
+	dialOutbound = func() (net.Conn, error) {
+		return nil, errors.New("context canceled")
 	}
-	// Verify that our function handles this gracefully
+
 	ip := GetOutboundIP()
-	// This doesn't test the canceled context path directly,
-	// but verifies the error handling works
-	_ = ip
+	if ip != "" {
+		t.Errorf("GetOutboundIP() = %q, want empty string on canceled context", ip)
+	}
 }

--- a/internal/platform/network_test.go
+++ b/internal/platform/network_test.go
@@ -1,8 +1,10 @@
 package platform
 
 import (
+	"context"
 	"net"
 	"testing"
+	"time"
 )
 
 func TestGetOutboundIP_ReturnsNonLoopback(t *testing.T) {
@@ -31,4 +33,60 @@ func TestGetOutboundIP_Format(t *testing.T) {
 	if parsed == nil {
 		t.Errorf("GetOutboundIP() = %q, not a valid IP address", ip)
 	}
+}
+
+func TestGetOutboundIP_DialError(t *testing.T) {
+	// Replace dialer with one that always fails
+	origDialer := outboundDialer
+	outboundDialer = net.Dialer{Timeout: 1 * time.Nanosecond}
+	defer func() { outboundDialer = origDialer }()
+
+	ip := GetOutboundIP()
+	// With an impossibly short timeout, the dial should fail
+	// and return empty string
+	if ip != "" {
+		t.Errorf("GetOutboundIP() = %q, want empty string on dial error", ip)
+	}
+}
+
+func TestGetOutboundIP_CustomDialer(t *testing.T) {
+	// Test with a real dialer to exercise the success path
+	origDialer := outboundDialer
+	outboundDialer = net.Dialer{Timeout: 2 * time.Second}
+	defer func() { outboundDialer = origDialer }()
+
+	ip := GetOutboundIP()
+	if ip == "" {
+		t.Skip("no outbound IP available in this environment")
+	}
+
+	parsed := net.ParseIP(ip)
+	if parsed == nil {
+		t.Errorf("GetOutboundIP() = %q, not a valid IP address", ip)
+	}
+	if parsed.IsLoopback() {
+		t.Errorf("GetOutboundIP() returned loopback IP %q", ip)
+	}
+}
+
+func TestGetOutboundIP_ContextCanceled(t *testing.T) {
+	// Use a canceled context to force immediate failure
+	origDialer := outboundDialer
+	defer func() { outboundDialer = origDialer }()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel() // cancel immediately
+
+	outboundDialer = net.Dialer{Timeout: 5 * time.Second}
+	conn, err := outboundDialer.DialContext(ctx, "udp", "8.8.8.8:53")
+	if err == nil {
+		conn.Close()
+		// If dial succeeded despite canceled context, skip
+		t.Skip("dial succeeded despite canceled context")
+	}
+	// Verify that our function handles this gracefully
+	ip := GetOutboundIP()
+	// This doesn't test the canceled context path directly,
+	// but verifies the error handling works
+	_ = ip
 }

--- a/internal/platform/network_test.go
+++ b/internal/platform/network_test.go
@@ -1,0 +1,34 @@
+package platform
+
+import (
+	"net"
+	"testing"
+)
+
+func TestGetOutboundIP_ReturnsNonLoopback(t *testing.T) {
+	ip := GetOutboundIP()
+	if ip == "" {
+		// May be empty in isolated environments (no network)
+		t.Log("GetOutboundIP() returned empty string (no outbound route available)")
+		return
+	}
+	parsed := net.ParseIP(ip)
+	if parsed == nil {
+		t.Errorf("GetOutboundIP() returned invalid IP %q", ip)
+	}
+	if parsed.IsLoopback() {
+		t.Errorf("GetOutboundIP() returned loopback IP %q, want non-loopback", ip)
+	}
+}
+
+func TestGetOutboundIP_Format(t *testing.T) {
+	ip := GetOutboundIP()
+	if ip == "" {
+		t.Skip("no outbound IP available in this environment")
+	}
+	// Should be a valid IPv4 or IPv6 address string
+	parsed := net.ParseIP(ip)
+	if parsed == nil {
+		t.Errorf("GetOutboundIP() = %q, not a valid IP address", ip)
+	}
+}

--- a/internal/service/scheduler.go
+++ b/internal/service/scheduler.go
@@ -139,6 +139,13 @@ func (s *Scheduler) TaskSummarizer() *summarize.TaskSummarizer {
 	return s.taskSummarizer
 }
 
+// TaskCount returns the number of registered cron tasks.
+func (s *Scheduler) TaskCount() int {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return len(s.entries)
+}
+
 // UnmarkTaskRunning removes the running flag for a task. Used for testing cleanup.
 func (s *Scheduler) UnmarkTaskRunning(taskID int64) {
 	s.taskRunning.Delete(taskID)

--- a/internal/service/scheduler_test.go
+++ b/internal/service/scheduler_test.go
@@ -137,6 +137,48 @@ func TestNewScheduler(t *testing.T) {
 	assert.NotNil(t, s)
 }
 
+func TestTaskCount_Empty(t *testing.T) {
+	s, cleanup := setupScheduler(t)
+	defer cleanup()
+
+	assert.Equal(t, 0, s.TaskCount())
+}
+
+func TestTaskCount_AfterAddTask(t *testing.T) {
+	s, cleanup := setupScheduler(t)
+	defer cleanup()
+
+	err := s.LoadTasksFromDB("")
+	assert.NoError(t, err)
+
+	task := helperTask()
+	err = s.AddTask(task)
+	assert.NoError(t, err)
+
+	assert.Equal(t, 1, s.TaskCount())
+}
+
+func TestTaskCount_AfterRemoveTask(t *testing.T) {
+	s, cleanup := setupScheduler(t)
+	defer cleanup()
+
+	err := s.LoadTasksFromDB("")
+	assert.NoError(t, err)
+
+	task := helperTask()
+	err = s.AddTask(task)
+	assert.NoError(t, err)
+	assert.Equal(t, 1, s.TaskCount())
+
+	// Get the task ID from DB
+	tasks, err := service.GetTasks("")
+	assert.NoError(t, err)
+	assert.Len(t, tasks, 1)
+
+	s.RemoveTask(tasks[0].ID)
+	assert.Equal(t, 0, s.TaskCount())
+}
+
 // ---------- Start / Stop ----------
 
 func TestSchedulerStartStop(t *testing.T) {

--- a/internal/startup/banner.go
+++ b/internal/startup/banner.go
@@ -1,0 +1,237 @@
+// Package startup renders a structured banner on server ready.
+// All content lines are aligned using fmt %-*s with rune-width awareness
+// so that CJK characters and emojis do not break the box border.
+package startup
+
+import (
+	"fmt"
+	"os"
+	"strings"
+	"time"
+)
+
+// AgentInfo describes one discovered AI agent for the banner.
+type AgentInfo struct {
+	Name   string // human-readable agent name (e.g. "codebuddy")
+	Models int    // number of available models
+}
+
+// BannerConfig holds all data needed to render the startup banner.
+type BannerConfig struct {
+	Version     string
+	Scheme      string // "http" or "https"
+	Port        int
+	LocalIP     string // non-loopback LAN IP; empty = not available
+	AutoPassword string // plaintext auto-generated password; empty = user configured
+	DataDir     string // .clawbench/ absolute path
+	Agents      []AgentInfo
+	SSHEnabled  bool
+	SSHPort     int
+	TTSEngine   string
+	RAGAvailable bool
+	TerminalOn  bool
+	TaskCount   int
+	StartupDuration time.Duration
+}
+
+// ---------------------------------------------------------------------------
+// rune-width helpers (CJK / emoji aware)
+// ---------------------------------------------------------------------------
+
+// runeWidth returns the display width of a string in terminal cells.
+// ASCII = 1 cell, CJK ideographs / Hangul / Kana / emoji = 2 cells.
+func runeWidth(s string) int {
+	w := 0
+	for _, r := range s {
+		w += charWidth(r)
+	}
+	return w
+}
+
+// charWidth returns the display width of a single rune.
+func charWidth(r rune) int {
+	// Quick path for ASCII printable + control
+	if r < 0x1100 {
+		return 1
+	}
+	// Wide ranges: CJK, Hangul, Kana, emoji, full-width forms, etc.
+	switch {
+	case r >= 0x1100 && r <= 0x115F: // Hangul Jamo
+		return 2
+	case r == 0x2329 || r == 0x232A: // Angle brackets
+		return 2
+	case r >= 0x2E80 && r <= 0xA4CF && r != 0x303F: // CJK Radicals..Yi
+		return 2
+	case r >= 0xAC00 && r <= 0xD7A3: // Hangul Syllables
+		return 2
+	case r >= 0xF900 && r <= 0xFAFF: // CJK Compatibility Ideographs
+		return 2
+	case r >= 0xFE10 && r <= 0xFE19: // Vertical forms
+		return 2
+	case r >= 0xFE30 && r <= 0xFE6F: // CJK Compatibility Forms
+		return 2
+	case r >= 0xFF01 && r <= 0xFF60: // Fullwidth forms
+		return 2
+	case r >= 0xFFE0 && r <= 0xFFE6: // Fullwidth signs
+		return 2
+	case r >= 0x1F300 && r <= 0x1FAFF: // Emoji & symbols
+		return 2
+	case r >= 0x20000 && r <= 0x2FFFD: // CJK Extension B..I
+		return 2
+	case r >= 0x30000 && r <= 0x3FFFD: // CJK Extension G..
+		return 2
+	}
+	return 1
+}
+
+// padRight pads s with spaces on the right so that its display width equals width.
+func padRight(s string, width int) string {
+	gap := width - runeWidth(s)
+	if gap <= 0 {
+		return s
+	}
+	return s + strings.Repeat(" ", gap)
+}
+
+// ---------------------------------------------------------------------------
+// banner line builder
+// ---------------------------------------------------------------------------
+
+// buildLines constructs the content lines (without borders).
+// Each line is a plain string; the caller pads them to equal rune-width.
+func buildLines(cfg BannerConfig) []string {
+	var lines []string
+
+	// label formats a label-value pair with emoji and consistent label width.
+	// All labels are padded to the same display width so values align vertically.
+	labelW := 14 // display width: "🌐 Network:" = 2+1+8+1 = 12, "🔐 Password:" = 2+1+9+1 = 13 → 14
+	label := func(prefix, text string) string {
+		return padRight(prefix, labelW) + text
+	}
+
+	// --- Version ---
+	lines = append(lines, fmt.Sprintf("🐾 ClawBench  %s", cfg.Version))
+	lines = append(lines, "")
+
+	// --- URLs ---
+	localURL := fmt.Sprintf("%s://localhost:%d", cfg.Scheme, cfg.Port)
+	lines = append(lines, label("💻 Local:", localURL))
+	if cfg.LocalIP != "" {
+		networkURL := fmt.Sprintf("%s://%s:%d", cfg.Scheme, cfg.LocalIP, cfg.Port)
+		lines = append(lines, label("🌐 Network:", networkURL))
+	}
+
+	// --- Password ---
+	if cfg.AutoPassword != "" {
+		lines = append(lines, label("🔑 Password:", cfg.AutoPassword))
+	} else {
+		lines = append(lines, label("🔐 Auth:", "password configured"))
+	}
+	lines = append(lines, "")
+
+	// --- Agents ---
+	if len(cfg.Agents) == 0 {
+		lines = append(lines, label("🤖 Agents:", "(none — setup wizard will launch)"))
+	} else {
+		lines = append(lines, "🤖 Agents:")
+		// Compute max agent name width for alignment
+		maxNameW := 0
+		for _, a := range cfg.Agents {
+			if rw := runeWidth(a.Name); rw > maxNameW {
+				maxNameW = rw
+			}
+		}
+		for _, a := range cfg.Agents {
+			modelsStr := ""
+			if a.Models == 1 {
+				modelsStr = "1 model"
+			} else {
+				modelsStr = fmt.Sprintf("%d models", a.Models)
+			}
+			lines = append(lines, fmt.Sprintf("  ● %s  %s", padRight(a.Name, maxNameW), modelsStr))
+		}
+	}
+	lines = append(lines, "")
+
+	// --- SSH (conditional) ---
+	if cfg.SSHEnabled {
+		sshCmd := fmt.Sprintf("ssh -p %d clawbench@%s", cfg.SSHPort, firstNonEmpty(cfg.LocalIP, "localhost"))
+		lines = append(lines, label("🔒 SSH:", sshCmd))
+		lines = append(lines, "")
+	}
+
+	// --- Data directory ---
+	lines = append(lines, label("📁 Data:", cfg.DataDir))
+	lines = append(lines, "")
+
+	// --- Service status line ---
+	// Note: use single-codepoint emoji only to avoid combining-sequence width issues.
+	parts := []string{}
+	if cfg.TTSEngine != "" {
+		parts = append(parts, fmt.Sprintf("🔊 TTS: %s", cfg.TTSEngine))
+	}
+	if cfg.RAGAvailable {
+		parts = append(parts, "🔍 RAG ✦")
+	} else {
+		parts = append(parts, "🔍 RAG —")
+	}
+	if cfg.TerminalOn {
+		parts = append(parts, "⌨️ Terminal ✦")
+	} else {
+		parts = append(parts, "⌨️ Terminal —")
+	}
+	parts = append(parts, fmt.Sprintf("📋 Tasks: %d", cfg.TaskCount))
+	lines = append(lines, strings.Join(parts, "  "))
+	lines = append(lines, "")
+
+	// --- Startup duration ---
+	lines = append(lines, fmt.Sprintf("⚡ Ready in %s", formatDuration(cfg.StartupDuration)))
+
+	return lines
+}
+
+// formatDuration returns a human-friendly duration string.
+func formatDuration(d time.Duration) string {
+	if d < time.Microsecond {
+		return fmt.Sprintf("%dns", d.Nanoseconds())
+	}
+	if d < time.Second {
+		return fmt.Sprintf("%.1fms", float64(d.Microseconds())/1000.0)
+	}
+	return fmt.Sprintf("%.1fs", d.Seconds())
+}
+
+// firstNonEmpty returns the first non-empty string argument, or "".
+func firstNonEmpty(ss ...string) string {
+	for _, s := range ss {
+		if s != "" {
+			return s
+		}
+	}
+	return ""
+}
+
+// PrintBanner renders the startup banner to stdout.
+// padRight ensures each line has exactly maxW display cells,
+// so we use plain %s — not fmt's %-*s which pads by byte count
+// and would misalign CJK/emoji content.
+func PrintBanner(cfg BannerConfig) {
+	lines := buildLines(cfg)
+
+	// Compute max display width across all lines
+	maxW := 0
+	for _, l := range lines {
+		if rw := runeWidth(l); rw > maxW {
+			maxW = rw
+		}
+	}
+
+	horiz := strings.Repeat("─", maxW)
+	fmt.Println()
+	fmt.Fprintf(os.Stdout, " ┌%s┐\n", horiz)
+	for _, l := range lines {
+		fmt.Fprintf(os.Stdout, " │ %s │\n", padRight(l, maxW))
+	}
+	fmt.Fprintf(os.Stdout, " └%s┘\n", horiz)
+	fmt.Println()
+}

--- a/internal/startup/banner.go
+++ b/internal/startup/banner.go
@@ -1,10 +1,11 @@
 // Package startup renders a structured banner on server ready.
-// All content lines are aligned using fmt %-*s with rune-width awareness
+// All content lines are aligned using rune-width awareness
 // so that CJK characters and emojis do not break the box border.
 package startup
 
 import (
 	"fmt"
+	"io"
 	"os"
 	"strings"
 	"time"
@@ -18,25 +19,68 @@ type AgentInfo struct {
 
 // BannerConfig holds all data needed to render the startup banner.
 type BannerConfig struct {
-	Version     string
-	Scheme      string // "http" or "https"
-	Port        int
-	LocalIP     string // non-loopback LAN IP; empty = not available
-	AutoPassword string // plaintext auto-generated password; empty = user configured
-	DataDir     string // .clawbench/ absolute path
-	Agents      []AgentInfo
-	SSHEnabled  bool
-	SSHPort     int
-	TTSEngine   string
-	RAGAvailable bool
-	TerminalOn  bool
-	TaskCount   int
+	Version         string
+	Scheme          string // "http" or "https"
+	Port            int
+	LocalIP         string // non-loopback LAN IP; empty = not available
+	AutoPassword    string // plaintext auto-generated password; empty = user configured
+	DataDir         string // .clawbench/ absolute path
+	Agents          []AgentInfo
+	SSHEnabled      bool
+	SSHPort         int
+	TTSEngine       string
+	RAGAvailable    bool
+	TerminalOn      bool
+	TaskCount       int
 	StartupDuration time.Duration
 }
 
 // ---------------------------------------------------------------------------
 // rune-width helpers (CJK / emoji aware)
 // ---------------------------------------------------------------------------
+
+// wideRange defines a Unicode range where all codepoints have display width 2.
+type wideRange struct {
+	lo, hi rune // inclusive range
+}
+
+// wideRanges lists Unicode ranges where characters occupy 2 terminal cells.
+// Ordered by lo for binary search. Covers CJK, Hangul, emoji, fullwidth, etc.
+var wideRanges = []wideRange{
+	{0x1100, 0x115F},   // Hangul Jamo
+	{0x2329, 0x232A},   // Angle brackets
+	{0x2E80, 0xA4CF},   // CJK Radicals..Yi
+	{0xAC00, 0xD7A3},   // Hangul Syllables
+	{0xF900, 0xFAFF},   // CJK Compatibility Ideographs
+	{0xFE10, 0xFE19},   // Vertical forms
+	{0xFE30, 0xFE6F},   // CJK Compatibility Forms
+	{0xFF01, 0xFF60},   // Fullwidth forms
+	{0xFFE0, 0xFFE6},   // Fullwidth signs
+	{0x1F300, 0x1FAFF}, // Emoji & symbols
+	{0x20000, 0x2FFFD}, // CJK Extension B..I
+	{0x30000, 0x3FFFD}, // CJK Extension G..
+}
+
+// excludedCodepoints are codepoints within a wideRange that are actually narrow.
+var excludedCodepoints = map[rune]bool{
+	0x303F: true, // within 0x2E80..0xA4CF but narrow
+}
+
+// charWidth returns the display width of a single rune in terminal cells.
+func charWidth(r rune) int {
+	if r < 0x1100 {
+		return 1
+	}
+	if excludedCodepoints[r] {
+		return 1
+	}
+	for _, wr := range wideRanges {
+		if r >= wr.lo && r <= wr.hi {
+			return 2
+		}
+	}
+	return 1
+}
 
 // runeWidth returns the display width of a string in terminal cells.
 // ASCII = 1 cell, CJK ideographs / Hangul / Kana / emoji = 2 cells.
@@ -46,42 +90,6 @@ func runeWidth(s string) int {
 		w += charWidth(r)
 	}
 	return w
-}
-
-// charWidth returns the display width of a single rune.
-func charWidth(r rune) int {
-	// Quick path for ASCII printable + control
-	if r < 0x1100 {
-		return 1
-	}
-	// Wide ranges: CJK, Hangul, Kana, emoji, full-width forms, etc.
-	switch {
-	case r >= 0x1100 && r <= 0x115F: // Hangul Jamo
-		return 2
-	case r == 0x2329 || r == 0x232A: // Angle brackets
-		return 2
-	case r >= 0x2E80 && r <= 0xA4CF && r != 0x303F: // CJK Radicals..Yi
-		return 2
-	case r >= 0xAC00 && r <= 0xD7A3: // Hangul Syllables
-		return 2
-	case r >= 0xF900 && r <= 0xFAFF: // CJK Compatibility Ideographs
-		return 2
-	case r >= 0xFE10 && r <= 0xFE19: // Vertical forms
-		return 2
-	case r >= 0xFE30 && r <= 0xFE6F: // CJK Compatibility Forms
-		return 2
-	case r >= 0xFF01 && r <= 0xFF60: // Fullwidth forms
-		return 2
-	case r >= 0xFFE0 && r <= 0xFFE6: // Fullwidth signs
-		return 2
-	case r >= 0x1F300 && r <= 0x1FAFF: // Emoji & symbols
-		return 2
-	case r >= 0x20000 && r <= 0x2FFFD: // CJK Extension B..I
-		return 2
-	case r >= 0x30000 && r <= 0x3FFFD: // CJK Extension G..
-		return 2
-	}
-	return 1
 }
 
 // padRight pads s with spaces on the right so that its display width equals width.
@@ -100,18 +108,15 @@ func padRight(s string, width int) string {
 // buildLines constructs the content lines (without borders).
 // Each line is a plain string; the caller pads them to equal rune-width.
 func buildLines(cfg BannerConfig) []string {
-	var lines []string
-
-	// label formats a label-value pair with emoji and consistent label width.
-	// All labels are padded to the same display width so values align vertically.
-	labelW := 14 // display width: "🌐 Network:" = 2+1+8+1 = 12, "🔐 Password:" = 2+1+9+1 = 13 → 14
+	labelW := 14 // display width for label alignment
 	label := func(prefix, text string) string {
 		return padRight(prefix, labelW) + text
 	}
 
-	// --- Version ---
-	lines = append(lines, fmt.Sprintf("🐾 ClawBench  %s", cfg.Version))
-	lines = append(lines, "")
+	lines := []string{
+		fmt.Sprintf("🐾 ClawBench  %s", cfg.Version),
+		"",
+	}
 
 	// --- URLs ---
 	localURL := fmt.Sprintf("%s://localhost:%d", cfg.Scheme, cfg.Port)
@@ -134,7 +139,6 @@ func buildLines(cfg BannerConfig) []string {
 		lines = append(lines, label("🤖 Agents:", "(none — setup wizard will launch)"))
 	} else {
 		lines = append(lines, "🤖 Agents:")
-		// Compute max agent name width for alignment
 		maxNameW := 0
 		for _, a := range cfg.Agents {
 			if rw := runeWidth(a.Name); rw > maxNameW {
@@ -142,10 +146,8 @@ func buildLines(cfg BannerConfig) []string {
 			}
 		}
 		for _, a := range cfg.Agents {
-			modelsStr := ""
-			if a.Models == 1 {
-				modelsStr = "1 model"
-			} else {
+			modelsStr := "1 model"
+			if a.Models != 1 {
 				modelsStr = fmt.Sprintf("%d models", a.Models)
 			}
 			lines = append(lines, fmt.Sprintf("  ● %s  %s", padRight(a.Name, maxNameW), modelsStr))
@@ -156,13 +158,11 @@ func buildLines(cfg BannerConfig) []string {
 	// --- SSH (conditional) ---
 	if cfg.SSHEnabled {
 		sshCmd := fmt.Sprintf("ssh -p %d clawbench@%s", cfg.SSHPort, firstNonEmpty(cfg.LocalIP, "localhost"))
-		lines = append(lines, label("🔒 SSH:", sshCmd))
-		lines = append(lines, "")
+		lines = append(lines, label("🔒 SSH:", sshCmd), "")
 	}
 
 	// --- Data directory ---
-	lines = append(lines, label("📁 Data:", cfg.DataDir))
-	lines = append(lines, "")
+	lines = append(lines, label("📁 Data:", cfg.DataDir), "")
 
 	// --- Service status line ---
 	// Note: use single-codepoint emoji only to avoid combining-sequence width issues.
@@ -181,8 +181,7 @@ func buildLines(cfg BannerConfig) []string {
 		parts = append(parts, "⌨️ Terminal —")
 	}
 	parts = append(parts, fmt.Sprintf("📋 Tasks: %d", cfg.TaskCount))
-	lines = append(lines, strings.Join(parts, "  "))
-	lines = append(lines, "")
+	lines = append(lines, strings.Join(parts, "  "), "")
 
 	// --- Startup duration ---
 	lines = append(lines, fmt.Sprintf("⚡ Ready in %s", formatDuration(cfg.StartupDuration)))
@@ -216,6 +215,11 @@ func firstNonEmpty(ss ...string) string {
 // so we use plain %s — not fmt's %-*s which pads by byte count
 // and would misalign CJK/emoji content.
 func PrintBanner(cfg BannerConfig) {
+	FprintBanner(os.Stdout, cfg)
+}
+
+// FprintBanner renders the startup banner to w.
+func FprintBanner(w io.Writer, cfg BannerConfig) {
 	lines := buildLines(cfg)
 
 	// Compute max display width across all lines
@@ -227,11 +231,11 @@ func PrintBanner(cfg BannerConfig) {
 	}
 
 	horiz := strings.Repeat("─", maxW)
-	fmt.Println()
-	fmt.Fprintf(os.Stdout, " ┌%s┐\n", horiz)
+	_, _ = fmt.Fprintln(w)
+	_, _ = fmt.Fprintf(w, " ┌%s┐\n", horiz)
 	for _, l := range lines {
-		fmt.Fprintf(os.Stdout, " │ %s │\n", padRight(l, maxW))
+		_, _ = fmt.Fprintf(w, " │ %s │\n", padRight(l, maxW))
 	}
-	fmt.Fprintf(os.Stdout, " └%s┘\n", horiz)
-	fmt.Println()
+	_, _ = fmt.Fprintf(w, " └%s┘\n", horiz)
+	_, _ = fmt.Fprintln(w)
 }

--- a/internal/startup/banner_test.go
+++ b/internal/startup/banner_test.go
@@ -1,0 +1,414 @@
+package startup
+
+import (
+	"strings"
+	"testing"
+	"time"
+)
+
+// ---------- runeWidth tests ----------
+
+func TestRuneWidth_ASCII(t *testing.T) {
+	got := runeWidth("hello")
+	if got != 5 {
+		t.Errorf("runeWidth(%q) = %d, want 5", "hello", got)
+	}
+}
+
+func TestRuneWidth_CJK(t *testing.T) {
+	// Each CJK character is 2 cells wide
+	got := runeWidth("中文")
+	if got != 4 {
+		t.Errorf("runeWidth(%q) = %d, want 4", "中文", got)
+	}
+}
+
+func TestRuneWidth_Mixed(t *testing.T) {
+	// "🐾" = 2, " hello" = 6
+	got := runeWidth("🐾 hello")
+	if got != 8 {
+		t.Errorf("runeWidth(%q) = %d, want 8", "🐾 hello", got)
+	}
+}
+
+func TestRuneWidth_Emoji(t *testing.T) {
+	got := runeWidth("🎉")
+	if got != 2 {
+		t.Errorf("runeWidth(%q) = %d, want 2", "🎉", got)
+	}
+}
+
+func TestRuneWidth_Fullwidth(t *testing.T) {
+	// Fullwidth Latin letter Ａ = U+FF21, width 2
+	got := runeWidth("Ａ")
+	if got != 2 {
+		t.Errorf("runeWidth(%q) = %d, want 2", "Ａ", got)
+	}
+}
+
+// ---------- padRight tests ----------
+
+func TestPadRight_ASCII(t *testing.T) {
+	got := padRight("hi", 5)
+	if got != "hi   " {
+		t.Errorf("padRight(%q, 5) = %q, want %q", "hi", got, "hi   ")
+	}
+}
+
+func TestPadRight_CJK(t *testing.T) {
+	// "中文" has runeWidth 4, pad to 6 => 2 spaces
+	got := padRight("中文", 6)
+	if got != "中文  " {
+		t.Errorf("padRight(%q, 6) = %q, want %q", "中文", got, "中文  ")
+	}
+}
+
+func TestPadRight_NoPadNeeded(t *testing.T) {
+	got := padRight("hello", 3)
+	if got != "hello" {
+		t.Errorf("padRight(%q, 3) = %q, want %q", "hello", got, "hello")
+	}
+}
+
+// ---------- buildLines border alignment tests ----------
+
+// verifyBorderAlignment checks that all lines in the banner output
+// have consistent border alignment by verifying equal rune-width.
+func verifyBorderAlignment(t *testing.T, lines []string) {
+	t.Helper()
+	maxW := 0
+	for _, l := range lines {
+		if rw := runeWidth(l); rw > maxW {
+			maxW = rw
+		}
+	}
+	for i, l := range lines {
+		if rw := runeWidth(l); rw != maxW {
+			t.Errorf("line %d runeWidth=%d, want %d: %q", i, rw, maxW, l)
+		}
+	}
+}
+
+func TestBannerBasic(t *testing.T) {
+	cfg := BannerConfig{
+		Version:     "v1.0.0",
+		Scheme:      "http",
+		Port:        20000,
+		LocalIP:     "192.168.1.100",
+		AutoPassword: "a1b2c3d4",
+		DataDir:     "/home/user/clawbench/.clawbench",
+		Agents: []AgentInfo{
+			{Name: "codebuddy", Models: 21},
+			{Name: "pi", Models: 8},
+			{Name: "gemini", Models: 5},
+		},
+		SSHEnabled:    true,
+		SSHPort:       20001,
+		TTSEngine:     "edge",
+		RAGAvailable:  true,
+		TerminalOn:    true,
+		TaskCount:     3,
+		StartupDuration: 1200 * time.Millisecond,
+	}
+	lines := buildLines(cfg)
+
+	// Verify all lines have equal display width
+	padded := make([]string, len(lines))
+	maxW := 0
+	for _, l := range lines {
+		if rw := runeWidth(l); rw > maxW {
+			maxW = rw
+		}
+	}
+	for i, l := range lines {
+		padded[i] = padRight(l, maxW)
+		if rw := runeWidth(padded[i]); rw != maxW {
+			t.Errorf("padded line %d runeWidth=%d, want %d: %q", i, rw, maxW, padded[i])
+		}
+	}
+
+	// Verify key content
+	joined := strings.Join(lines, "\n")
+	if !strings.Contains(joined, "v1.0.0") {
+		t.Error("banner should contain version")
+	}
+	if !strings.Contains(joined, "http://localhost:20000") {
+		t.Error("banner should contain local URL")
+	}
+	if !strings.Contains(joined, "http://192.168.1.100:20000") {
+		t.Error("banner should contain network URL")
+	}
+	if !strings.Contains(joined, "a1b2c3d4") {
+		t.Error("banner should contain auto-password")
+	}
+	if !strings.Contains(joined, "codebuddy") {
+		t.Error("banner should contain agent name")
+	}
+	if !strings.Contains(joined, "21 models") {
+		t.Error("banner should contain model count")
+	}
+	if !strings.Contains(joined, "ssh -p 20001") {
+		t.Error("banner should contain SSH command")
+	}
+	if !strings.Contains(joined, "RAG ✦") {
+		t.Error("banner should show RAG available")
+	}
+	if !strings.Contains(joined, "Tasks: 3") {
+		t.Error("banner should show task count")
+	}
+	if !strings.Contains(joined, "1.2s") {
+		t.Error("banner should show startup duration")
+	}
+}
+
+func TestBannerNoAgents(t *testing.T) {
+	cfg := BannerConfig{
+		Version:     "dev",
+		Scheme:      "http",
+		Port:        20000,
+		AutoPassword: "abcdefgh",
+		DataDir:     "/tmp/.clawbench",
+		Agents:      nil,
+		TTSEngine:   "edge",
+		TaskCount:   0,
+		StartupDuration: 300 * time.Millisecond,
+	}
+	lines := buildLines(cfg)
+	joined := strings.Join(lines, "\n")
+
+	if !strings.Contains(joined, "setup wizard") {
+		t.Error("banner should mention setup wizard when no agents")
+	}
+
+	// Verify alignment
+	maxW := 0
+	for _, l := range lines {
+		if rw := runeWidth(l); rw > maxW {
+			maxW = rw
+		}
+	}
+	for i, l := range lines {
+		padded := padRight(l, maxW)
+		if rw := runeWidth(padded); rw != maxW {
+			t.Errorf("padded line %d runeWidth=%d, want %d: %q", i, rw, maxW, padded)
+		}
+	}
+}
+
+func TestBannerCJKWidth(t *testing.T) {
+	cfg := BannerConfig{
+		Version:     "v1.0.0",
+		Scheme:      "http",
+		Port:        20000,
+		LocalIP:     "192.168.1.100",
+		AutoPassword: "测试密码", // CJK password (unlikely but tests alignment)
+		DataDir:     "/home/用户/.clawbench", // CJK path
+		Agents: []AgentInfo{
+			{Name: "智能体", Models: 5}, // CJK name
+		},
+		TTSEngine:      "edge",
+		RAGAvailable:   true,
+		TerminalOn:     true,
+		TaskCount:      0,
+		StartupDuration: 500 * time.Millisecond,
+	}
+	lines := buildLines(cfg)
+
+	// All padded lines must have equal rune width
+	maxW := 0
+	for _, l := range lines {
+		if rw := runeWidth(l); rw > maxW {
+			maxW = rw
+		}
+	}
+	for i, l := range lines {
+		padded := padRight(l, maxW)
+		if rw := runeWidth(padded); rw != maxW {
+			t.Errorf("CJK: padded line %d runeWidth=%d, want %d: %q", i, rw, maxW, padded)
+		}
+	}
+}
+
+func TestBannerNoSSH(t *testing.T) {
+	cfg := BannerConfig{
+		Version:     "v1.0.0",
+		Scheme:      "https",
+		Port:        20000,
+		AutoPassword: "",
+		DataDir:     "/opt/clawbench/.clawbench",
+		Agents: []AgentInfo{
+			{Name: "claude", Models: 12},
+		},
+		SSHEnabled:     false,
+		TTSEngine:      "edge",
+		RAGAvailable:   false,
+		TerminalOn:     true,
+		TaskCount:      0,
+		StartupDuration: 800 * time.Millisecond,
+	}
+	lines := buildLines(cfg)
+	joined := strings.Join(lines, "\n")
+
+	if strings.Contains(joined, "ssh") {
+		t.Error("banner should NOT contain SSH info when disabled")
+	}
+	if !strings.Contains(joined, "https://localhost:20000") {
+		t.Error("banner should use https scheme")
+	}
+	if !strings.Contains(joined, "password configured") {
+		t.Error("banner should show 'password configured' when no auto-password")
+	}
+	if !strings.Contains(joined, "RAG —") {
+		t.Error("banner should show RAG unavailable")
+	}
+}
+
+func TestBannerAgentNameAlignment(t *testing.T) {
+	cfg := BannerConfig{
+		Version:     "v1.0.0",
+		Scheme:      "http",
+		Port:        20000,
+		AutoPassword: "test",
+		DataDir:     "/tmp/.clawbench",
+		Agents: []AgentInfo{
+			{Name: "pi", Models: 8},
+			{Name: "codebuddy", Models: 21},
+			{Name: "deepseek-tui", Models: 3},
+		},
+		TTSEngine:      "edge",
+		RAGAvailable:   true,
+		TerminalOn:     true,
+		TaskCount:      0,
+		StartupDuration: 100 * time.Millisecond,
+	}
+	lines := buildLines(cfg)
+
+	// Find agent lines and verify the "● name" part has the same display width
+	var agentLines []string
+	for _, l := range lines {
+		if strings.HasPrefix(l, "  ● ") {
+			agentLines = append(agentLines, l)
+		}
+	}
+	if len(agentLines) != 3 {
+		t.Fatalf("expected 3 agent lines, got %d", len(agentLines))
+	}
+
+	// Extract the "● name" portion (up to the double-space before model count)
+	widths := make([]int, len(agentLines))
+	for i, l := range agentLines {
+		// The format is "  ● name  N models" — double space separates name from count
+		// Find the double-space gap after the padded name
+		doubleSpIdx := strings.Index(l, "  ")
+		if doubleSpIdx < 0 {
+			// Single-word agent with no padding? The "  " separates name from "N models"
+			t.Fatalf("agent line %d has no double-space separator: %q", i, l)
+		}
+		prefix := l[:doubleSpIdx]
+		widths[i] = runeWidth(prefix)
+	}
+
+	for i, w := range widths {
+		if w != widths[0] {
+			t.Errorf("agent line %d prefix width=%d, want %d: %q", i, w, widths[0], agentLines[i])
+		}
+	}
+}
+
+func TestFormatDuration(t *testing.T) {
+	tests := []struct {
+		d    time.Duration
+		want string
+	}{
+		{100 * time.Nanosecond, "100ns"},
+		{500 * time.Microsecond, "0.5ms"},
+		{1500 * time.Millisecond, "1.5s"},
+		{2 * time.Second, "2.0s"},
+	}
+	for _, tt := range tests {
+		got := formatDuration(tt.d)
+		if got != tt.want {
+			t.Errorf("formatDuration(%v) = %q, want %q", tt.d, got, tt.want)
+		}
+	}
+}
+
+func TestPrintBannerDoesNotPanic(t *testing.T) {
+	// Just verify PrintBanner doesn't panic with various configs
+	cfg := BannerConfig{
+		Version:     "dev",
+		Scheme:      "http",
+		Port:        20000,
+		AutoPassword: "test1234",
+		DataDir:     "/tmp/.clawbench",
+		Agents:      []AgentInfo{{Name: "codebuddy", Models: 5}},
+		TTSEngine:   "edge",
+		TaskCount:   1,
+		StartupDuration: 100 * time.Millisecond,
+	}
+	// Output goes to stdout; we just verify no panic
+	PrintBanner(cfg)
+}
+
+func TestPrintBannerEmptyConfig(t *testing.T) {
+	// Minimal config — no agents, no SSH, no password
+	cfg := BannerConfig{
+		Version:     "dev",
+		Scheme:      "http",
+		Port:        20000,
+		DataDir:     "/tmp/.clawbench",
+		TTSEngine:   "edge",
+		TaskCount:   0,
+		StartupDuration: 50 * time.Millisecond,
+	}
+	PrintBanner(cfg)
+}
+
+func TestBannerBorderAlignmentWithCJK(t *testing.T) {
+	// Verify that the actual rendered output has consistent border alignment
+	// even with CJK/emoji content. We simulate the PrintBanner rendering
+	// and verify all lines have equal display width.
+	cfg := BannerConfig{
+		Version:     "v1.0.0",
+		Scheme:      "http",
+		Port:        20000,
+		LocalIP:     "192.168.1.100",
+		AutoPassword: "测试密码", // CJK
+		DataDir:     "/home/用户/.clawbench", // CJK
+		Agents: []AgentInfo{
+			{Name: "智能体", Models: 5}, // CJK
+			{Name: "codebuddy", Models: 21},
+		},
+		SSHEnabled:     true,
+		SSHPort:        20001,
+		TTSEngine:      "edge",
+		RAGAvailable:   true,
+		TerminalOn:     true,
+		TaskCount:      3,
+		StartupDuration: 1 * time.Second,
+	}
+
+	lines := buildLines(cfg)
+
+	// Compute max display width
+	maxW := 0
+	for _, l := range lines {
+		if rw := runeWidth(l); rw > maxW {
+			maxW = rw
+		}
+	}
+
+	// Verify every padded line has exactly maxW display width
+	for i, l := range lines {
+		padded := padRight(l, maxW)
+		if rw := runeWidth(padded); rw != maxW {
+			t.Errorf("CJK border: line %d padded runeWidth=%d, want %d: %q", i, rw, maxW, padded)
+		}
+	}
+
+	// Also verify the border horizontal line is correct width
+	horiz := strings.Repeat("─", maxW)
+	if runeWidth(horiz) != maxW {
+		t.Errorf("horizontal border runeWidth=%d, want %d", runeWidth(horiz), maxW)
+	}
+}

--- a/internal/startup/banner_test.go
+++ b/internal/startup/banner_test.go
@@ -72,42 +72,25 @@ func TestPadRight_NoPadNeeded(t *testing.T) {
 
 // ---------- buildLines border alignment tests ----------
 
-// verifyBorderAlignment checks that all lines in the banner output
-// have consistent border alignment by verifying equal rune-width.
-func verifyBorderAlignment(t *testing.T, lines []string) {
-	t.Helper()
-	maxW := 0
-	for _, l := range lines {
-		if rw := runeWidth(l); rw > maxW {
-			maxW = rw
-		}
-	}
-	for i, l := range lines {
-		if rw := runeWidth(l); rw != maxW {
-			t.Errorf("line %d runeWidth=%d, want %d: %q", i, rw, maxW, l)
-		}
-	}
-}
-
 func TestBannerBasic(t *testing.T) {
 	cfg := BannerConfig{
-		Version:     "v1.0.0",
-		Scheme:      "http",
-		Port:        20000,
-		LocalIP:     "192.168.1.100",
+		Version:      "v1.0.0",
+		Scheme:       "http",
+		Port:         20000,
+		LocalIP:      "192.168.1.100",
 		AutoPassword: "a1b2c3d4",
-		DataDir:     "/home/user/clawbench/.clawbench",
+		DataDir:      "/home/user/clawbench/.clawbench",
 		Agents: []AgentInfo{
 			{Name: "codebuddy", Models: 21},
 			{Name: "pi", Models: 8},
 			{Name: "gemini", Models: 5},
 		},
-		SSHEnabled:    true,
-		SSHPort:       20001,
-		TTSEngine:     "edge",
-		RAGAvailable:  true,
-		TerminalOn:    true,
-		TaskCount:     3,
+		SSHEnabled:      true,
+		SSHPort:         20001,
+		TTSEngine:       "edge",
+		RAGAvailable:    true,
+		TerminalOn:      true,
+		TaskCount:       3,
 		StartupDuration: 1200 * time.Millisecond,
 	}
 	lines := buildLines(cfg)
@@ -163,14 +146,14 @@ func TestBannerBasic(t *testing.T) {
 
 func TestBannerNoAgents(t *testing.T) {
 	cfg := BannerConfig{
-		Version:     "dev",
-		Scheme:      "http",
-		Port:        20000,
-		AutoPassword: "abcdefgh",
-		DataDir:     "/tmp/.clawbench",
-		Agents:      nil,
-		TTSEngine:   "edge",
-		TaskCount:   0,
+		Version:         "dev",
+		Scheme:          "http",
+		Port:            20000,
+		AutoPassword:    "abcdefgh",
+		DataDir:         "/tmp/.clawbench",
+		Agents:          nil,
+		TTSEngine:       "edge",
+		TaskCount:       0,
 		StartupDuration: 300 * time.Millisecond,
 	}
 	lines := buildLines(cfg)
@@ -197,19 +180,19 @@ func TestBannerNoAgents(t *testing.T) {
 
 func TestBannerCJKWidth(t *testing.T) {
 	cfg := BannerConfig{
-		Version:     "v1.0.0",
-		Scheme:      "http",
-		Port:        20000,
-		LocalIP:     "192.168.1.100",
-		AutoPassword: "测试密码", // CJK password (unlikely but tests alignment)
-		DataDir:     "/home/用户/.clawbench", // CJK path
+		Version:      "v1.0.0",
+		Scheme:       "http",
+		Port:         20000,
+		LocalIP:      "192.168.1.100",
+		AutoPassword: "测试密码",                // CJK password (unlikely but tests alignment)
+		DataDir:      "/home/用户/.clawbench", // CJK path
 		Agents: []AgentInfo{
 			{Name: "智能体", Models: 5}, // CJK name
 		},
-		TTSEngine:      "edge",
-		RAGAvailable:   true,
-		TerminalOn:     true,
-		TaskCount:      0,
+		TTSEngine:       "edge",
+		RAGAvailable:    true,
+		TerminalOn:      true,
+		TaskCount:       0,
 		StartupDuration: 500 * time.Millisecond,
 	}
 	lines := buildLines(cfg)
@@ -231,19 +214,19 @@ func TestBannerCJKWidth(t *testing.T) {
 
 func TestBannerNoSSH(t *testing.T) {
 	cfg := BannerConfig{
-		Version:     "v1.0.0",
-		Scheme:      "https",
-		Port:        20000,
+		Version:      "v1.0.0",
+		Scheme:       "https",
+		Port:         20000,
 		AutoPassword: "",
-		DataDir:     "/opt/clawbench/.clawbench",
+		DataDir:      "/opt/clawbench/.clawbench",
 		Agents: []AgentInfo{
 			{Name: "claude", Models: 12},
 		},
-		SSHEnabled:     false,
-		TTSEngine:      "edge",
-		RAGAvailable:   false,
-		TerminalOn:     true,
-		TaskCount:      0,
+		SSHEnabled:      false,
+		TTSEngine:       "edge",
+		RAGAvailable:    false,
+		TerminalOn:      true,
+		TaskCount:       0,
 		StartupDuration: 800 * time.Millisecond,
 	}
 	lines := buildLines(cfg)
@@ -265,20 +248,20 @@ func TestBannerNoSSH(t *testing.T) {
 
 func TestBannerAgentNameAlignment(t *testing.T) {
 	cfg := BannerConfig{
-		Version:     "v1.0.0",
-		Scheme:      "http",
-		Port:        20000,
+		Version:      "v1.0.0",
+		Scheme:       "http",
+		Port:         20000,
 		AutoPassword: "test",
-		DataDir:     "/tmp/.clawbench",
+		DataDir:      "/tmp/.clawbench",
 		Agents: []AgentInfo{
 			{Name: "pi", Models: 8},
 			{Name: "codebuddy", Models: 21},
 			{Name: "deepseek-tui", Models: 3},
 		},
-		TTSEngine:      "edge",
-		RAGAvailable:   true,
-		TerminalOn:     true,
-		TaskCount:      0,
+		TTSEngine:       "edge",
+		RAGAvailable:    true,
+		TerminalOn:      true,
+		TaskCount:       0,
 		StartupDuration: 100 * time.Millisecond,
 	}
 	lines := buildLines(cfg)
@@ -336,14 +319,14 @@ func TestFormatDuration(t *testing.T) {
 func TestPrintBannerDoesNotPanic(t *testing.T) {
 	// Just verify PrintBanner doesn't panic with various configs
 	cfg := BannerConfig{
-		Version:     "dev",
-		Scheme:      "http",
-		Port:        20000,
-		AutoPassword: "test1234",
-		DataDir:     "/tmp/.clawbench",
-		Agents:      []AgentInfo{{Name: "codebuddy", Models: 5}},
-		TTSEngine:   "edge",
-		TaskCount:   1,
+		Version:         "dev",
+		Scheme:          "http",
+		Port:            20000,
+		AutoPassword:    "test1234",
+		DataDir:         "/tmp/.clawbench",
+		Agents:          []AgentInfo{{Name: "codebuddy", Models: 5}},
+		TTSEngine:       "edge",
+		TaskCount:       1,
 		StartupDuration: 100 * time.Millisecond,
 	}
 	// Output goes to stdout; we just verify no panic
@@ -353,12 +336,12 @@ func TestPrintBannerDoesNotPanic(t *testing.T) {
 func TestPrintBannerEmptyConfig(t *testing.T) {
 	// Minimal config — no agents, no SSH, no password
 	cfg := BannerConfig{
-		Version:     "dev",
-		Scheme:      "http",
-		Port:        20000,
-		DataDir:     "/tmp/.clawbench",
-		TTSEngine:   "edge",
-		TaskCount:   0,
+		Version:         "dev",
+		Scheme:          "http",
+		Port:            20000,
+		DataDir:         "/tmp/.clawbench",
+		TTSEngine:       "edge",
+		TaskCount:       0,
 		StartupDuration: 50 * time.Millisecond,
 	}
 	PrintBanner(cfg)
@@ -369,22 +352,22 @@ func TestBannerBorderAlignmentWithCJK(t *testing.T) {
 	// even with CJK/emoji content. We simulate the PrintBanner rendering
 	// and verify all lines have equal display width.
 	cfg := BannerConfig{
-		Version:     "v1.0.0",
-		Scheme:      "http",
-		Port:        20000,
-		LocalIP:     "192.168.1.100",
-		AutoPassword: "测试密码", // CJK
-		DataDir:     "/home/用户/.clawbench", // CJK
+		Version:      "v1.0.0",
+		Scheme:       "http",
+		Port:         20000,
+		LocalIP:      "192.168.1.100",
+		AutoPassword: "测试密码",                // CJK
+		DataDir:      "/home/用户/.clawbench", // CJK
 		Agents: []AgentInfo{
 			{Name: "智能体", Models: 5}, // CJK
 			{Name: "codebuddy", Models: 21},
 		},
-		SSHEnabled:     true,
-		SSHPort:        20001,
-		TTSEngine:      "edge",
-		RAGAvailable:   true,
-		TerminalOn:     true,
-		TaskCount:      3,
+		SSHEnabled:      true,
+		SSHPort:         20001,
+		TTSEngine:       "edge",
+		RAGAvailable:    true,
+		TerminalOn:      true,
+		TaskCount:       3,
 		StartupDuration: 1 * time.Second,
 	}
 

--- a/internal/version/version.go
+++ b/internal/version/version.go
@@ -6,13 +6,17 @@ import "runtime/debug"
 // When not set (e.g. bare "go build"), Get() falls back to VCS info.
 var Version = ""
 
+// readBuildInfo is a variable for testability — tests can override it
+// to simulate different build info scenarios.
+var readBuildInfo = debug.ReadBuildInfo
+
 // Get returns a human-readable version string.
 // Priority: ldflags-injected Version > VCS short SHA from build info > "dev".
 func Get() string {
 	if Version != "" {
 		return Version
 	}
-	info, ok := debug.ReadBuildInfo()
+	info, ok := readBuildInfo()
 	if !ok {
 		return "dev"
 	}

--- a/internal/version/version.go
+++ b/internal/version/version.go
@@ -1,5 +1,28 @@
 package version
 
+import "runtime/debug"
+
 // Version is set at build time via -ldflags "-X clawbench/internal/version.Version=...".
-// When not set (e.g. bare "go build"), getBuildVersion() falls back to VCS info.
+// When not set (e.g. bare "go build"), Get() falls back to VCS info.
 var Version = ""
+
+// Get returns a human-readable version string.
+// Priority: ldflags-injected Version > VCS short SHA from build info > "dev".
+func Get() string {
+	if Version != "" {
+		return Version
+	}
+	info, ok := debug.ReadBuildInfo()
+	if !ok {
+		return "dev"
+	}
+	for _, s := range info.Settings {
+		if s.Key == "vcs.revision" && len(s.Value) >= 7 {
+			return s.Value[:7]
+		}
+	}
+	if info.Main.Version != "" && info.Main.Version != "(devel)" {
+		return info.Main.Version
+	}
+	return "dev"
+}

--- a/internal/version/version_test.go
+++ b/internal/version/version_test.go
@@ -32,6 +32,16 @@ func TestGet_ReturnsVersionWhenSet(t *testing.T) {
 	}
 }
 
+func TestGet_PriorityOverVCS(t *testing.T) {
+	original := Version
+	defer func() { Version = original }()
+
+	Version = "v3.0.0-beta"
+	if got := Get(); got != "v3.0.0-beta" {
+		t.Errorf("Get() = %q, want %q (ldflags should take priority)", got, "v3.0.0-beta")
+	}
+}
+
 func TestGet_FallsBackToVCS(t *testing.T) {
 	original := Version
 	defer func() { Version = original }()
@@ -44,50 +54,129 @@ func TestGet_FallsBackToVCS(t *testing.T) {
 	}
 }
 
-func TestGet_FallsBackToMainVersion(t *testing.T) {
-	// When Version is empty and there's no VCS info but Main.Version is set,
-	// Get() should return info.Main.Version.
-	// In practice this branch is hard to trigger in a real git checkout
-	// because VCS info is always present. We verify the logic path by
-	// confirming the function doesn't panic and returns a non-empty string.
+func TestGet_ReadBuildInfoFails(t *testing.T) {
 	original := Version
-	defer func() { Version = original }()
+	origReadBuildInfo := readBuildInfo
+	defer func() {
+		Version = original
+		readBuildInfo = origReadBuildInfo
+	}()
 
 	Version = ""
+	readBuildInfo = func() (*debug.BuildInfo, bool) {
+		return nil, false
+	}
+
 	got := Get()
-	if got == "" {
-		t.Error("Get() returned empty string")
-	}
-
-	// Verify the result comes from one of the expected sources
-	if _, ok := debug.ReadBuildInfo(); !ok {
-		// No build info at all — should return "dev"
-		if got != "dev" {
-			t.Errorf("Get() = %q without build info, want %q", got, "dev")
-		}
+	if got != "dev" {
+		t.Errorf("Get() = %q when ReadBuildInfo fails, want %q", got, "dev")
 	}
 }
 
-func TestGet_EmptyVersionString(t *testing.T) {
+func TestGet_VCSRevisionFound(t *testing.T) {
 	original := Version
-	defer func() { Version = original }()
+	origReadBuildInfo := readBuildInfo
+	defer func() {
+		Version = original
+		readBuildInfo = origReadBuildInfo
+	}()
 
 	Version = ""
-	result := Get()
+	readBuildInfo = func() (*debug.BuildInfo, bool) {
+		return &debug.BuildInfo{
+			Settings: []debug.BuildSetting{
+				{Key: "vcs.revision", Value: "abc1234def5678"},
+			},
+		}, true
+	}
 
-	// Result must be one of: VCS short SHA, Main.Version, or "dev"
-	if result == "" {
-		t.Error("Get() should never return empty string")
+	got := Get()
+	if got != "abc1234" {
+		t.Errorf("Get() = %q, want %q", got, "abc1234")
 	}
 }
 
-func TestGet_PriorityOverVCS(t *testing.T) {
-	// When Version is set via ldflags, it should take priority over VCS fallback
+func TestGet_VCSRevisionTooShort(t *testing.T) {
 	original := Version
-	defer func() { Version = original }()
+	origReadBuildInfo := readBuildInfo
+	defer func() {
+		Version = original
+		readBuildInfo = origReadBuildInfo
+	}()
 
-	Version = "v3.0.0-beta"
-	if got := Get(); got != "v3.0.0-beta" {
-		t.Errorf("Get() = %q, want %q (ldflags should take priority)", got, "v3.0.0-beta")
+	Version = ""
+	readBuildInfo = func() (*debug.BuildInfo, bool) {
+		return &debug.BuildInfo{
+			Settings: []debug.BuildSetting{
+				{Key: "vcs.revision", Value: "abc"}, // too short
+			},
+			Main: debug.Module{Version: "v0.0.1"},
+		}, true
+	}
+
+	got := Get()
+	if got != "v0.0.1" {
+		t.Errorf("Get() = %q, want %q (should fall back to Main.Version)", got, "v0.0.1")
+	}
+}
+
+func TestGet_MainVersionDevel(t *testing.T) {
+	original := Version
+	origReadBuildInfo := readBuildInfo
+	defer func() {
+		Version = original
+		readBuildInfo = origReadBuildInfo
+	}()
+
+	Version = ""
+	readBuildInfo = func() (*debug.BuildInfo, bool) {
+		return &debug.BuildInfo{
+			Main: debug.Module{Version: "(devel)"},
+		}, true
+	}
+
+	got := Get()
+	if got != "dev" {
+		t.Errorf("Get() = %q when Main.Version is (devel), want %q", got, "dev")
+	}
+}
+
+func TestGet_NoVCSNoMainVersion(t *testing.T) {
+	original := Version
+	origReadBuildInfo := readBuildInfo
+	defer func() {
+		Version = original
+		readBuildInfo = origReadBuildInfo
+	}()
+
+	Version = ""
+	readBuildInfo = func() (*debug.BuildInfo, bool) {
+		return &debug.BuildInfo{}, true
+	}
+
+	got := Get()
+	if got != "dev" {
+		t.Errorf("Get() = %q when no VCS or Main.Version, want %q", got, "dev")
+	}
+}
+
+func TestGet_MainVersionSet(t *testing.T) {
+	original := Version
+	origReadBuildInfo := readBuildInfo
+	defer func() {
+		Version = original
+		readBuildInfo = origReadBuildInfo
+	}()
+
+	Version = ""
+	readBuildInfo = func() (*debug.BuildInfo, bool) {
+		return &debug.BuildInfo{
+			Main: debug.Module{Version: "v1.2.3"},
+		}, true
+	}
+
+	got := Get()
+	if got != "v1.2.3" {
+		t.Errorf("Get() = %q, want %q", got, "v1.2.3")
 	}
 }

--- a/internal/version/version_test.go
+++ b/internal/version/version_test.go
@@ -1,6 +1,9 @@
 package version
 
-import "testing"
+import (
+	"runtime/debug"
+	"testing"
+)
 
 func TestVersionDefault(t *testing.T) {
 	// Default value should be empty string (not set by ldflags)
@@ -16,5 +19,75 @@ func TestVersionCanBeSet(t *testing.T) {
 	Version = "v1.0.0"
 	if Version != "v1.0.0" {
 		t.Errorf("expected Version to be %q, got %q", "v1.0.0", Version)
+	}
+}
+
+func TestGet_ReturnsVersionWhenSet(t *testing.T) {
+	original := Version
+	defer func() { Version = original }()
+
+	Version = "v2.0.0"
+	if got := Get(); got != "v2.0.0" {
+		t.Errorf("Get() = %q, want %q", got, "v2.0.0")
+	}
+}
+
+func TestGet_FallsBackToVCS(t *testing.T) {
+	original := Version
+	defer func() { Version = original }()
+
+	Version = ""
+	got := Get()
+	// In a git checkout, should return a short SHA or "dev"
+	if got == "" {
+		t.Error("Get() returned empty string, expected non-empty version")
+	}
+}
+
+func TestGet_FallsBackToMainVersion(t *testing.T) {
+	// When Version is empty and there's no VCS info but Main.Version is set,
+	// Get() should return info.Main.Version.
+	// In practice this branch is hard to trigger in a real git checkout
+	// because VCS info is always present. We verify the logic path by
+	// confirming the function doesn't panic and returns a non-empty string.
+	original := Version
+	defer func() { Version = original }()
+
+	Version = ""
+	got := Get()
+	if got == "" {
+		t.Error("Get() returned empty string")
+	}
+
+	// Verify the result comes from one of the expected sources
+	if _, ok := debug.ReadBuildInfo(); !ok {
+		// No build info at all — should return "dev"
+		if got != "dev" {
+			t.Errorf("Get() = %q without build info, want %q", got, "dev")
+		}
+	}
+}
+
+func TestGet_EmptyVersionString(t *testing.T) {
+	original := Version
+	defer func() { Version = original }()
+
+	Version = ""
+	result := Get()
+
+	// Result must be one of: VCS short SHA, Main.Version, or "dev"
+	if result == "" {
+		t.Error("Get() should never return empty string")
+	}
+}
+
+func TestGet_PriorityOverVCS(t *testing.T) {
+	// When Version is set via ldflags, it should take priority over VCS fallback
+	original := Version
+	defer func() { Version = original }()
+
+	Version = "v3.0.0-beta"
+	if got := Get(); got != "v3.0.0-beta" {
+		t.Errorf("Get() = %q, want %q (ldflags should take priority)", got, "v3.0.0-beta")
 	}
 }


### PR DESCRIPTION
Replace the old single-line password box with a structured startup banner showing version, URLs, password, agents, SSH, data directory, service status, and startup duration. Border alignment uses runeWidth/padRight (CJK/emoji aware) with %s output.