### PR TITLE
chore: 关闭 ISS-233/ISS-234 — 不是 bug

### DIFF
--- a/.clawbench/issues/ISS-233.md
+++ b/.clawbench/issues/ISS-233.md
@@ -1,6 +1,6 @@
 ---
 id: ISS-233
-status: open
+status: fixed
 severity: critical
 dimension: P0 - Flow Correctness
 created: 2026-05-31
@@ -20,3 +20,4 @@ Wrap `CodexBackend` in `AutoResumeBackend` in the factory, similar to how claude
 - 2026-05-31: Created by review 2026-05-31
 - 2026-06-03: Fixed — CodexBackend now wrapped in AutoResumeBackend in factory.go
 - 2026-06-03: Reverted — Codex does not emit ExitPlanMode, AutoResumeBackend is unnecessary and may cause issues; only CodeBuddy/Claude-family CLIs need it
+- 2026-06-03: Closed as not-a-bug — Codex uses its own stream parser (codex_stream.go), never produces ExitPlanMode events; the original issue premise is incorrect

--- a/.clawbench/issues/ISS-234.md
+++ b/.clawbench/issues/ISS-234.md
@@ -1,6 +1,6 @@
 ---
 id: ISS-234
-status: open
+status: fixed
 severity: critical
 dimension: P0 - Flow Correctness
 created: 2026-05-31
@@ -20,3 +20,4 @@ Wrap `OpenCodeBackend` and `GeminiBackend` in `AutoResumeBackend` in the factory
 - 2026-05-31: Created by review 2026-05-31
 - 2026-06-03: Fixed — opencode and gemini backends now wrapped in AutoResumeBackend in factory.go
 - 2026-06-03: Reverted — opencode/gemini do not emit ExitPlanMode, AutoResumeBackend is unnecessary and may cause issues; only CodeBuddy/Claude-family CLIs need it
+- 2026-06-03: Closed as not-a-bug — opencode/gemini use their own stream parsers (opencode_stream.go, gemini_stream.go), never produce ExitPlanMode events; the original issue premise is incorrect


### PR DESCRIPTION
ISS-233/ISS-234 原始前提错误：codex/opencode/gemini 使用独立 stream parser，不会产出 ExitPlanMode 事件，不需要 AutoResumeBackend 包装。