### PR TITLE
fix(ci): remove install.sh upload from release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -423,13 +423,6 @@ jobs:
         with:
           fetch-depth: 0
 
-      - name: Upload install scripts
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: |
-          TAG=${GITHUB_REF#refs/tags/}
-          gh release upload "$TAG" install.sh --clobber
-
       - name: Generate release notes
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
install.sh was deleted in #199 (green portable install), but the release workflow still tried to upload it, causing the v0.44.0 release pipeline to fail.

Removes the "Upload install scripts" step from the release-notes job.