### PR TITLE
fix: apply De Morgan's law to fix staticcheck QF1001

### DIFF
--- a/internal/model/defaults_test.go
+++ b/internal/model/defaults_test.go
@@ -515,7 +515,7 @@ func TestApplyDefaults_AutoPasswordEntropy(t *testing.T) {
 
 	// Verify it's valid hex
 	for _, c := range pwd {
-		if !((c >= '0' && c <= '9') || (c >= 'a' && c <= 'f')) {
+		if (c < '0' || c > '9') && (c < 'a' || c > 'f') {
 			t.Errorf("auto-generated password contains non-hex char %q, ISS-269", c)
 			break
 		}


### PR DESCRIPTION
修复 `internal/model/defaults_test.go:518` 中的 staticcheck QF1001 lint 错误，应用德摩根定律重写条件表达式。

此问题导致 v0.44.1 Release 流水线 Lint 失败，需要合入后重新触发发布。