### PR TITLE
fix: word-wrap模式下粘性行号对齐与正常行保持一致

### DIFF
--- a/web/src/components/file/CodePreview.vue
+++ b/web/src/components/file/CodePreview.vue
@@ -241,8 +241,6 @@ watch(
 
 .raw-content-pre.word-wrap .sticky-line-num {
     line-height: normal;
-    display: flex;
-    align-items: center;
 }
 
 .raw-content-pre.word-wrap .sticky-code-text {


### PR DESCRIPTION
## Problem

word-wrap + 行号模式下，粘性行号靠左显示，而正常行号靠右显示，不一致。

**根因：** `.sticky-line-num` 在 word-wrap 模式下被设置了 `display: flex; align-items: center;`，覆盖了 `text-align: right` 的靠右效果。

## Fix

移除 word-wrap 模式下 `.sticky-line-num` 的 `display: flex; align-items: center;`，仅保留 `line-height: normal`，让 `text-align: right` 正常生效，与正常行号对齐方式一致。