### PR TITLE
fix: 修复 Review Issues 2026-06-04

### DIFF
--- a/internal/service/agent_store.go
+++ b/internal/service/agent_store.go
@@ -200,11 +200,13 @@ func LoadAgentsIntoMemory(db *sql.DB) error {
 		return err
 	}
 
-	model.Agents = make(map[string]*model.Agent)
+	// Build new map fully before assigning to avoid a window where
+	// concurrent HTTP handlers see 0 agents (ISS-302).
+	newAgentsMap := make(map[string]*model.Agent, len(agents))
 	model.AgentList = agents
 
 	for _, agent := range agents {
-		model.Agents[agent.ID] = agent
+		newAgentsMap[agent.ID] = agent
 		// Populate runtime-only fields from BackendRegistry
 		// (CanRefreshModels and ThinkingEffortLevels are not persisted in DB)
 		if spec := model.FindSpecByBackend(agent.Backend); spec != nil {
@@ -227,6 +229,9 @@ func LoadAgentsIntoMemory(db *sql.DB) error {
 			populateModelsFromProvider(agent)
 		}
 	}
+
+	// Atomically assign the fully-built map so concurrent readers never see an empty map.
+	model.Agents = newAgentsMap
 
 	// Sort by ID for deterministic ordering
 	sort.Slice(model.AgentList, func(i, j int) bool {

--- a/internal/service/scheduler.go
+++ b/internal/service/scheduler.go
@@ -71,7 +71,12 @@ func (s *Scheduler) Stop() {
 func (s *Scheduler) GetRunningExecutions(taskID int64) []model.RunningExecutionView {
 	var result []model.RunningExecutionView
 	s.runningExecutions.Range(func(key, value any) bool {
-		exec, _ := value.(*RunningExecution)
+		exec, ok := value.(*RunningExecution) // ISS-280: check type assertion
+		if !ok || exec == nil {
+			slog.Warn("unexpected type in runningExecutions, deleting entry", slog.Any("key", key), slog.Any("value", value))
+			s.runningExecutions.Delete(key)
+			return true
+		}
 		if exec.TaskID == taskID {
 			result = append(result, model.RunningExecutionView{
 				ID:          exec.ID,
@@ -88,7 +93,12 @@ func (s *Scheduler) GetRunningExecutions(taskID int64) []model.RunningExecutionV
 func (s *Scheduler) GetRunningCounts() map[int64]int {
 	counts := make(map[int64]int)
 	s.runningExecutions.Range(func(key, value any) bool {
-		exec, _ := value.(*RunningExecution)
+		exec, ok := value.(*RunningExecution) // ISS-280: check type assertion
+		if !ok || exec == nil {
+			slog.Warn("unexpected type in runningExecutions, deleting entry", slog.Any("key", key), slog.Any("value", value))
+			s.runningExecutions.Delete(key)
+			return true
+		}
 		counts[exec.TaskID]++
 		return true
 	})
@@ -99,7 +109,12 @@ func (s *Scheduler) GetRunningCounts() map[int64]int {
 func (s *Scheduler) HasRunningExecutions(taskID int64) bool {
 	found := false
 	s.runningExecutions.Range(func(key, value any) bool {
-		v, _ := value.(*RunningExecution)
+		v, ok := value.(*RunningExecution) // ISS-280: check type assertion
+		if !ok || v == nil {
+			slog.Warn("unexpected type in runningExecutions, deleting entry", slog.Any("key", key), slog.Any("value", value))
+			s.runningExecutions.Delete(key)
+			return true
+		}
 		if v.TaskID == taskID {
 			found = true
 			return false
@@ -158,7 +173,11 @@ func (s *Scheduler) CancelExecution(executionID string) error {
 	if !ok {
 		return fmt.Errorf("execution not found: %s", executionID)
 	}
-	exec, _ := val.(*RunningExecution)
+	exec, ok := val.(*RunningExecution) // ISS-280: check type assertion
+	if !ok || exec == nil {
+		s.runningExecutions.Delete(executionID)
+		return fmt.Errorf("invalid execution entry: %s", executionID)
+	}
 	exec.CancelFunc()
 	slog.Info(
 		"cancelled running execution",
@@ -171,7 +190,12 @@ func (s *Scheduler) CancelExecution(executionID string) error {
 // CancelAllExecutions cancels all running executions for a specific task.
 func (s *Scheduler) CancelAllExecutions(taskID int64) {
 	s.runningExecutions.Range(func(key, value any) bool {
-		exec, _ := value.(*RunningExecution)
+		exec, ok := value.(*RunningExecution) // ISS-280: check type assertion
+		if !ok || exec == nil {
+			slog.Warn("unexpected type in runningExecutions, deleting entry", slog.Any("key", key))
+			s.runningExecutions.Delete(key)
+			return true
+		}
 		if exec.TaskID == taskID {
 			exec.CancelFunc()
 			slog.Info(
@@ -519,6 +543,11 @@ func emitTaskEvent(taskID, status, executionID, sessionID, projectPath, taskName
 // executeTask runs a scheduled task by invoking the AI backend and inserting
 // the result as an assistant message in the original session.
 func (s *Scheduler) executeTask(task *model.ScheduledTask, projectPath string, triggerType string) { //nolint:gocognit,gocyclo // task execution with session lifecycle
+	// Ensure taskRunning flag is always cleaned up, even on early-return
+	// paths (agent not found, session creation failure, backend creation failure).
+	// Without this, the task is permanently stuck — no future execution possible (ISS-303).
+	defer s.taskRunning.Delete(task.ID)
+
 	agent, ok := model.Agents[task.AgentID]
 	if !ok {
 		slog.Error(
@@ -627,7 +656,6 @@ func (s *Scheduler) executeTask(task *model.ScheduledTask, projectPath string, t
 	s.runningExecutions.Store(sessionID, running)
 	defer func() {
 		s.runningExecutions.Delete(sessionID)
-		s.taskRunning.Delete(task.ID) // Allow next cron tick to run (ISS-187)
 		cancel()
 	}()
 

--- a/web/src/composables/__tests__/useChatStream.test.ts
+++ b/web/src/composables/__tests__/useChatStream.test.ts
@@ -642,7 +642,7 @@ describe('useChatStream', () => {
       expect(options.onQueueUpdate).toHaveBeenCalledWith([{ id: 'q1' }, { id: 'q2' }])
     })
 
-    it('should call onQueueUpdate even when guard fails (independent of streaming message)', () => {
+    it('should NOT call onQueueUpdate when guard fails (ISS-304: guard check first)', () => {
       const options = createOptions()
       const { connectStream } = useChatStream(options)
 
@@ -655,8 +655,8 @@ describe('useChatStream', () => {
 
       es.simulate('queue_update', { queue: [{ id: 'q1' }] })
 
-      // onQueueUpdate is called before the guard check, so it should still fire
-      expect(options.onQueueUpdate).toHaveBeenCalledWith([{ id: 'q1' }])
+      // onQueueUpdate is NOT called because guard() now runs first (ISS-304)
+      expect(options.onQueueUpdate).not.toHaveBeenCalled()
     })
   })
 

--- a/web/src/composables/useChatStream.ts
+++ b/web/src/composables/useChatStream.ts
@@ -351,10 +351,10 @@ export function useChatStream(options: UseChatStreamOptions) {
     })
 
     eventSource.addEventListener('tool_use', (e) => {
+      if (!guard()) return // Check guard first to prevent stale events corrupting new session (ISS-304)
       resetStreamTimeout()
       let data: any
       try { data = JSON.parse(e.data) } catch { console.warn('SSE tool_use: invalid JSON, skipping'); return }
-      if (!guard()) return
       const blocks = streamingMsg.blocks
       // Always check for existing block with same ID first — the backend may
       // emit multiple tool_use events for the same call (start + stop), and
@@ -412,10 +412,10 @@ export function useChatStream(options: UseChatStreamOptions) {
     })
 
     eventSource.addEventListener('tool_result', (e) => {
+      if (!guard()) return // Check guard first to prevent stale events corrupting new session (ISS-304)
       resetStreamTimeout()
       let data: any
       try { data = JSON.parse(e.data) } catch { console.warn('SSE tool_result: invalid JSON, skipping'); return }
-      if (!guard()) return
       const blocks = streamingMsg.blocks
       // Find the matching tool_use block and update output/status
       const existing = blocks.find(b => b.type === 'tool_use' && b.id === data.id)
@@ -560,6 +560,7 @@ export function useChatStream(options: UseChatStreamOptions) {
     })
 
     eventSource.addEventListener('queue_update', (e) => {
+      if (!guard()) return // Check guard first to prevent stale events corrupting new session (ISS-304)
       resetStreamTimeout()
       let data: any
       try { data = JSON.parse(e.data) } catch { console.warn('SSE queue_update: invalid JSON, skipping'); return }


### PR DESCRIPTION
修复 Critical Issues: ISS-281, ISS-302, ISS-303, ISS-304

## 修复内容

### ISS-303: executeTask 早期失败时 taskRunning 标记未删除
- **问题**: 如果 ai.NewBackend 失败、agent 未找到或 session 创建失败，taskRunning 标志不会被清理，导致任务永久卡住无法再次执行
- **修复**: 在 executeTask 函数开头添加 `defer s.taskRunning.Delete(task.ID)`，确保所有返回路径都会清理标志

### ISS-281: RunningExecution 类型断言丢弃 ok 值
- **问题**: 5 个函数中 `exec, _ := val.(*RunningExecution)` 丢弃了类型断言的成功指示，可能导致 nil 指针 panic
- **修复**: 所有类型断言改为 `exec, ok := value.(*RunningExecution)` 并在断言失败时记录日志、删除条目、返回错误

### ISS-302: model.Agents 替换为空 map 后再填充
- **问题**: LoadAgentsIntoMemory 先创建空 map 赋值给 model.Agents 再逐步填充，并发 HTTP 请求会看到 0 个 agent
- **修复**: 先在局部变量 newAgentsMap 中完整构建 map，再一次性赋值给 model.Agents，消除空 map 窗口

### ISS-304: tool_use/tool_result/queue_update handler 在 guard() 前修改状态
- **问题**: SSE 事件处理器先调用 resetStreamTimeout() 和 JSON.parse() 再检查 guard()，过时事件可能损坏新 session 的流式消息
- **修复**: 将 guard() 检查移至 tool_use、tool_result、queue_update 处理器中最先执行的位置

## 验证
- go build ✅
- go test ./... ✅  
- npm test ✅ (3350 tests passed)