### PR TITLE
fix: terminal not connecting on initial panel activation

### DIFF
--- a/web/src/components/terminal/TerminalPanelContent.vue
+++ b/web/src/components/terminal/TerminalPanelContent.vue
@@ -764,6 +764,8 @@ onMounted(async () => {
   if (props.active) {
     emit('open')
     enableVolumeKeys()
+    // Wait for v-for :ref callbacks to populate tabContainerRefs
+    await nextTick()
     const tab = activeTab.value
     if (tab) {
       const container = tabContainerRefs.get(tab.id)


### PR DESCRIPTION
Fix regression where terminal panel would not establish WebSocket connection on first open.

**Root cause:** In `TerminalPanelContent.vue`'s `onMounted` hook, `tabContainerRefs` was accessed before Vue's `v-for :ref` callbacks had populated the Map. This meant `mountTabToContainer` was never called, xterm was never mounted, and the WebSocket connection was never established.

**Fix:** Added `await nextTick()` before accessing `tabContainerRefs` in `onMounted`, ensuring the `v-for :ref` callbacks have executed.

The `watch(() => props.active)` handler already had `await nextTick()` so switching to the terminal tab worked — only the initial mount path was broken.