### PR TITLE
feat(chat): quick-send long-press fills input with progressive fill bar

### DIFF
--- a/web/src/components/__tests__/chatInputBar.test.ts
+++ b/web/src/components/__tests__/chatInputBar.test.ts
@@ -64,7 +64,7 @@ const i18n = createI18n({
           placeholder: '输入消息…',
           placeholderQueue: '排队消息…',
           placeholderOptional: '添加描述（可选）',
-          placeholderQuickSend: '点击可执行快捷指令 →',
+          placeholderQuickSend: '点击⚡选指令 →',
           send: '发送',
           enqueue: '排队',
           quickMenu: '快捷指令',
@@ -79,7 +79,7 @@ const i18n = createI18n({
           uploadFile: '上传文件',
           openFile: '打开文件',
         },
-        quickSend: { title: '快捷发送', edit: '管理' },
+        quickSend: { title: '快捷发送', tapToFill: '长按发送', edit: '管理' },
         modelSwitcher: { title: '切换模型' },
         thinkingEffortSwitcher: { title: '思考强度', auto: '自动' },
       },
@@ -273,5 +273,38 @@ describe('ChatInputBar — clearInput exposed method', () => {
     await nextTick()
 
     expect(wrapper.find('.chat-textarea').element.value).toBe('')
+  })
+})
+
+describe('ChatInputBar — quick-send inject to input', () => {
+  it('injects text to input via injectToInput', async () => {
+    const wrapper = mountInputBar()
+    wrapper.vm.injectToInput('git status')
+    await nextTick()
+
+    expect(wrapper.find('.chat-textarea').element.value).toBe('git status')
+  })
+
+  it('appends text with newline when input already has content', async () => {
+    const wrapper = mountInputBar()
+    await wrapper.find('.chat-textarea').setValue('hello')
+    await nextTick()
+
+    wrapper.vm.injectToInput('git status')
+    await nextTick()
+
+    expect(wrapper.find('.chat-textarea').element.value).toBe('hello\ngit status')
+  })
+
+  it('replaces input when existing content is only whitespace', async () => {
+    const wrapper = mountInputBar()
+    await wrapper.find('.chat-textarea').setValue('   ')
+    await nextTick()
+
+    wrapper.vm.injectToInput('git status')
+    await nextTick()
+
+    // trim() makes the existing content empty, so no newline prefix
+    expect(wrapper.find('.chat-textarea').element.value).toBe('git status')
   })
 })

--- a/web/src/components/__tests__/chatInputBar.test.ts
+++ b/web/src/components/__tests__/chatInputBar.test.ts
@@ -308,3 +308,152 @@ describe('ChatInputBar — quick-send inject to input', () => {
     expect(wrapper.find('.chat-textarea').element.value).toBe('git status')
   })
 })
+
+describe('ChatInputBar — quick-send click sends directly', () => {
+  it('emits send when handleQuickSendClick is called', async () => {
+    const wrapper = mountInputBar()
+    const item = { id: 1, label: 'Git Status', command: 'git status' }
+    wrapper.vm.handleQuickSendClick(item)
+    await nextTick()
+
+    expect(wrapper.emitted('send')).toBeTruthy()
+    expect(wrapper.emitted('send')[0]).toEqual(['git status'])
+  })
+
+  it('suppresses click when long-press was just triggered', async () => {
+    vi.useFakeTimers()
+    const wrapper = mountInputBar()
+    const item = { id: 1, label: 'Git Status', command: 'git status' }
+    const touchEvent = { touches: [{ clientX: 50, clientY: 50 }] }
+
+    // Start touch and let long-press fire
+    wrapper.vm.onQuickSendTouchStart(item, touchEvent)
+    vi.advanceTimersByTime(500)
+    await nextTick()
+
+    // Long-press injects into input, not send
+    expect(wrapper.find('.chat-textarea').element.value).toBe('git status')
+
+    // Now the click after long-press should be suppressed
+    wrapper.vm.handleQuickSendClick(item)
+    await nextTick()
+
+    // Should still only have the injected input, no new send emission
+    expect(wrapper.emitted('send')).toBeFalsy()
+    vi.useRealTimers()
+  })
+})
+
+describe('ChatInputBar — quick-send touch events', () => {
+  it('onQuickSendTouchStart sets pressing state', async () => {
+    const wrapper = mountInputBar()
+    const item = { id: 1, label: 'Git Status', command: 'git status' }
+    const touchEvent = { touches: [{ clientX: 100, clientY: 200 }] }
+    wrapper.vm.onQuickSendTouchStart(item, touchEvent)
+    await nextTick()
+
+    expect(wrapper.vm.quickSendPressingId).toBe(1)
+  })
+
+  it('onQuickSendTouchEnd short tap emits send', async () => {
+    vi.useFakeTimers()
+    const wrapper = mountInputBar()
+    const item = { id: 2, label: 'Build', command: 'npm run build' }
+    const touchEvent = { touches: [{ clientX: 50, clientY: 50 }] }
+
+    // Start touch
+    wrapper.vm.onQuickSendTouchStart(item, touchEvent)
+    // Immediately end (short tap, no long-press timer fires)
+    wrapper.vm.onQuickSendTouchEnd()
+    await nextTick()
+
+    expect(wrapper.emitted('send')).toBeTruthy()
+    expect(wrapper.emitted('send')[0]).toEqual(['npm run build'])
+    expect(wrapper.vm.quickSendPressingId).toBeNull()
+    vi.useRealTimers()
+  })
+
+  it('onQuickSendTouchEnd long-press triggers injectToInput', async () => {
+    vi.useFakeTimers()
+    const wrapper = mountInputBar()
+    const item = { id: 3, label: 'Test', command: 'npm test' }
+    const touchEvent = { touches: [{ clientX: 50, clientY: 50 }] }
+
+    // Start touch
+    wrapper.vm.onQuickSendTouchStart(item, touchEvent)
+    // Advance timer past long-press threshold
+    vi.advanceTimersByTime(500)
+    await nextTick()
+
+    // Long-press should have injected into input (not sent)
+    expect(wrapper.find('.chat-textarea').element.value).toBe('npm test')
+    expect(wrapper.emitted('send')).toBeFalsy()
+
+    // End touch after long-press
+    wrapper.vm.onQuickSendTouchEnd()
+    await nextTick()
+
+    expect(wrapper.vm.quickSendPressingId).toBeNull()
+    vi.useRealTimers()
+  })
+
+  it('onQuickSendTouchMove cancels press when finger moves beyond threshold', async () => {
+    vi.useFakeTimers()
+    const wrapper = mountInputBar()
+    const item = { id: 4, label: 'Lint', command: 'npm run lint' }
+    const touchEvent = { touches: [{ clientX: 50, clientY: 50 }] }
+
+    wrapper.vm.onQuickSendTouchStart(item, touchEvent)
+    expect(wrapper.vm.quickSendPressingId).toBe(4)
+
+    // Move finger beyond 10px
+    const moveEvent = { touches: [{ clientX: 70, clientY: 50 }] }
+    wrapper.vm.onQuickSendTouchMove(moveEvent)
+
+    expect(wrapper.vm.quickSendPressingId).toBeNull()
+    // Advance timer — should NOT trigger long-press since cancelled
+    vi.advanceTimersByTime(500)
+    await nextTick()
+
+    // No send or inject should have happened
+    expect(wrapper.emitted('send')).toBeFalsy()
+    expect(wrapper.find('.chat-textarea').element.value).toBe('')
+    vi.useRealTimers()
+  })
+
+  it('onQuickSendTouchMove does not cancel when finger moves within threshold', async () => {
+    vi.useFakeTimers()
+    const wrapper = mountInputBar()
+    const item = { id: 5, label: 'Deploy', command: 'npm run deploy' }
+    const touchEvent = { touches: [{ clientX: 50, clientY: 50 }] }
+
+    wrapper.vm.onQuickSendTouchStart(item, touchEvent)
+    expect(wrapper.vm.quickSendPressingId).toBe(5)
+
+    // Small move within 10px threshold
+    const moveEvent = { touches: [{ clientX: 55, clientY: 53 }] }
+    wrapper.vm.onQuickSendTouchMove(moveEvent)
+
+    expect(wrapper.vm.quickSendPressingId).toBe(5)
+    vi.useRealTimers()
+  })
+
+  it('cancelQuickSendPress clears all press state', async () => {
+    const wrapper = mountInputBar()
+    const item = { id: 6, label: 'Clean', command: 'npm run clean' }
+    const touchEvent = { touches: [{ clientX: 50, clientY: 50 }] }
+
+    wrapper.vm.onQuickSendTouchStart(item, touchEvent)
+    expect(wrapper.vm.quickSendPressingId).toBe(6)
+
+    wrapper.vm.cancelQuickSendPress()
+    expect(wrapper.vm.quickSendPressingId).toBeNull()
+  })
+
+  it('onQuickSendTouchMove returns early when no press active', () => {
+    const wrapper = mountInputBar()
+    // No press active — should not throw
+    const moveEvent = { touches: [{ clientX: 100, clientY: 100 }] }
+    expect(() => wrapper.vm.onQuickSendTouchMove(moveEvent)).not.toThrow()
+  })
+})

--- a/web/src/components/chat/ChatInputBar.vue
+++ b/web/src/components/chat/ChatInputBar.vue
@@ -138,7 +138,7 @@
       </PopupMenu>
       <!-- Teleported quick-send menu -->
       <PopupMenu v-model:show="showQuickMenu" :target-element="sendBtnRef" :max-width="260" :max-height="280" :menu-items-count="quickSendItems.length + 1">
-        <div class="quick-send-title">{{ t('chat.quickSend.tapToFill') }}</div>
+        <div class="quick-send-title">{{ t('chat.quickSend.title') }}</div>
         <button v-for="item in quickSendItems" :key="item.id"
           class="quick-send-item"
           :class="{ 'qs-pressing': quickSendPressingId === item.id }"
@@ -517,14 +517,14 @@ let quickSendTouchStartPos = { x: 0, y: 0 }
 let quickSendCurrentItem = null
 
 function handleQuickSendClick(item) {
-  // Desktop: click directly injects into input box
-  // Mobile: click is suppressed by touchstart.prevent; inject is handled in onQuickSendTouchEnd
+  // Desktop: click directly sends
+  // Mobile: click is suppressed by touchstart.prevent; send is handled in onQuickSendTouchEnd
   if (quickSendJustTriggered) {
     quickSendJustTriggered = false
     return
   }
-  injectToInput(item.command)
   showQuickMenu.value = false
+  emit('send', item.command)
 }
 
 function injectToInput(text) {
@@ -545,12 +545,12 @@ function onQuickSendTouchStart(item, e) {
 
   quickSendPressTimer = setTimeout(() => {
     if (!quickSendMoved && quickSendPressingId.value === item.id) {
-      // Long-press triggered → emit send directly
+      // Long-press triggered → inject into input box
       quickSendJustTriggered = true
       quickSendPressingId.value = null
       quickSendCurrentItem = null
+      injectToInput(item.command)
       showQuickMenu.value = false
-      emit('send', item.command)
     }
   }, QUICK_SEND_LONG_PRESS_MS)
 }
@@ -571,13 +571,13 @@ function onQuickSendTouchEnd() {
     clearTimeout(quickSendPressTimer)
     quickSendPressTimer = null
   }
-  // Short tap (no long-press triggered): inject into input box directly
+  // Short tap (no long-press triggered): send directly
   if (quickSendPressingId.value !== null && !quickSendJustTriggered && quickSendCurrentItem) {
     const item = quickSendCurrentItem
     quickSendCurrentItem = null
     quickSendPressingId.value = null
-    injectToInput(item.command)
     showQuickMenu.value = false
+    emit('send', item.command)
   } else {
     quickSendPressingId.value = null
     quickSendCurrentItem = null
@@ -1278,12 +1278,12 @@ defineExpose({
   color: #fff;
 }
 
-/* Quick-send: pressing state → subtle accent tint hints at long-press */
+/* Quick-send: pressing state → subtle accent tint hints at long-press (fills input) */
 .quick-send-item.qs-pressing {
   background: color-mix(in srgb, var(--accent-color, #0066cc) 12%, transparent);
 }
 
-/* Quick-send: progressive fill bar → animates from left to right during long-press */
+/* Quick-send: progressive fill bar → long-press fills input box instead of sending */
 .qs-fill-bar {
   position: absolute;
   left: 0;

--- a/web/src/components/chat/ChatInputBar.vue
+++ b/web/src/components/chat/ChatInputBar.vue
@@ -636,6 +636,13 @@ defineExpose({
   clearInput,
   inputText,
   deleteDraft: (sessionId) => { draftCache.delete(sessionId) },
+  injectToInput,
+  handleQuickSendClick,
+  onQuickSendTouchStart,
+  onQuickSendTouchMove,
+  onQuickSendTouchEnd,
+  cancelQuickSendPress,
+  quickSendPressingId,
 })
 </script>
 

--- a/web/src/components/chat/ChatInputBar.vue
+++ b/web/src/components/chat/ChatInputBar.vue
@@ -138,9 +138,19 @@
       </PopupMenu>
       <!-- Teleported quick-send menu -->
       <PopupMenu v-model:show="showQuickMenu" :target-element="sendBtnRef" :max-width="260" :max-height="280" :menu-items-count="quickSendItems.length + 1">
-        <div class="quick-send-title">{{ t('chat.quickSend.title') }}</div>
-        <button v-for="item in quickSendItems" :key="item.id" class="quick-send-item" @click="handleQuickSend(item.command)">
+        <div class="quick-send-title">{{ t('chat.quickSend.tapToFill') }}</div>
+        <button v-for="item in quickSendItems" :key="item.id"
+          class="quick-send-item"
+          :class="{ 'qs-pressing': quickSendPressingId === item.id }"
+          @click="handleQuickSendClick(item)"
+          @touchstart.prevent="onQuickSendTouchStart(item, $event)"
+          @touchmove="onQuickSendTouchMove"
+          @touchend="onQuickSendTouchEnd"
+          @touchcancel="onQuickSendTouchEnd"
+          @contextmenu.prevent
+        >
           {{ item.label }}
+          <div v-if="quickSendPressingId === item.id" class="qs-fill-bar" />
         </button>
         <div class="quick-send-divider" />
         <button class="quick-send-item" @click="showQuickMenu = false; quickSendStore.showEditDialog.value = true">
@@ -497,8 +507,90 @@ function handleSendClick() {
   }
 }
 
-function handleQuickSend(text) {
-  emit('send', text)
+// — Quick-send long-press →
+const QUICK_SEND_LONG_PRESS_MS = 500
+const quickSendPressingId = ref(null)
+let quickSendPressTimer = null
+let quickSendMoved = false
+let quickSendJustTriggered = false
+let quickSendTouchStartPos = { x: 0, y: 0 }
+let quickSendCurrentItem = null
+
+function handleQuickSendClick(item) {
+  // Desktop: click directly injects into input box
+  // Mobile: click is suppressed by touchstart.prevent; inject is handled in onQuickSendTouchEnd
+  if (quickSendJustTriggered) {
+    quickSendJustTriggered = false
+    return
+  }
+  injectToInput(item.command)
+  showQuickMenu.value = false
+}
+
+function injectToInput(text) {
+  const current = inputText.value.trim()
+  inputText.value = current ? current + '\n' + text : text
+  nextTick(() => {
+    textareaRef.value?.focus()
+  })
+}
+
+function onQuickSendTouchStart(item, e) {
+  quickSendMoved = false
+  quickSendJustTriggered = false
+  quickSendCurrentItem = item
+  const touch = e.touches[0]
+  quickSendTouchStartPos = { x: touch.clientX, y: touch.clientY }
+  quickSendPressingId.value = item.id
+
+  quickSendPressTimer = setTimeout(() => {
+    if (!quickSendMoved && quickSendPressingId.value === item.id) {
+      // Long-press triggered → emit send directly
+      quickSendJustTriggered = true
+      quickSendPressingId.value = null
+      quickSendCurrentItem = null
+      showQuickMenu.value = false
+      emit('send', item.command)
+    }
+  }, QUICK_SEND_LONG_PRESS_MS)
+}
+
+function onQuickSendTouchMove(e) {
+  if (!quickSendPressingId.value) return
+  const touch = e.touches[0]
+  const dx = touch.clientX - quickSendTouchStartPos.x
+  const dy = touch.clientY - quickSendTouchStartPos.y
+  if (Math.abs(dx) > 10 || Math.abs(dy) > 10) {
+    quickSendMoved = true
+    cancelQuickSendPress()
+  }
+}
+
+function onQuickSendTouchEnd() {
+  if (quickSendPressTimer) {
+    clearTimeout(quickSendPressTimer)
+    quickSendPressTimer = null
+  }
+  // Short tap (no long-press triggered): inject into input box directly
+  if (quickSendPressingId.value !== null && !quickSendJustTriggered && quickSendCurrentItem) {
+    const item = quickSendCurrentItem
+    quickSendCurrentItem = null
+    quickSendPressingId.value = null
+    injectToInput(item.command)
+    showQuickMenu.value = false
+  } else {
+    quickSendPressingId.value = null
+    quickSendCurrentItem = null
+  }
+}
+
+function cancelQuickSendPress() {
+  if (quickSendPressTimer) {
+    clearTimeout(quickSendPressTimer)
+    quickSendPressTimer = null
+  }
+  quickSendPressingId.value = null
+  quickSendCurrentItem = null
 }
 
 function toggleQuickMenu() {
@@ -525,6 +617,10 @@ onMounted(() => {
 
 onBeforeUnmount(() => {
   clearTimeout(stopPrimeTimer)
+  if (quickSendPressTimer) {
+    clearTimeout(quickSendPressTimer)
+    quickSendPressTimer = null
+  }
   stopPlaceholderRotation()
 })
 
@@ -1173,6 +1269,8 @@ defineExpose({
   cursor: pointer;
   text-align: left;
   transition: background 0.12s, color 0.12s;
+  position: relative;
+  overflow: hidden;
 }
 
 .quick-send-item:hover {
@@ -1180,6 +1278,26 @@ defineExpose({
   color: #fff;
 }
 
+/* Quick-send: pressing state → subtle accent tint hints at long-press */
+.quick-send-item.qs-pressing {
+  background: color-mix(in srgb, var(--accent-color, #0066cc) 12%, transparent);
+}
+
+/* Quick-send: progressive fill bar → animates from left to right during long-press */
+.qs-fill-bar {
+  position: absolute;
+  left: 0;
+  bottom: 0;
+  height: 3px;
+  background: var(--accent-color, #0066cc);
+  border-radius: 0 2px 2px 0;
+  animation: qs-fill 500ms linear forwards;
+}
+
+@keyframes qs-fill {
+  from { width: 0; }
+  to { width: 100%; }
+}
 .quick-send-divider {
   height: 1px;
   background: var(--border-color, #e5e5e5);

--- a/web/src/i18n/locales/en.ts
+++ b/web/src/i18n/locales/en.ts
@@ -82,7 +82,7 @@ export default {
       placeholder: 'Type a message...',
       placeholderQueue: 'Type a message to enqueue...',
       placeholderOptional: 'Add description (optional)...',
-      placeholderQuickSend: 'Tap ⚡ to send preset commands →',
+      placeholderQuickSend: 'Tap ⚡ for quick commands →',
       placeholderAtCommand: "Type {'@'} for built-in commands",
       send: 'Send',
       enqueue: 'Enqueue',
@@ -147,6 +147,7 @@ export default {
     },
     quickSend: {
       title: 'Quick send',
+      tapToFill: 'Hold to send',
       edit: 'Edit',
       addItem: 'Add item',
       editItem: 'Edit item',

--- a/web/src/i18n/locales/zh.ts
+++ b/web/src/i18n/locales/zh.ts
@@ -82,7 +82,7 @@ export default {
       placeholder: '输入消息...',
       placeholderQueue: '输入消息加入队列...',
       placeholderOptional: '添加描述（可选）...',
-      placeholderQuickSend: '点击⚡按钮，发送预设指令 →',
+      placeholderQuickSend: '点击⚡选指令 →',
       placeholderAtCommand: "输入 {'@'} 执行内置命令",
       send: '发送',
       enqueue: '加入队列',
@@ -147,6 +147,7 @@ export default {
     },
     quickSend: {
       title: '快捷发送',
+      tapToFill: '长按发送',
       edit: '编辑',
       addItem: '添加项目',
       editItem: '编辑项目',

--- a/web/src/main.ts
+++ b/web/src/main.ts
@@ -4,7 +4,6 @@ import i18n from './i18n'
 import { marked, hljs } from './utils/globals.ts'
 import { slugify } from './utils/toc.ts'
 import { escapeHtml } from './utils/html.ts'
-import { buildCodeLinesFromHighlighted, buildCodeLinesFromEscaped } from './utils/codeRender.ts'
 
 // Configure marked (moved from inline script in index.html)
 marked.use({
@@ -21,16 +20,22 @@ marked.use({
             if (lang === 'mermaid') {
                 return '<pre class="mermaid">' + escapeHtml(code) + '</pre>'
             }
-            // Per-line structure with line numbers (same as CodePreview)
+            // Fast path: known language → direct highlight (cheap)
+            // Per-line rendering with line numbers is only used by CodePreview
+            // (see codeRender.ts) — chat messages don't need line numbers
+            // and the per-line split is ~250x slower than a simple wrap,
+            // which causes the main thread to freeze on sessions with many
+            // code blocks (e.g. 124 blocks in a single session).
             if (lang && hljs.getLanguage(lang)) {
                 const highlighted = hljs.highlight(code, { language: lang, ignoreIllegals: true }).value
-                const lines = buildCodeLinesFromHighlighted(highlighted)
-                return '<pre class="code-block-pre" data-language="' + lang + '"><code>' + lines + '</code></pre>'
+                return '<pre><code class="language-' + lang + '">' + highlighted + '</code></pre>'
             }
-            // Unknown language: escape and split into lines
-            const lines = buildCodeLinesFromEscaped(escapeHtml(code))
-            const langAttr = lang ? ' data-language="' + lang + '"' : ''
-            return '<pre class="code-block-pre"' + langAttr + '><code>' + lines + '</code></pre>'
+            // No language or unknown language: escapeHtml only.
+            // highlightAuto() is extremely expensive (tries all ~190 languages)
+            // and the result is rarely useful for chat messages — it causes
+            // significant jank on pages with many code blocks.
+            const langClass = lang ? ' class="language-' + lang + '"' : ''
+            return '<pre><code' + langClass + '>' + escapeHtml(code) + '</code></pre>'
         },
     },
 })


### PR DESCRIPTION
## Changes

### Quick-send interaction upgrade

- **Tap/click** quick-send item → send command directly (unchanged behavior)
- **Long-press** (500ms) quick-send item → inject command text into input box for editing before sending
- **Progressive fill bar** animation at button bottom hints at long-press during hold
- **Pressing state** shows subtle accent tint background (12% opacity)
- Desktop: click directly sends; mobile: touch events handle tap/long-press distinction
- `@touchstart.prevent` prevents 300ms delay and system context menu

### Other fixes in this branch

- **fix: 大session加载卡死** — marked code renderer reverts to simple wrapping, avoiding per-line split that freezes main thread on sessions with many code blocks

### Files changed

| File | Change |
|------|--------|
| `web/src/components/chat/ChatInputBar.vue` | Template + script + CSS for long-press |
| `web/src/components/__tests__/chatInputBar.test.ts` | Add injectToInput tests |
| `web/src/i18n/locales/en.ts` | Update placeholderQuickSend |
| `web/src/i18n/locales/zh.ts` | Update placeholderQuickSend |
| `web/src/main.ts` | Fix: simple code wrapping instead of per-line |