### PR TITLE
revert: 回滚 ISS-233/ISS-234 — AutoResumeBackend 仅适用于 CodeBuddy 系 CLI

### DIFF
--- a/.clawbench/issues/ISS-233.md
+++ b/.clawbench/issues/ISS-233.md
@@ -1,6 +1,6 @@
 ---
 id: ISS-233
-status: fixed
+status: open
 severity: critical
 dimension: P0 - Flow Correctness
 created: 2026-05-31
@@ -19,3 +19,4 @@ Wrap `CodexBackend` in `AutoResumeBackend` in the factory, similar to how claude
 ## History
 - 2026-05-31: Created by review 2026-05-31
 - 2026-06-03: Fixed — CodexBackend now wrapped in AutoResumeBackend in factory.go
+- 2026-06-03: Reverted — Codex does not emit ExitPlanMode, AutoResumeBackend is unnecessary and may cause issues; only CodeBuddy/Claude-family CLIs need it

--- a/.clawbench/issues/ISS-234.md
+++ b/.clawbench/issues/ISS-234.md
@@ -1,6 +1,6 @@
 ---
 id: ISS-234
-status: fixed
+status: open
 severity: critical
 dimension: P0 - Flow Correctness
 created: 2026-05-31
@@ -19,3 +19,4 @@ Wrap `OpenCodeBackend` and `GeminiBackend` in `AutoResumeBackend` in the factory
 ## History
 - 2026-05-31: Created by review 2026-05-31
 - 2026-06-03: Fixed — opencode and gemini backends now wrapped in AutoResumeBackend in factory.go
+- 2026-06-03: Reverted — opencode/gemini do not emit ExitPlanMode, AutoResumeBackend is unnecessary and may cause issues; only CodeBuddy/Claude-family CLIs need it

--- a/internal/ai/factory.go
+++ b/internal/ai/factory.go
@@ -12,11 +12,11 @@ func NewBackend(backendType string) (AIBackend, error) {
 	case "codebuddy":
 		return &AutoResumeBackend{inner: codebuddyBackend}, nil
 	case "opencode":
-		return &AutoResumeBackend{inner: opencodeBackend}, nil
+		return opencodeBackend, nil
 	case "gemini":
-		return &AutoResumeBackend{inner: geminiBackend}, nil
+		return geminiBackend, nil
 	case "codex":
-		return &AutoResumeBackend{inner: &CodexBackend{}}, nil
+		return &CodexBackend{}, nil
 	case "qoder":
 		return &AutoResumeBackend{inner: qoderBackend}, nil
 	case "vecli":

--- a/internal/ai/factory_test.go
+++ b/internal/ai/factory_test.go
@@ -31,9 +31,9 @@ func TestNewBackend_OpenCode(t *testing.T) {
 	assert.NoError(t, err)
 	assert.NotNil(t, backend)
 	assert.Equal(t, "opencode", backend.Name())
-	// OpenCode is wrapped in AutoResumeBackend (ExitPlanMode auto-resume)
+	// OpenCode is NOT wrapped in AutoResumeBackend (no ExitPlanMode issue)
 	_, ok := backend.(*AutoResumeBackend)
-	assert.True(t, ok, "opencode should be wrapped in AutoResumeBackend")
+	assert.False(t, ok, "opencode should NOT be wrapped in AutoResumeBackend")
 }
 
 func TestNewBackend_Gemini(t *testing.T) {
@@ -41,9 +41,9 @@ func TestNewBackend_Gemini(t *testing.T) {
 	assert.NoError(t, err)
 	assert.NotNil(t, backend)
 	assert.Equal(t, "gemini", backend.Name())
-	// Gemini is wrapped in AutoResumeBackend (ExitPlanMode auto-resume)
+	// Gemini is NOT wrapped in AutoResumeBackend (no ExitPlanMode issue)
 	_, ok := backend.(*AutoResumeBackend)
-	assert.True(t, ok, "gemini should be wrapped in AutoResumeBackend")
+	assert.False(t, ok, "gemini should NOT be wrapped in AutoResumeBackend")
 }
 
 func TestNewBackend_Qoder(t *testing.T) {
@@ -91,9 +91,9 @@ func TestNewBackend_Codex(t *testing.T) {
 	assert.NoError(t, err)
 	assert.NotNil(t, backend)
 	assert.Equal(t, "codex", backend.Name())
-	// Codex is wrapped in AutoResumeBackend (ExitPlanMode auto-resume)
-	_, ok := backend.(*AutoResumeBackend)
-	assert.True(t, ok, "codex should be wrapped in AutoResumeBackend")
+	// Codex is NOT wrapped in AutoResumeBackend (custom ExecuteStream, no ExitPlanMode)
+	_, ok := backend.(*CodexBackend)
+	assert.True(t, ok, "codex should be a CodexBackend (not wrapped in AutoResumeBackend)")
 }
 
 func TestNewBackend_Unsupported(t *testing.T) {


### PR DESCRIPTION
## 回滚原因

ISS-233 和 ISS-234 的修复是不正确的。AutoResumeBackend 仅在使用 CLIBackend + stream_parser.go 的 CLI 后端中有意义。

### 为什么只有 CodeBuddy 系 CLI 需要 AutoResumeBackend？

- **claude, codebuddy, qoder, deepseek, pi**: 使用 CLIBackend + 通用 stream_parser.go，CLI 输出格式一致，会产出 ExitPlanMode 工具调用，导致 --print 模式下挂起等待用户审批 → 需要 AutoResumeBackend 自动恢复
- **opencode, gemini, codex**: 各自有独立的 stream parser，不会产出 ExitPlanMode 事件 → 包装 AutoResumeBackend 是多余的

### 回滚内容
- factory.go: opencode/gemini/codex 恢复为不包装 AutoResumeBackend
- factory_test.go: 恢复对应测试断言
- ISS-233/ISS-234: 恢复为 open 状态