### PR TITLE
perf: 优化会话切换查询性能 — 添加覆盖索引 + 合并冗余DB往返

### DIFF
--- a/internal/handler/chat.go
+++ b/internal/handler/chat.go
@@ -76,18 +76,19 @@ func AIChat(w http.ResponseWriter, r *http.Request) {
 
 		var sessionID string
 		var sessionBackend string
+		var cachedSessionInfo *service.SessionInfo // reused to avoid extra DB queries
 
 		if requestedSessionID != "" {
-			// Use the requested session
+			// Use the requested session — single query to get backend + project_path + metadata
 			sessionID = requestedSessionID
-			sessionBackend = service.GetSessionBackend(sessionID)
-			if sessionBackend == "" {
+			cachedSessionInfo = service.GetSessionFullInfo(sessionID)
+			if cachedSessionInfo == nil {
 				writeLocalizedErrorf(w, r, http.StatusNotFound, "SessionNotFound")
 				return
 			}
+			sessionBackend = cachedSessionInfo.Backend
 			// Verify the session belongs to the requesting project (ISS-180)
-			// Skip ownership check if session doesn't exist in DB (session auto-created below)
-			if sessionProject := service.GetSessionProjectPath(sessionID); sessionProject != "" && sessionProject != projectPath {
+			if cachedSessionInfo.ProjectPath != projectPath {
 				writeLocalizedError(w, r, model.Forbidden(nil, "AccessDenied"))
 				return
 			}
@@ -160,16 +161,20 @@ func AIChat(w http.ResponseWriter, r *http.Request) {
 
 		totalCount := service.GetChatMessageCount(sessionID)
 		messages, err := service.GetChatHistoryPaged(projectPath, sessionBackend, sessionID, limit, beforeID)
-		// Get session metadata in a single query
-		sessionInfo, _ := service.GetSessionInfo(sessionID)
+		// Use cached session info from earlier lookup, or fetch if not yet available
+		// (e.g. when session was found via GetLatestSessionID or newly created).
+		// This avoids an extra DB query for the common case of switching to an existing session.
+		if cachedSessionInfo == nil {
+			cachedSessionInfo = service.GetSessionFullInfo(sessionID)
+		}
 		var sessionTitle, sessionAgentID, sessionModelID, sessionThinkingEffort string
 		var sessionInfoBackend string
-		if sessionInfo != nil {
-			sessionTitle = sessionInfo.Title
-			sessionInfoBackend = sessionInfo.Backend
-			sessionAgentID = sessionInfo.AgentID
-			sessionModelID = sessionInfo.Model
-			sessionThinkingEffort = sessionInfo.ThinkingEffort
+		if cachedSessionInfo != nil {
+			sessionTitle = cachedSessionInfo.Title
+			sessionInfoBackend = cachedSessionInfo.Backend
+			sessionAgentID = cachedSessionInfo.AgentID
+			sessionModelID = cachedSessionInfo.Model
+			sessionThinkingEffort = cachedSessionInfo.ThinkingEffort
 		}
 		if sessionInfoBackend != "" {
 			sessionBackend = sessionInfoBackend

--- a/internal/service/chat.go
+++ b/internal/service/chat.go
@@ -647,6 +647,7 @@ type SessionInfo struct {
 	AgentID        string
 	Model          string
 	ThinkingEffort string
+	ProjectPath    string // populated by GetSessionFullInfo only
 }
 
 // GetSessionInfo fetches session metadata (title, backend, agent_id, model, thinking_effort)
@@ -662,6 +663,23 @@ func GetSessionInfo(sessionID string) (*SessionInfo, error) {
 		return nil, err
 	}
 	return info, nil
+}
+
+// GetSessionFullInfo fetches all session metadata including project_path in a single query.
+// This replaces the common pattern of calling GetSessionBackend + GetSessionProjectPath +
+// GetSessionInfo (3 separate PK lookups on the same row) with a single query.
+// Returns nil if the session is not found or soft-deleted.
+func GetSessionFullInfo(sessionID string) *SessionInfo {
+	info := &SessionInfo{}
+	err := DBRead.QueryRow(
+		`SELECT backend, project_path, title, agent_id, model, thinking_effort
+		 FROM chat_sessions WHERE id = ? AND deleted = 0`,
+		sessionID,
+	).Scan(&info.Backend, &info.ProjectPath, &info.Title, &info.AgentID, &info.Model, &info.ThinkingEffort)
+	if err != nil {
+		return nil
+	}
+	return info
 }
 
 // GetSessionAgentID returns the agent_id of an active (non-deleted) session.

--- a/internal/service/chat_test.go
+++ b/internal/service/chat_test.go
@@ -86,6 +86,9 @@ CREATE INDEX IF NOT EXISTS idx_history_session ON chat_history(project_path, bac
 CREATE INDEX IF NOT EXISTS idx_sessions_project_backend ON chat_sessions(project_path, backend);
 CREATE INDEX IF NOT EXISTS idx_executions_session ON task_executions(session_id);
 CREATE INDEX IF NOT EXISTS idx_tasks_project ON scheduled_tasks(project_path, created_at DESC);
+CREATE INDEX IF NOT EXISTS idx_history_session_id ON chat_history(session_id, role, streaming, created_at);
+CREATE INDEX IF NOT EXISTS idx_history_unread ON chat_history(project_path, role, streaming, created_at);
+CREATE INDEX IF NOT EXISTS idx_sessions_order ON chat_sessions(session_type, project_path, deleted, updated_at DESC, id DESC);
 CREATE TABLE IF NOT EXISTS ai_raw_responses (
 	id INTEGER PRIMARY KEY AUTOINCREMENT,
 	session_id TEXT NOT NULL,
@@ -1946,6 +1949,54 @@ func TestGetSessionTitlesBatchIncludeDeleted_Empty(t *testing.T) {
 	titles, err := service.GetSessionTitlesBatchIncludeDeleted([]string{})
 	assert.NoError(t, err)
 	assert.Empty(t, titles)
+}
+
+// ---------- GetSessionFullInfo ----------
+
+func TestGetSessionFullInfo(t *testing.T) {
+	_ = setupDB(t)
+
+	sid, err := service.CreateSession("/my/project", "claude", "Full Info Test", "my-agent", "gpt-4o", "user", "chat")
+	assert.NoError(t, err)
+
+	info := service.GetSessionFullInfo(sid)
+	assert.NotNil(t, info)
+	assert.Equal(t, "claude", info.Backend)
+	assert.Equal(t, "/my/project", info.ProjectPath)
+	assert.Equal(t, "Full Info Test", info.Title)
+	assert.Equal(t, "my-agent", info.AgentID)
+	assert.Equal(t, "gpt-4o", info.Model)
+	assert.Equal(t, "", info.ThinkingEffort)
+}
+
+func TestGetSessionFullInfo_WithThinkingEffort(t *testing.T) {
+	_ = setupDB(t)
+
+	sid, err := service.CreateSession("/project", "claude", "Thinking", "claude", "", "default", "chat")
+	assert.NoError(t, err)
+	err = service.UpdateSessionThinkingEffort(sid, "high")
+	assert.NoError(t, err)
+
+	info := service.GetSessionFullInfo(sid)
+	assert.NotNil(t, info)
+	assert.Equal(t, "high", info.ThinkingEffort)
+}
+
+func TestGetSessionFullInfo_NotFound(t *testing.T) {
+	_ = setupDB(t)
+
+	info := service.GetSessionFullInfo("nonexistent")
+	assert.Nil(t, info)
+}
+
+func TestGetSessionFullInfo_Deleted(t *testing.T) {
+	_ = setupDB(t)
+
+	sid, _ := service.CreateSession("/project", "claude", "Deleted", "claude", "", "default", "chat")
+	service.DeleteSession("/project", "claude", sid)
+
+	info := service.GetSessionFullInfo(sid)
+	assert.Nil(t, info)
 }
 
 // ---------- GetSessionInfo ----------

--- a/internal/service/database.go
+++ b/internal/service/database.go
@@ -136,6 +136,15 @@ func InitDB(runFromServer ...bool) error { //nolint:gocognit,gocyclo // multi-ta
 		CREATE INDEX IF NOT EXISTS idx_history_session_id ON chat_history(session_id, role, streaming, created_at);
 		-- Index for task listing by project
 		CREATE INDEX IF NOT EXISTS idx_tasks_project ON scheduled_tasks(project_path, created_at DESC);
+		-- Covering index for unread count subquery in GetSessions/GetSessionsPaged:
+		-- WHERE project_path = ? AND role = 'assistant' AND streaming = 0 AND created_at > ?
+		-- Without this, the unread subquery can only use the project_path prefix of idx_history_session,
+		-- requiring a full scan of all messages in the project to filter by role and streaming.
+		CREATE INDEX IF NOT EXISTS idx_history_unread ON chat_history(project_path, role, streaming, created_at);
+		-- Covering index for session list ORDER BY + cursor pagination:
+		-- WHERE session_type = 'chat' AND project_path = ? AND deleted = 0 ORDER BY updated_at DESC, id DESC
+		-- Without this, idx_sessions_type covers WHERE but requires a filesort for ORDER BY.
+		CREATE INDEX IF NOT EXISTS idx_sessions_order ON chat_sessions(session_type, project_path, deleted, updated_at DESC, id DESC);
 
 		CREATE TABLE IF NOT EXISTS summaries (
 			id INTEGER PRIMARY KEY AUTOINCREMENT,


### PR DESCRIPTION
## 问题

会话切换时感觉卡顿，根源有两个：

1. **unread 子查询无最优索引**：`GetSessions`/`GetSessionsPaged` 的 unread count 子查询 `WHERE project_path=? AND role='assistant' AND streaming=0 AND created_at>?` 只能用 `idx_history_session(project_path, backend, session_id, created_at)` 的 `project_path` 前缀（中间 `backend` 列阻断了前缀匹配），需要扫描该项目所有消息来过滤 `role` 和 `streaming`。

2. **ORDER BY 无覆盖索引**：会话列表 `ORDER BY updated_at DESC, id DESC` 需要 filesort，因为 `idx_sessions_type(session_type, project_path, deleted)` 只覆盖了 WHERE 而不含排序列。

3. **冗余 DB 查询**：GET handler 切换会话时对 `chat_sessions` 同一行做了 3 次 PK lookup（`GetSessionBackend` + `GetSessionProjectPath` + `GetSessionInfo`）。

## 改动

### 新增两个覆盖索引（`database.go`）

- `idx_history_unread ON chat_history(project_path, role, streaming, created_at)` — 直接 seek 到 `(project_path, 'assistant', 0)` 前缀，unread 子查询从全项目扫描变为范围扫描
- `idx_sessions_order ON chat_sessions(session_type, project_path, deleted, updated_at DESC, id DESC)` — WHERE + ORDER BY 被同一索引覆盖，无需额外排序

两个索引均使用 `CREATE INDEX IF NOT EXISTS`，**向后兼容**：老数据库启动时自动补建。

### 合并冗余查询（`chat.go`）

新增 `GetSessionFullInfo()` 一次返回 `backend + project_path + title + agent_id + model + thinking_effort`，替换原来 3 次独立 PK lookup。Handler 中缓存结果复用，减少 2 次 DB 往返。

### 单元测试（`chat_test.go`）

- `TestGetSessionFullInfo` / `_NotFound` / `_Deleted` / `_WithThinkingEffort` — 覆盖新函数所有分支
- 同步测试 schema 中的索引定义与生产代码一致

## 性能影响

| 操作 | 之前 | 之后 |
|------|------|------|
| Unread 子查询 | 扫描项目所有 history 行 | 索引 seek + 范围扫描 |
| 会话列表排序 | filesort | 索引有序读取 |
| 切换会话 DB 查询数 | 6 次 | 4 次（减少 2 次往返）|