### PR TITLE
fix: #208 聊天消息中已中断标签在 thinking 折叠时被隐藏/遮挡

### DIFF
--- a/web/src/components/chat/ContentBlocks.vue
+++ b/web/src/components/chat/ContentBlocks.vue
@@ -28,6 +28,9 @@
           <span class="thinking-label">{{ t('chat.message.deepThinking') }}</span>
           <!-- Spinner during streaming -->
           <span v-if="isThinkingStreaming(block)" class="thinking-spinner"></span>
+          <!-- Cancelled marker: show inline in thinking header when this is the last block and message was cancelled.
+               Prevents the cancelled mark from being visually hidden/trapped under the collapsed thinking chip. -->
+          <span v-if="!isThinkingStreaming(block) && isLastBlock(bi) && cancelled" class="chat-cancelled-mark-inline">{{ t('chat.contentBlocks.cancelled') }}</span>
         </div>
         <!-- Inline streaming content: only visible during streaming or collapse animation -->
         <div v-if="isThinkingStreaming(block) || !!collapsingThinking[bi]" class="thinking-inline-content" v-html="getThinkingHtml(bi, block)"></div>
@@ -127,8 +130,8 @@
     </template>
     <!-- Loading dots while AI is still streaming (not when cancelled, and not when showing summary) -->
     <div v-if="streaming && !cancelled && !(showingSummary && summary)" class="placeholder-dots"><span></span><span></span><span></span></div>
-    <!-- Cancelled marker -->
-    <div v-if="cancelled" class="chat-cancelled-mark">{{ t('chat.contentBlocks.cancelled') }}</div>
+    <!-- Cancelled marker: hidden when the last block is thinking (shown inline in thinking-header instead) -->
+    <div v-if="cancelled && !isLastBlockThinking" class="chat-cancelled-mark">{{ t('chat.contentBlocks.cancelled') }}</div>
   </div>
 </template>
 
@@ -248,6 +251,18 @@ function handleThinkingClick(block, bi) {
 function isThinkingStreaming(block) {
   return props.streaming
 }
+
+/** Whether the given block index is the last block in the blocks array. */
+function isLastBlock(bi) {
+  return bi === (props.blocks?.length || 0) - 1
+}
+
+/** Whether the last block is a thinking block (used to avoid duplicate cancelled marker). */
+const isLastBlockThinking = computed(() => {
+  const blocks = props.blocks
+  if (!blocks || blocks.length === 0) return false
+  return blocks[blocks.length - 1].type === 'thinking'
+})
 
 // ── Thinking block collapse animation state ──
 const collapsingThinking = ref({})   // { [blockIndex]: true } for blocks mid-collapse
@@ -456,6 +471,16 @@ onUnmounted(() => {
   padding: 2px 8px;
   border-radius: 4px;
   margin-top: 4px;
+}
+
+/* Inline cancelled marker inside thinking header — always visible even when thinking is collapsed */
+.chat-cancelled-mark-inline {
+  font-size: 11px;
+  color: var(--text-muted, #999);
+  background: var(--bg-tertiary, #f0f0f0);
+  padding: 1px 6px;
+  border-radius: 4px;
+  margin-left: auto;
 }
 
 

--- a/web/src/components/chat/__tests__/cancelledMark.test.ts
+++ b/web/src/components/chat/__tests__/cancelledMark.test.ts
@@ -1,0 +1,160 @@
+import { describe, expect, it } from 'vitest'
+
+/**
+ * Tests for the cancelled-marker visibility logic in ContentBlocks.vue.
+ *
+ * Bug #208: When the last content block is a thinking block and the message was
+ * cancelled, the "已中断" (cancelled) mark was visually hidden/trapped under
+ * the collapsed thinking chip (28px max-height). The fix renders the cancelled
+ * mark inline inside the thinking header when the last block is thinking,
+ * instead of placing it below all blocks.
+ *
+ * The core logic is:
+ * - isLastBlock(bi): bi === blocks.length - 1
+ * - isLastBlockThinking: blocks[blocks.length - 1]?.type === 'thinking'
+ * - Inline cancelled mark visible: !streaming && isLastBlock(bi) && cancelled
+ * - Outer cancelled mark visible: cancelled && !isLastBlockThinking
+ */
+
+describe('isLastBlock logic', () => {
+  /** Replicates the isLastBlock function from ContentBlocks.vue */
+  function isLastBlock(bi: number, blocks: any[]): boolean {
+    return bi === (blocks?.length || 0) - 1
+  }
+
+  it('returns true for the last block index', () => {
+    const blocks = [{ type: 'text' }, { type: 'thinking' }]
+    expect(isLastBlock(1, blocks)).toBe(true)
+  })
+
+  it('returns false for non-last block indices', () => {
+    const blocks = [{ type: 'text' }, { type: 'thinking' }]
+    expect(isLastBlock(0, blocks)).toBe(false)
+  })
+
+  it('returns false for empty blocks array', () => {
+    expect(isLastBlock(0, [])).toBe(false)
+  })
+
+  it('returns true for single-element array at index 0', () => {
+    const blocks = [{ type: 'thinking' }]
+    expect(isLastBlock(0, blocks)).toBe(true)
+  })
+})
+
+describe('isLastBlockThinking logic', () => {
+  /** Replicates the isLastBlockThinking computed from ContentBlocks.vue */
+  function isLastBlockThinking(blocks: any[]): boolean {
+    if (!blocks || blocks.length === 0) return false
+    return blocks[blocks.length - 1].type === 'thinking'
+  }
+
+  it('returns true when the last block is thinking', () => {
+    const blocks = [{ type: 'text' }, { type: 'thinking' }]
+    expect(isLastBlockThinking(blocks)).toBe(true)
+  })
+
+  it('returns false when the last block is not thinking', () => {
+    const blocks = [{ type: 'text' }, { type: 'tool_use' }]
+    expect(isLastBlockThinking(blocks)).toBe(false)
+  })
+
+  it('returns false for empty array', () => {
+    expect(isLastBlockThinking([])).toBe(false)
+  })
+
+  it('returns false for null/undefined', () => {
+    expect(isLastBlockThinking(null as any)).toBe(false)
+    expect(isLastBlockThinking(undefined as any)).toBe(false)
+  })
+
+  it('returns true for single thinking block', () => {
+    const blocks = [{ type: 'thinking' }]
+    expect(isLastBlockThinking(blocks)).toBe(true)
+  })
+})
+
+describe('cancelled marker visibility (bug #208)', () => {
+  /**
+   * Simulates the template logic:
+   * - Inline cancelled mark (in thinking header):
+   *     !streaming && isLastBlock(bi) && cancelled && block.type === 'thinking'
+   * - Outer cancelled mark (below all blocks):
+   *     cancelled && !isLastBlockThinking
+   */
+  function getCancelledMarkerState(
+    blocks: any[],
+    cancelled: boolean,
+    streaming: boolean,
+  ) {
+    const lastIdx = blocks.length - 1
+    const lastIsThinking =
+      blocks.length > 0 && blocks[lastIdx]?.type === 'thinking'
+
+    // Inline: shown in thinking header when last block is thinking and cancelled
+    const showInline =
+      cancelled && !streaming && lastIsThinking && lastIdx >= 0
+
+    // Outer: shown below all blocks, but NOT when last is thinking (to avoid duplicate)
+    const showOuter = cancelled && !lastIsThinking
+
+    return { showInline, showOuter }
+  }
+
+  it('shows inline mark when last block is thinking and message is cancelled', () => {
+    const blocks = [{ type: 'text' }, { type: 'thinking' }]
+    const { showInline, showOuter } = getCancelledMarkerState(
+      blocks,
+      true, /* cancelled */
+      false, /* streaming */
+    )
+    // Bug #208 fix: inline mark visible in thinking header
+    expect(showInline).toBe(true)
+    // Outer mark hidden to avoid duplication
+    expect(showOuter).toBe(false)
+  })
+
+  it('shows outer mark when last block is not thinking and message is cancelled', () => {
+    const blocks = [{ type: 'text' }, { type: 'tool_use' }]
+    const { showInline, showOuter } = getCancelledMarkerState(
+      blocks,
+      true, /* cancelled */
+      false, /* streaming */
+    )
+    expect(showInline).toBe(false)
+    expect(showOuter).toBe(true)
+  })
+
+  it('shows no mark when message is not cancelled', () => {
+    const blocks = [{ type: 'thinking' }]
+    const { showInline, showOuter } = getCancelledMarkerState(
+      blocks,
+      false, /* cancelled */
+      false, /* streaming */
+    )
+    expect(showInline).toBe(false)
+    expect(showOuter).toBe(false)
+  })
+
+  it('does not show inline mark while streaming (spinner visible instead)', () => {
+    const blocks = [{ type: 'thinking' }]
+    const { showInline, showOuter } = getCancelledMarkerState(
+      blocks,
+      true, /* cancelled */
+      true, /* streaming — shouldn't happen normally but test the guard */
+    )
+    // Inline mark guarded by !streaming
+    expect(showInline).toBe(false)
+  })
+
+  it('shows outer mark for text-only message that was cancelled', () => {
+    const blocks = [{ type: 'text', text: 'Hello' }]
+    const { showInline, showOuter } = getCancelledMarkerState(
+      blocks,
+      true, /* cancelled */
+      false, /* streaming */
+    )
+    expect(showInline).toBe(false)
+    expect(showOuter).toBe(true)
+  })
+})


### PR DESCRIPTION
修复 #208

## 修复内容

当 AI 回复被中断且最后一个内容块是 thinking 块时，"已中断"标签会被折叠的 thinking chip (28px) 视觉遮挡。修复方案：

- 在 thinking-header 内侧新增 inline 已中断标签 (chat-cancelled-mark-inline)
- 当最后一个块是 thinking 且消息已取消时，在内侧显示标签而非外侧
- 原有外侧标签 (chat-cancelled-mark) 在此情况下隐藏，避免重复
- 新增 isLastBlock() 和 isLastBlockThinking 计算属性控制显示逻辑

## 测试
- 新增 14 个单元测试覆盖 isLastBlock、isLastBlockThinking 和取消标记可见性逻辑
- Go build 通过
- 前端所有现有测试通过 (1 个预存失败与本次修改无关)

Fixes #208