### PR TITLE
fix: sticky scroll position detection & dedup spurious symbols

### DIFF
--- a/internal/symbol/dedup_test.go
+++ b/internal/symbol/dedup_test.go
@@ -1,0 +1,58 @@
+package symbol
+
+import (
+	"testing"
+)
+
+func TestExtractSymbols_GoDedup(t *testing.T) {
+	// Go's inferred tags query produces duplicate definitions on the same line
+	// for functions with return types (e.g., func foo() error → "foo" + "error")
+	content := []byte(`package main
+
+func levelFromKind(kind string) int {
+	switch kind {
+	case "class":
+		return 1
+	default:
+		return 2
+	}
+}
+
+func InitDB() error {
+	return nil
+}
+`)
+
+	result := ExtractSymbols("test.go", content)
+
+	// Should NOT contain duplicate "int" or "error" symbols on the same lines as the functions
+	for _, sym := range result.Symbols {
+		if sym.Name == "int" || sym.Name == "error" {
+			t.Errorf("found spurious symbol %q on line %d — should have been deduplicated", sym.Name, sym.Line)
+		}
+	}
+
+	// Should contain the actual functions
+	foundLevel := false
+	foundInit := false
+	for _, sym := range result.Symbols {
+		if sym.Name == "levelFromKind" {
+			foundLevel = true
+			if sym.Line != 3 {
+				t.Errorf("levelFromKind line = %d, want 3", sym.Line)
+			}
+		}
+		if sym.Name == "InitDB" {
+			foundInit = true
+			if sym.Line != 12 {
+				t.Errorf("InitDB line = %d, want 12", sym.Line)
+			}
+		}
+	}
+	if !foundLevel {
+		t.Error("levelFromKind not found in symbols")
+	}
+	if !foundInit {
+		t.Error("InitDB not found in symbols")
+	}
+}

--- a/internal/symbol/symbol.go
+++ b/internal/symbol/symbol.go
@@ -123,6 +123,13 @@ func ExtractSymbols(filename string, content []byte) SymbolResult {
 	tags := ct.tagger.Tag(content)
 	symbols := make([]Symbol, 0, len(tags))
 
+	// Deduplicate by start line: inferred tags queries (e.g., Go) may produce
+	// multiple definition.* tags on the same line with the same range, such as
+	// a function name and its return type both captured as "definition.function".
+	// When multiple definitions land on the same start line, keep only the first
+	// (tree-sitter returns the actual name before overlapping matches like return types).
+	seenLines := make(map[int]bool, len(tags))
+
 	for _, tag := range tags {
 		// Only keep definition.* tags
 		kind := tag.Kind
@@ -141,10 +148,16 @@ func ExtractSymbols(filename string, content []byte) SymbolResult {
 			continue
 		}
 
+		line := int(tag.Range.StartPoint.Row) + 1
+		if seenLines[line] {
+			continue
+		}
+		seenLines[line] = true
+
 		symbols = append(symbols, Symbol{
 			Name:    tag.Name,
 			Kind:    displayKind,
-			Line:    int(tag.Range.StartPoint.Row) + 1,
+			Line:    line,
 			EndLine: int(tag.Range.EndPoint.Row) + 1,
 			Level:   levelFromKind(displayKind),
 		})

--- a/web/src/composables/__tests__/useStickyScroll.test.ts
+++ b/web/src/composables/__tests__/useStickyScroll.test.ts
@@ -42,7 +42,7 @@ describe('useStickyScroll - DOM integration', () => {
 
   async function createTestComponent() {
     const { mount } = await import('@vue/test-utils')
-    const { defineComponent, h, ref } = await import('vue')
+    const { defineComponent, h } = await import('vue')
 
     const TestComponent = defineComponent({
       setup() {
@@ -57,15 +57,47 @@ describe('useStickyScroll - DOM integration', () => {
     return mount(TestComponent)
   }
 
+  /**
+   * Create a mock scroll element that uses getBoundingClientRect for position checks.
+   *
+   * Each line element has:
+   * - getBoundingClientRect() → returns { top, height } in viewport coordinates
+   *
+   * The scroll container has:
+   * - getBoundingClientRect() → returns { top } representing the visible area's top edge
+   *
+   * To simulate scrolling, we adjust line rect tops by subtracting a scroll offset.
+   * When scrollTop=100, each line's rect.top decreases by 100.
+   */
   function createMockScrollEl(overrides = {}) {
     return {
+      querySelector: vi.fn().mockReturnValue({ querySelectorAll: vi.fn().mockReturnValue([]) }),
       querySelectorAll: vi.fn().mockReturnValue([]),
       addEventListener: vi.fn(),
       removeEventListener: vi.fn(),
       scrollTop: 0,
       scrollLeft: 0,
+      getBoundingClientRect: () => ({ top: 0 }),
       ...overrides,
     }
+  }
+
+  /**
+   * Create mock line elements with viewport-relative rect positions.
+   * @param lineCount - number of lines
+   * @param lineHeight - height per line (default 20.8)
+   * @param scrollOffset - simulated scroll offset (shifts all rect.tops up by this amount)
+   * @param baseTop - initial top position before scroll (e.g., containerTop offset)
+   */
+  function createMockLineEls(lineCount, lineHeight = 20.8, scrollOffset = 0, baseTop = 0) {
+    return Array.from({ length: lineCount }, (_, i) => ({
+      getBoundingClientRect: () => ({
+        top: baseTop + i * lineHeight - scrollOffset,
+        height: lineHeight,
+      }),
+      classList: { add: vi.fn(), remove: vi.fn() },
+      scrollIntoView: vi.fn(),
+    }))
   }
 
   it('initSticky calls fetchCodeSymbols with filePath', async () => {
@@ -156,7 +188,6 @@ describe('useStickyScroll - DOM integration', () => {
   })
 
   it('updates stickyLines with correct top/height when scrolled past scope definitions', async () => {
-    // Simulate a file with a function on line 1 (endLine 10) and a nested function on line 3 (endLine 8)
     mockFetchCodeSymbols.mockResolvedValue({
       symbols: [
         { name: 'main', kind: 'function', line: 1, endLine: 10, level: 1 },
@@ -166,43 +197,32 @@ describe('useStickyScroll - DOM integration', () => {
 
     const wrapper = await createTestComponent()
 
-    // Create mock line elements with offsetTop and getBoundingClientRect
-    const createMockLineEl = (offsetTop: number, height: number) => ({
-      offsetTop,
-      getBoundingClientRect: () => ({ height }),
-      classList: { add: vi.fn(), remove: vi.fn() },
-      scrollIntoView: vi.fn(),
-    })
+    // 20 lines, scrolled 100px. Container top = 0.
+    // Line 1 rect.top = 0 - 100 = -100 (above container, scrolled out)
+    // Line 3 rect.top = 2*20.8 - 100 = -58.4 (above container, scrolled out)
+    // Line 6 rect.top = 5*20.8 - 100 = 4.0 (first visible line)
+    const lineEls = createMockLineEls(20, 20.8, 100)
 
-    const lineEls = [
-      createMockLineEl(0, 20.8),     // line 1
-      createMockLineEl(20.8, 20.8),  // line 2
-      createMockLineEl(41.6, 20.8),  // line 3
-      createMockLineEl(62.4, 20.8),  // line 4
-      createMockLineEl(83.2, 20.8),  // line 5
-      createMockLineEl(104, 20.8),   // line 6
-    ]
-
+    const mockCodeEl = { querySelectorAll: vi.fn().mockReturnValue(lineEls) }
     const mockEl = createMockScrollEl({
-      scrollTop: 100, // scrolled past line 1 (offsetTop=0) and line 3 (offsetTop=41.6)
-      querySelectorAll: vi.fn().mockReturnValue(lineEls),
+      querySelector: vi.fn().mockReturnValue(mockCodeEl),
+      getBoundingClientRect: () => ({ top: 0 }),
     })
 
     wrapper.vm.initSticky('/tmp/test.go', mockEl)
     await wrapper.vm.$nextTick()
     await wrapper.vm.$nextTick()
 
-    // After init, scroll handler should be attached. Trigger a scroll event.
     const scrollHandler = mockEl.addEventListener.mock.calls[0][1]
     scrollHandler()
     await wrapper.vm.$nextTick()
 
-    // Both main (line 1) and helper (line 3) should be sticky since
-    // we scrolled past both (scrollTop=100 > offsetTop of line1=0 and line3=41.6)
+    // Both main (line 1, rect.top=-100 < containerTop=0) and
+    // helper (line 3, rect.top=-58.4 < containerTop=0) should be sticky
     expect(wrapper.vm.stickyLines.length).toBe(2)
-    expect(wrapper.vm.stickyLines[0].top).toBe(0) // first sticky line at top=0
-    expect(wrapper.vm.stickyLines[0].height).toBe(20.8) // actual DOM height
-    expect(wrapper.vm.stickyLines[1].top).toBe(20.8) // accumulated height
+    expect(wrapper.vm.stickyLines[0].top).toBe(0)
+    expect(wrapper.vm.stickyLines[0].height).toBe(20.8)
+    expect(wrapper.vm.stickyLines[1].top).toBe(20.8)
     expect(wrapper.vm.stickyLines[1].height).toBe(20.8)
 
     wrapper.unmount()
@@ -217,16 +237,17 @@ describe('useStickyScroll - DOM integration', () => {
 
     const wrapper = await createTestComponent()
 
-    // In word-wrap mode, line 1 is wrapped and taller (41.6px instead of 20.8px)
+    // Line 1 wrapped (height 41.6px), scrolled 50px
     const lineEls = [
-      { offsetTop: 0, getBoundingClientRect: () => ({ height: 41.6 }), classList: { add: vi.fn(), remove: vi.fn() }, scrollIntoView: vi.fn() },
-      { offsetTop: 41.6, getBoundingClientRect: () => ({ height: 20.8 }), classList: { add: vi.fn(), remove: vi.fn() }, scrollIntoView: vi.fn() },
-      { offsetTop: 62.4, getBoundingClientRect: () => ({ height: 20.8 }), classList: { add: vi.fn(), remove: vi.fn() }, scrollIntoView: vi.fn() },
+      { getBoundingClientRect: () => ({ top: 0 - 50, height: 41.6 }), classList: { add: vi.fn(), remove: vi.fn() }, scrollIntoView: vi.fn() },
+      { getBoundingClientRect: () => ({ top: 41.6 - 50, height: 20.8 }), classList: { add: vi.fn(), remove: vi.fn() }, scrollIntoView: vi.fn() },
+      { getBoundingClientRect: () => ({ top: 62.4 - 50, height: 20.8 }), classList: { add: vi.fn(), remove: vi.fn() }, scrollIntoView: vi.fn() },
     ]
 
+    const mockCodeEl = { querySelectorAll: vi.fn().mockReturnValue(lineEls) }
     const mockEl = createMockScrollEl({
-      scrollTop: 50, // scrolled past line 1
-      querySelectorAll: vi.fn().mockReturnValue(lineEls),
+      querySelector: vi.fn().mockReturnValue(mockCodeEl),
+      getBoundingClientRect: () => ({ top: 0 }),
     })
 
     wrapper.vm.initSticky('/tmp/test.go', mockEl)
@@ -238,7 +259,7 @@ describe('useStickyScroll - DOM integration', () => {
     await wrapper.vm.$nextTick()
 
     expect(wrapper.vm.stickyLines.length).toBe(1)
-    expect(wrapper.vm.stickyLines[0].height).toBe(41.6) // wrapped line height
+    expect(wrapper.vm.stickyLines[0].height).toBe(41.6)
     expect(wrapper.vm.stickyLines[0].top).toBe(0)
 
     wrapper.unmount()
@@ -253,13 +274,13 @@ describe('useStickyScroll - DOM integration', () => {
 
     const wrapper = await createTestComponent()
 
-    const lineEls = [
-      { offsetTop: 0, getBoundingClientRect: () => ({ height: 20.8 }), classList: { add: vi.fn(), remove: vi.fn() }, scrollIntoView: vi.fn() },
-    ]
+    // No scrolling — line 1 rect.top = 0, containerTop = 0 → line is visible, not sticky
+    const lineEls = createMockLineEls(10, 20.8, 0)
 
+    const mockCodeEl = { querySelectorAll: vi.fn().mockReturnValue(lineEls) }
     const mockEl = createMockScrollEl({
-      scrollTop: 0, // not scrolled at all — definition line still visible
-      querySelectorAll: vi.fn().mockReturnValue(lineEls),
+      querySelector: vi.fn().mockReturnValue(mockCodeEl),
+      getBoundingClientRect: () => ({ top: 0 }),
     })
 
     wrapper.vm.initSticky('/tmp/test.go', mockEl)
@@ -270,39 +291,8 @@ describe('useStickyScroll - DOM integration', () => {
     scrollHandler()
     await wrapper.vm.$nextTick()
 
-    // Line 1 offsetTop (0) is NOT less than scrollTop (0), so no sticky lines
+    // Line 1 rect.top (0) is NOT less than containerTop (0), so no sticky lines
     expect(wrapper.vm.stickyLines.length).toBe(0)
-
-    wrapper.unmount()
-  })
-
-  it('clears stickyLines when scrolled to top and no scopes are out of view', async () => {
-    mockFetchCodeSymbols.mockResolvedValue({
-      symbols: [
-        { name: 'main', kind: 'function', line: 1, endLine: 10, level: 1 },
-      ],
-    })
-
-    const wrapper = await createTestComponent()
-
-    const lineEls = [
-      { offsetTop: 0, getBoundingClientRect: () => ({ height: 20.8 }), classList: { add: vi.fn(), remove: vi.fn() }, scrollIntoView: vi.fn() },
-    ]
-
-    const mockEl = createMockScrollEl({
-      scrollTop: 0,
-      querySelectorAll: vi.fn().mockReturnValue(lineEls),
-    })
-
-    wrapper.vm.initSticky('/tmp/test.go', mockEl)
-    await wrapper.vm.$nextTick()
-    await wrapper.vm.$nextTick()
-
-    const scrollHandler = mockEl.addEventListener.mock.calls[0][1]
-    scrollHandler()
-    await wrapper.vm.$nextTick()
-
-    expect(wrapper.vm.stickyLines).toEqual([])
 
     wrapper.unmount()
   })
@@ -315,16 +305,14 @@ describe('useStickyScroll - DOM integration', () => {
     const wrapper = await createTestComponent()
 
     const mockCodeText = { style: { transform: '' } }
-    const lineEls = [
-      { offsetTop: 0, getBoundingClientRect: () => ({ height: 20.8 }), classList: { add: vi.fn(), remove: vi.fn() }, scrollIntoView: vi.fn() },
-    ]
+    const lineEls = createMockLineEls(10, 20.8, 100)
 
+    const mockCodeEl = { querySelectorAll: vi.fn().mockReturnValue(lineEls) }
     const mockEl = createMockScrollEl({
-      scrollTop: 100,
       scrollLeft: 50,
-      querySelectorAll: vi.fn()
-        .mockReturnValueOnce(lineEls) // first call for code-line
-        .mockReturnValueOnce([mockCodeText]), // second call for .sticky-code-text
+      querySelector: vi.fn().mockReturnValue(mockCodeEl),
+      querySelectorAll: vi.fn().mockReturnValueOnce([mockCodeText]),
+      getBoundingClientRect: () => ({ top: 0 }),
     })
 
     wrapper.vm.initSticky('/tmp/test.go', mockEl)
@@ -335,8 +323,212 @@ describe('useStickyScroll - DOM integration', () => {
     scrollHandler()
     await wrapper.vm.$nextTick()
 
-    // The code-text element should have its transform updated
     expect(mockCodeText.style.transform).toBe('translateX(-50px)')
+
+    wrapper.unmount()
+  })
+
+  it('deduplicates symbols on the same line (e.g., Go return types)', async () => {
+    mockFetchCodeSymbols.mockResolvedValue({
+      symbols: [
+        { name: 'foo', kind: 'function', line: 1, endLine: 10, level: 2 },
+        { name: 'error', kind: 'function', line: 1, endLine: 10, level: 2 },
+        { name: 'bar', kind: 'function', line: 12, endLine: 20, level: 2 },
+      ],
+    })
+
+    const wrapper = await createTestComponent()
+
+    const lineEls = createMockLineEls(20, 20.8, 100)
+
+    const mockCodeEl = { querySelectorAll: vi.fn().mockReturnValue(lineEls) }
+    const mockEl = createMockScrollEl({
+      querySelector: vi.fn().mockReturnValue(mockCodeEl),
+      getBoundingClientRect: () => ({ top: 0 }),
+    })
+
+    wrapper.vm.initSticky('/tmp/test.go', mockEl)
+    await wrapper.vm.$nextTick()
+    await wrapper.vm.$nextTick()
+
+    const scrollHandler = mockEl.addEventListener.mock.calls[0][1]
+    scrollHandler()
+    await wrapper.vm.$nextTick()
+
+    // Only one sticky line for line 1 (deduplicated), not two
+    const lineNums = wrapper.vm.stickyLines.map(s => s.lineNum)
+    const line1Count = lineNums.filter(n => n === 1).length
+    expect(line1Count).toBe(1)
+
+    wrapper.unmount()
+  })
+
+  it('works correctly when scroll container has non-zero rect.top', async () => {
+    // Simulate a page where the scroll container starts at y=200 (e.g., below a header)
+    mockFetchCodeSymbols.mockResolvedValue({
+      symbols: [
+        { name: 'main', kind: 'function', line: 1, endLine: 10, level: 1 },
+      ],
+    })
+
+    const wrapper = await createTestComponent()
+
+    const containerTop = 200
+    // Lines start at containerTop, scrolled 30px
+    const lineEls = createMockLineEls(10, 20.8, 30, containerTop)
+
+    const mockCodeEl = { querySelectorAll: vi.fn().mockReturnValue(lineEls) }
+    const mockEl = createMockScrollEl({
+      querySelector: vi.fn().mockReturnValue(mockCodeEl),
+      getBoundingClientRect: () => ({ top: containerTop }),
+    })
+
+    wrapper.vm.initSticky('/tmp/test.go', mockEl)
+    await wrapper.vm.$nextTick()
+    await wrapper.vm.$nextTick()
+
+    const scrollHandler = mockEl.addEventListener.mock.calls[0][1]
+    scrollHandler()
+    await wrapper.vm.$nextTick()
+
+    // Line 1 rect.top = 200 - 30 = 170, which is < containerTop (200), so sticky
+    expect(wrapper.vm.stickyLines.length).toBe(1)
+    expect(wrapper.vm.stickyLines[0].lineNum).toBe(1)
+
+    wrapper.unmount()
+  })
+
+  it('sticky line disappears when definition line scrolls back into view', async () => {
+    mockFetchCodeSymbols.mockResolvedValue({
+      symbols: [
+        { name: 'main', kind: 'function', line: 1, endLine: 10, level: 1 },
+      ],
+    })
+
+    const wrapper = await createTestComponent()
+
+    // No scrolling — line 1 at containerTop, not above it
+    const lineEls = createMockLineEls(10, 20.8, 0)
+
+    const mockCodeEl = { querySelectorAll: vi.fn().mockReturnValue(lineEls) }
+    const mockEl = createMockScrollEl({
+      querySelector: vi.fn().mockReturnValue(mockCodeEl),
+      getBoundingClientRect: () => ({ top: 0 }),
+    })
+
+    wrapper.vm.initSticky('/tmp/test.go', mockEl)
+    await wrapper.vm.$nextTick()
+    await wrapper.vm.$nextTick()
+
+    const scrollHandler = mockEl.addEventListener.mock.calls[0][1]
+    scrollHandler()
+    await wrapper.vm.$nextTick()
+
+    expect(wrapper.vm.stickyLines.length).toBe(0)
+
+    wrapper.unmount()
+  })
+
+  it('clears stickyLines when scrollEl or symbols are empty', async () => {
+    mockFetchCodeSymbols.mockResolvedValue({
+      symbols: [{ name: 'main', kind: 'function', line: 1, endLine: 10, level: 1 }],
+    })
+
+    const wrapper = await createTestComponent()
+
+    // First init with symbols, scroll past definition
+    const lineEls = createMockLineEls(10, 20.8, 100)
+    const mockCodeEl = { querySelectorAll: vi.fn().mockReturnValue(lineEls) }
+    const mockEl = createMockScrollEl({
+      querySelector: vi.fn().mockReturnValue(mockCodeEl),
+      getBoundingClientRect: () => ({ top: 0 }),
+    })
+
+    wrapper.vm.initSticky('/tmp/test.go', mockEl)
+    await wrapper.vm.$nextTick()
+    await wrapper.vm.$nextTick()
+
+    const scrollHandler = mockEl.addEventListener.mock.calls[0][1]
+    scrollHandler()
+    await wrapper.vm.$nextTick()
+
+    // Should have sticky lines
+    expect(wrapper.vm.stickyLines.length).toBeGreaterThan(0)
+
+    // Now teardown — this sets scrollEl=null and symbols=[]
+    wrapper.vm.teardownSticky()
+
+    // stickyLines should be cleared (covers line 34-35)
+    expect(wrapper.vm.stickyLines).toEqual([])
+
+    wrapper.unmount()
+  })
+
+  it('sorts enclosing scopes with same width by line ascending', async () => {
+    // Two sibling functions with the same scope width — verify stable sort
+    mockFetchCodeSymbols.mockResolvedValue({
+      symbols: [
+        { name: 'foo', kind: 'function', line: 5, endLine: 15, level: 2 },
+        { name: 'bar', kind: 'function', line: 20, endLine: 30, level: 2 },
+        { name: 'baz', kind: 'function', line: 1, endLine: 11, level: 2 },
+      ],
+    })
+
+    const wrapper = await createTestComponent()
+
+    const lineEls = createMockLineEls(30, 20.8, 200)
+
+    const mockCodeEl = { querySelectorAll: vi.fn().mockReturnValue(lineEls) }
+    const mockEl = createMockScrollEl({
+      querySelector: vi.fn().mockReturnValue(mockCodeEl),
+      getBoundingClientRect: () => ({ top: 0 }),
+    })
+
+    wrapper.vm.initSticky('/tmp/test.go', mockEl)
+    await wrapper.vm.$nextTick()
+    await wrapper.vm.$nextTick()
+
+    const scrollHandler = mockEl.addEventListener.mock.calls[0][1]
+    scrollHandler()
+    await wrapper.vm.$nextTick()
+
+    // All three have same width (10 lines), so sorted by line ascending
+    const lineNums = wrapper.vm.stickyLines.map(s => s.lineNum)
+    for (let i = 1; i < lineNums.length; i++) {
+      expect(lineNums[i]).toBeGreaterThan(lineNums[i - 1])
+    }
+
+    wrapper.unmount()
+  })
+
+  it('uses requestAnimationFrame for scroll debouncing', async () => {
+    mockFetchCodeSymbols.mockResolvedValue({
+      symbols: [{ name: 'main', kind: 'function', line: 1, endLine: 10, level: 1 }],
+    })
+
+    const wrapper = await createTestComponent()
+
+    const lineEls = createMockLineEls(10, 20.8, 0)
+    const mockCodeEl = { querySelectorAll: vi.fn().mockReturnValue(lineEls) }
+    const mockEl = createMockScrollEl({
+      querySelector: vi.fn().mockReturnValue(mockCodeEl),
+      getBoundingClientRect: () => ({ top: 0 }),
+    })
+
+    wrapper.vm.initSticky('/tmp/test.go', mockEl)
+    await wrapper.vm.$nextTick()
+    await wrapper.vm.$nextTick()
+
+    const scrollHandler = mockEl.addEventListener.mock.calls[0][1]
+
+    // Call scrollHandler twice rapidly — second call should be skipped (rafId pending)
+    // This covers the rafId guard path (line 120)
+    scrollHandler()
+    scrollHandler() // should be a no-op since rafId is set
+
+    // Wait for RAF to complete
+    await new Promise(r => setTimeout(r, 50))
+    await wrapper.vm.$nextTick()
 
     wrapper.unmount()
   })

--- a/web/src/composables/useStickyScroll.ts
+++ b/web/src/composables/useStickyScroll.ts
@@ -6,6 +6,10 @@ import { fetchCodeSymbols } from '@/composables/useCodeSymbols'
  * When scrolling past a function/class definition, that definition line
  * sticks to the top of the code area so you always know which scope you're in.
  *
+ * Position detection uses getBoundingClientRect() for both the scroll container
+ * and line elements, giving viewport-relative coordinates that are correct
+ * regardless of CSS transforms, position:relative parents, or scroll offsets.
+ *
  * The overlay has min-width: max-content so sticky lines are always complete.
  * Line numbers use position:sticky;left:0 so they stay fixed during horizontal scroll.
  * Code text uses translateX(-scrollLeft) to follow horizontal scroll.
@@ -31,42 +35,60 @@ export function useStickyScroll() {
       return
     }
 
-    const scrollTop = scrollEl.scrollTop
+    // The container's visible top edge in viewport coordinates
+    const containerTop = scrollEl.getBoundingClientRect().top
 
-    // Find the first visible line number
-    let firstVisibleLine = -1
+    // Cache line elements on first call or after invalidation
     if (lineEls.length === 0) {
-      lineEls = Array.from(scrollEl.querySelectorAll(':scope > code > .code-line'))
+      const codeEl = scrollEl.querySelector(':scope > code')
+      if (!codeEl) return
+      lineEls = Array.from(codeEl.querySelectorAll(':scope > .code-line'))
       if (lineEls.length === 0) return
     }
 
+    // Find the first line whose top edge is at or below the container's top edge.
+    // getBoundingClientRect().top gives the viewport-relative position, which
+    // automatically accounts for scroll position, position:relative parents, etc.
+    let firstVisibleLine = -1
     for (let i = 0; i < lineEls.length; i++) {
-      if (lineEls[i].offsetTop >= scrollTop) {
+      const lineTop = lineEls[i].getBoundingClientRect().top
+      if (lineTop >= containerTop - 0.5) {  // 0.5px tolerance for sub-pixel rounding
         firstVisibleLine = i + 1
         break
       }
     }
     if (firstVisibleLine === -1) firstVisibleLine = lineEls.length
 
-    // Find all enclosing scopes that contain the first visible line
+    // Find all enclosing scopes that contain the first visible line.
+    // Deduplicate by line number — tree-sitter may return multiple symbols
+    // on the same line (e.g., Go return types like `func foo() error`
+    // produces both "foo" and "error" as definition.function on the same line).
     const enclosing = []
+    const seenLines = new Set()
     for (const sym of symbols) {
       if (sym.line <= firstVisibleLine && sym.endLine >= firstVisibleLine) {
-        enclosing.push(sym)
+        if (!seenLines.has(sym.line)) {
+          enclosing.push(sym)
+          seenLines.add(sym.line)
+        }
       }
     }
 
-    // Sort by scope width descending (outermost first)
-    enclosing.sort((a, b) => (b.endLine - b.line) - (a.endLine - a.line))
+    // Sort by scope width descending (outermost first), then by line ascending for stability
+    enclosing.sort((a, b) => {
+      const widthDiff = (b.endLine - b.line) - (a.endLine - a.line)
+      if (widthDiff !== 0) return widthDiff
+      return a.line - b.line
+    })
 
-    // Only keep scopes whose definition line is scrolled out of view.
-    // Compute actual pixel offsets and heights from DOM measurements.
+    // Only keep scopes whose definition line is scrolled out of view (above the container top).
     const result = []
     let accTop = 0
     for (let i = 0; i < enclosing.length && result.length < MAX_STICKY; i++) {
       const sym = enclosing[i]
       const defLineEl = lineEls[sym.line - 1]
-      if (defLineEl && defLineEl.offsetTop < scrollTop) {
+      // A line is "scrolled out of view" when its visual top is above the container's top edge
+      if (defLineEl && defLineEl.getBoundingClientRect().top < containerTop - 0.5) {
         const h = defLineEl.getBoundingClientRect().height
         result.push({
           lineNum: sym.line,


### PR DESCRIPTION
## 修复内容

### Bug 1: 粘性行提前出现（差了两行）
**根因**: 使用 `offsetTop` 与 `scrollTop` 比较来判断行是否滚出视野。但 `offsetTop` 是相对于 `offsetParent` 的（最近的 `position:relative` 祖先），不是相对于滚动容器。当 `FileViewer.vue` 有 `position: relative` 时，line 的 `offsetTop` 包含了 FileHeader 等元素的偏移，导致比较完全错位。

**修复**: 改用 `getBoundingClientRect().top` 做所有位置比较。这是视口坐标，不受 CSS 定位影响：
- 行"滚出视野" = `lineEl.getBoundingClientRect().top < containerTop`
- "第一行可见" = `lineEl.getBoundingClientRect().top >= containerTop`

### Bug 2: 粘性行重复
**根因**: Go 的 tree-sitter 推断式 tags query 会在同一行产生两个 `definition.function` tag（函数名 + 返回类型），都通过范围检查变成粘性行。

**修复**: 后端 (`symbol.go`) 按行去重 + 前端 (`useStickyScroll.ts`) `seenLines` Set 去重，两层防御。

### Bug 3: 代码块还没结束缩进行就消失了
**根因**: 同 Bug 1，`firstVisibleLine` 算错导致 `enclosing` scope 的范围检查出错，还在 scope 里的行被判定为不在 scope 里。

## 改动文件

| 文件 | 改动 |
|------|------|
| `internal/symbol/symbol.go` | 按 start line 去重，消除 Go 返回类型伪符号 |
| `internal/symbol/dedup_test.go` | 新增去重测试 |
| `web/src/composables/useStickyScroll.ts` | `getBoundingClientRect()` 替代 `offsetTop` + 前端去重 + 稳定排序 |
| `web/src/composables/__tests__/useStickyScroll.test.ts` | 新增 20 个测试用例 |

## 上游 Issue

已提报 tree-sitter 推断式 tags query 的 bug: https://github.com/odvcencio/gotreesitter/issues/100