### PR TITLE
fix(lint): resolve 8 golangci-lint errors blocking release

### DIFF
--- a/internal/handler/session_resume.go
+++ b/internal/handler/session_resume.go
@@ -38,7 +38,8 @@ func ServeSessionResume(w http.ResponseWriter, r *http.Request) {
 	// Check session exists and belongs to project
 	var sessionProjectPath string
 	var deleted int
-	err := service.DBRead.QueryRow(
+	err := service.DBRead.QueryRowContext(
+		r.Context(),
 		"SELECT project_path, deleted FROM chat_sessions WHERE id = ?",
 		req.SessionID,
 	).Scan(&sessionProjectPath, &deleted)
@@ -61,7 +62,8 @@ func ServeSessionResume(w http.ResponseWriter, r *http.Request) {
 	if deleted == 1 {
 		if model.SessionMaxCount > 0 {
 			var count int
-			err = service.DBRead.QueryRow(
+			err = service.DBRead.QueryRowContext(
+				r.Context(),
 				"SELECT COUNT(*) FROM chat_sessions WHERE project_path = ? AND deleted = 0 AND session_type = 'chat'",
 				sessionProjectPath,
 			).Scan(&count)
@@ -80,7 +82,8 @@ func ServeSessionResume(w http.ResponseWriter, r *http.Request) {
 		}
 
 		// Restore the session
-		_, err = service.DB.Exec(
+		_, err = service.DB.ExecContext(
+			r.Context(),
 			"UPDATE chat_sessions SET deleted = 0, updated_at = CURRENT_TIMESTAMP WHERE id = ?",
 			req.SessionID,
 		)

--- a/internal/handler/session_resume_test.go
+++ b/internal/handler/session_resume_test.go
@@ -15,7 +15,7 @@ import (
 // --- POST /api/ai/session/resume tests ---
 
 func TestServeSessionResume_MethodNotAllowed(t *testing.T) {
-	req := httptest.NewRequest(http.MethodGet, "/api/ai/session/resume", nil)
+	req := httptest.NewRequest(http.MethodGet, "/api/ai/session/resume", http.NoBody)
 	withProjectCookie(req, "/some/project")
 	w := httptest.NewRecorder()
 	ServeSessionResume(w, req)

--- a/internal/model/agent.go
+++ b/internal/model/agent.go
@@ -213,8 +213,6 @@ func WriteAgentYAML(agent *Agent) error {
 }
 
 // commonRulesTemplate is the built-in system prompt prepended to all agents.
-//
-//nolint:goconst // template content with backticks
 var commonRulesTemplate = strings.Join([]string{
 	"## User Interaction (Highest Priority)",
 	"",

--- a/internal/model/discovery.go
+++ b/internal/model/discovery.go
@@ -489,7 +489,7 @@ type codebuddyProduct struct {
 // file from the CLI installation directory. This JSON file contains the authoritative model
 // list with proper names and default status, making it far more reliable than --help output
 // (which launches a TUI that hangs without a TTY) or JS bundle scanning (which is fragile).
-func DiscoverCodebuddyModels() []AgentModel { //nolint:gocyclo // multi-format model discovery
+func DiscoverCodebuddyModels() []AgentModel {
 	// Resolve the real path for the codebuddy CLI, handling Windows .cmd wrappers
 	// Path is typically: .../node_modules/@tencent-ai/codebuddy-code/bin/codebuddy
 	realPath := platform.ResolveCLIPath("codebuddy")

--- a/internal/platform/strings.go
+++ b/internal/platform/strings.go
@@ -23,7 +23,7 @@ func ExtractStrings(path string, minLen int) ([]string, error) {
 	if err != nil {
 		return nil, err
 	}
-	defer f.Close()
+	defer func() { _ = f.Close() }()
 
 	return ExtractStringsFromReader(f, minLen), nil
 }

--- a/internal/platform/strings_test.go
+++ b/internal/platform/strings_test.go
@@ -155,10 +155,10 @@ func TestExtractStringsFromReader_ReadError(t *testing.T) {
 
 // errorAfterReader returns data bytes then err on the next Read call.
 type errorAfterReader struct {
-	data  []byte
-	err   error
-	pos   int
-	done  bool
+	data []byte
+	err  error
+	pos  int
+	done bool
 }
 
 func (r *errorAfterReader) Read(p []byte) (int, error) {


### PR DESCRIPTION
Fixes 8 lint errors that blocked the v0.44.0 release CI:

- **noctx**: `QueryRow`→`QueryRowContext`, `Exec`→`ExecContext` in session_resume.go
- **gocritic**: `nil`→`http.NoBody` in session_resume_test.go
- **errcheck**: `f.Close()`→`defer func(){_=f.Close()}` in strings.go
- **gofumpt**: alignment fix in strings_test.go
- **nolintlint**: remove unused `//nolint:goconst` and `//nolint:gocyclo` directives

These are all trivial lint fixes with no behavioral changes.