### PR TITLE
fix: preserve blank line height when line numbers are hidden

### DIFF
--- a/web/css/code-block.css
+++ b/web/css/code-block.css
@@ -73,6 +73,10 @@ pre.code-block-pre code {
     padding-right: 8px;
 }
 
+.no-line-num .code-line {
+    min-height: 1.6em;
+}
+
 /* ─── Word-wrap mode ─── */
 .word-wrap .code-line {
     align-items: stretch;


### PR DESCRIPTION
## Problem

When line numbers are hidden in CodePreview, blank/empty lines disappear entirely because the `.code-line` flex row collapses to 0px height.

**Root cause:** With line numbers visible, the `.line-num` span provides implicit height (text content + line-height: 1.6) even when `.code-text` is empty. When line numbers are hidden, `.line-num` is omitted, and an empty `.code-text` has zero content height, causing the row to collapse.

## Fix

Add `min-height: 1.6em` to `.no-line-num .code-line` in `web/css/code-block.css`, matching the `line-height: 1.6` of the parent `<pre>` element. This ensures blank lines always occupy one line of height regardless of line number visibility.

## Test Plan

- [x] Frontend coverage gate PASSED (Tier 1 + Tier 2)
- [x] Go coverage gate PASSED (Tier 1 + Tier 2)
- [ ] Manual: open a code file in CodePreview, toggle line numbers off, verify blank lines remain visible