### PR TITLE
fix: reduce cyclomatic/cognitive complexity for golangci-lint

### DIFF
--- a/internal/ai/block_helpers.go
+++ b/internal/ai/block_helpers.go
@@ -208,6 +208,31 @@ func ConvertAskQuestionBlocks(blocks []model.ContentBlock) []model.ContentBlock 
 	return blocks
 }
 
+// validateAskQuestionJSON checks whether a JSON object contains a valid "questions"
+// array with at least one entry that has both "question" and "options" fields.
+func validateAskQuestionJSON(trimmed string) bool {
+	var data map[string]any
+	if err := json.Unmarshal([]byte(trimmed), &data); err != nil {
+		return false
+	}
+	questions, ok := data["questions"].([]any)
+	if !ok || len(questions) == 0 {
+		return false
+	}
+	for _, q := range questions {
+		qm, ok := q.(map[string]any)
+		if !ok {
+			continue
+		}
+		if _, hasQ := qm["question"]; hasQ {
+			if opts, ok := qm["options"].([]any); ok && len(opts) > 0 {
+				return true
+			}
+		}
+	}
+	return false
+}
+
 // extractXMLCandidate checks if the content between <ask-question> tags contains
 // valid XML with <item> child elements or valid JSON with "questions" array.
 func extractXMLCandidate(raw string) string {
@@ -222,26 +247,9 @@ func extractXMLCandidate(raw string) string {
 		return trimmed
 	}
 	if strings.HasPrefix(trimmed, "{") && strings.Contains(trimmed, `"questions"`) {
-		var data map[string]any
-		if err := json.Unmarshal([]byte(trimmed), &data); err != nil {
-			return ""
+		if validateAskQuestionJSON(trimmed) {
+			return trimmed
 		}
-		questions, ok := data["questions"].([]any)
-		if !ok || len(questions) == 0 {
-			return ""
-		}
-		for _, q := range questions {
-			qm, ok := q.(map[string]any)
-			if !ok {
-				continue
-			}
-			if _, hasQ := qm["question"]; hasQ {
-				if opts, ok := qm["options"].([]any); ok && len(opts) > 0 {
-					return trimmed
-				}
-			}
-		}
-		return ""
 	}
 	return ""
 }
@@ -319,6 +327,28 @@ func parseAskQuestionXML(xmlContent string) map[string]any {
 	return map[string]any{"questions": questions}
 }
 
+// parseJSONOptions converts a list of raw option maps into the format expected
+// by ContentBlock.Input, keeping only options with a non-empty "label" field.
+func parseJSONOptions(rawOptions []any) []map[string]any {
+	var options []map[string]any
+	for _, ro := range rawOptions {
+		opt, ok := ro.(map[string]any)
+		if !ok {
+			continue
+		}
+		label, _ := opt["label"].(string)
+		if label == "" {
+			continue
+		}
+		entry := map[string]any{"label": label}
+		if desc, ok := opt["description"].(string); ok && desc != "" {
+			entry["description"] = desc
+		}
+		options = append(options, entry)
+	}
+	return options
+}
+
 // parseAskQuestionJSON parses JSON-format <ask-question> content into the
 // map[string]any format expected by ContentBlock.Input for "AskUserQuestion" tool.
 func parseAskQuestionJSON(jsonContent string) map[string]any {
@@ -347,28 +377,12 @@ func parseAskQuestionJSON(jsonContent string) map[string]any {
 		header, _ := item["header"].(string)
 		_, multiSelect := item["multiSelect"].(bool)
 
-		rawOptions, ok := item["options"].([]any)
-		if !ok || len(rawOptions) == 0 {
+		rawOpts, ok := item["options"].([]any)
+		if !ok || len(rawOpts) == 0 {
 			continue
 		}
 
-		var options []map[string]any
-		for _, ro := range rawOptions {
-			opt, ok := ro.(map[string]any)
-			if !ok {
-				continue
-			}
-			label, _ := opt["label"].(string)
-			if label == "" {
-				continue
-			}
-			entry := map[string]any{"label": label}
-			if desc, ok := opt["description"].(string); ok && desc != "" {
-				entry["description"] = desc
-			}
-			options = append(options, entry)
-		}
-
+		options := parseJSONOptions(rawOpts)
 		if len(options) == 0 {
 			continue
 		}

--- a/internal/handler/file.go
+++ b/internal/handler/file.go
@@ -147,6 +147,49 @@ func ListFiles(w http.ResponseWriter, r *http.Request) {
 	writeJSON(w, http.StatusOK, files)
 }
 
+// resolveFilePath determines the absolute path and whether it's external to the
+// project. Supports absolute paths via ?path= query param and project-relative
+// paths via URL path.
+func resolveFilePath(w http.ResponseWriter, r *http.Request, projectPath string) (absPath string, isExternal bool, ok bool) {
+	if queryPath := r.URL.Query().Get("path"); queryPath != "" {
+		// Accept paths starting with / (POSIX-style absolute from frontend)
+		// or platform-native absolute paths (e.g. C:\ on Windows).
+		if !strings.HasPrefix(queryPath, "/") && !filepath.IsAbs(queryPath) {
+			writeLocalizedErrorf(w, r, http.StatusBadRequest, "InvalidFilePath")
+			return "", false, false
+		}
+		var err error
+		absPath, err = filepath.Abs(queryPath)
+		if err != nil {
+			writeLocalizedErrorf(w, r, http.StatusBadRequest, "InvalidFilePath")
+			return "", false, false
+		}
+		return absPath, true, true
+	}
+
+	// Project-relative path from URL path
+	filepathStr := r.URL.Path
+	if !strings.HasPrefix(filepathStr, "/api/file/") {
+		http.NotFound(w, r)
+		return "", false, false
+	}
+	filepathStr = filepathStr[len("/api/file/"):]
+	// Strip leading slashes to handle double-slash URLs (/api/file//path)
+	// caused by encodeURIComponent("/path") which encodes as %2Fpath.
+	// Go's ServeMux decodes %2F back to /, producing double slashes.
+	filepathStr = strings.TrimLeft(filepathStr, "/")
+	filepathStr = path.Clean(filepathStr)
+
+	if filepathStr == ".." || path.IsAbs(filepathStr) {
+		writeLocalizedErrorf(w, r, http.StatusBadRequest, "InvalidFilePath")
+		return "", false, false
+	}
+
+	basePath, _ := filepath.Abs(projectPath)
+	absPath, ok = validateAndResolvePath(w, r, basePath, filepathStr)
+	return absPath, false, ok
+}
+
 // GetFile returns the content of a single file.
 func GetFile(w http.ResponseWriter, r *http.Request) {
 	projectPath, ok := requireProject(w, r)
@@ -154,50 +197,9 @@ func GetFile(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	// Check for absolute path passed as query parameter (?path=/etc/hosts).
-	// This avoids URL path encoding issues: encodeURIComponent("/path")
-	// produces %2Fpath, which Go's ServeMux decodes back to /, making the
-	// absolute path indistinguishable from a project-relative path.
-	var absPath string
-	var isExternal bool
-	if queryPath := r.URL.Query().Get("path"); queryPath != "" {
-		// Accept paths starting with / (POSIX-style absolute from frontend)
-		// or platform-native absolute paths (e.g. C:\ on Windows).
-		if !strings.HasPrefix(queryPath, "/") && !filepath.IsAbs(queryPath) {
-			writeLocalizedErrorf(w, r, http.StatusBadRequest, "InvalidFilePath")
-			return
-		}
-		var err error
-		absPath, err = filepath.Abs(queryPath)
-		if err != nil {
-			writeLocalizedErrorf(w, r, http.StatusBadRequest, "InvalidFilePath")
-			return
-		}
-		isExternal = true
-	} else {
-		// Project-relative path from URL path
-		filepathStr := r.URL.Path
-		if !strings.HasPrefix(filepathStr, "/api/file/") {
-			http.NotFound(w, r)
-			return
-		}
-		filepathStr = filepathStr[len("/api/file/"):]
-		// Strip leading slashes to handle double-slash URLs (/api/file//path)
-		// caused by encodeURIComponent("/path") which encodes as %2Fpath.
-		// Go's ServeMux decodes %2F back to /, producing double slashes.
-		filepathStr = strings.TrimLeft(filepathStr, "/")
-		filepathStr = path.Clean(filepathStr)
-
-		if filepathStr == ".." || path.IsAbs(filepathStr) {
-			writeLocalizedErrorf(w, r, http.StatusBadRequest, "InvalidFilePath")
-			return
-		}
-
-		basePath, _ := filepath.Abs(projectPath)
-		absPath, ok = validateAndResolvePath(w, r, basePath, filepathStr)
-		if !ok {
-			return
-		}
+	absPath, isExternal, ok := resolveFilePath(w, r, projectPath)
+	if !ok {
+		return
 	}
 
 	info, err := os.Stat(absPath)

--- a/internal/service/session_executor.go
+++ b/internal/service/session_executor.go
@@ -119,6 +119,61 @@ func NewSessionExecutor(ctx context.Context, cfg RunConfig) *SessionExecutor {
 	}
 }
 
+// handleNonTerminalEvent processes a single non-terminal stream event.
+// Returns true if the event loop should return (SSE send failure).
+func (e *SessionExecutor) handleNonTerminalEvent(event ai.StreamEvent) bool {
+	// raw_output: accumulate but don't forward or count
+	if event.Type == "raw_output" {
+		if e.rawOutput != "" {
+			e.rawOutput += "\n"
+		}
+		e.rawOutput += event.RawOutput
+		return false
+	}
+
+	// session_capture: persist external session ID
+	if event.Type == "session_capture" {
+		if event.Content != "" {
+			e.captureExternalSessionID(event.Content)
+		}
+		return false
+	}
+
+	// SSE forwarding (interactive mode only)
+	if e.cfg.Mode == ModeInteractive && e.cfg.StreamCh != nil {
+		if !ai.SendStreamEvent(e.ctx, e.cfg.StreamCh, event) {
+			// Context cancelled or stream channel closed
+			return true
+		}
+	}
+
+	// Accumulate block
+	ai.AccumulateBlock(&e.blocks, event)
+
+	// resume_split: finalize current message, start new one
+	if event.Type == "resume_split" {
+		e.handleResumeSplit()
+		return false
+	}
+
+	// metadata capture
+	if event.Type == "metadata" && event.Meta != nil {
+		e.responseMetadata = event.Meta
+		// Capture external session ID from metadata
+		if event.Meta.SessionID != "" {
+			e.captureExternalSessionID(event.Meta.SessionID)
+		}
+	}
+
+	// Incremental persistence (every 5 events)
+	e.eventCount++
+	if e.eventCount%5 == 0 {
+		e.flushStreamingMessage()
+	}
+
+	return false
+}
+
 // RunWithChannel executes the event loop against a pre-built event channel.
 // This is the core event processing logic shared by both interactive and scheduled modes.
 // The caller is responsible for creating the backend and obtaining the event channel.
@@ -146,53 +201,8 @@ func (e *SessionExecutor) RunWithChannel(eventCh <-chan ai.StreamEvent) RunResul
 				return e.buildResult(true, wallStart)
 			}
 
-			// raw_output: accumulate but don't forward or count
-			if event.Type == "raw_output" {
-				if e.rawOutput != "" {
-					e.rawOutput += "\n"
-				}
-				e.rawOutput += event.RawOutput
-				continue
-			}
-
-			// session_capture: persist external session ID
-			if event.Type == "session_capture" {
-				if event.Content != "" {
-					e.captureExternalSessionID(event.Content)
-				}
-				continue
-			}
-
-			// SSE forwarding (interactive mode only)
-			if e.cfg.Mode == ModeInteractive && e.cfg.StreamCh != nil {
-				if !ai.SendStreamEvent(e.ctx, e.cfg.StreamCh, event) {
-					// Context cancelled or stream channel closed
-					return e.buildResult(e.receivedTerminal, wallStart)
-				}
-			}
-
-			// Accumulate block
-			ai.AccumulateBlock(&e.blocks, event)
-
-			// resume_split: finalize current message, start new one
-			if event.Type == "resume_split" {
-				e.handleResumeSplit()
-				continue
-			}
-
-			// metadata capture
-			if event.Type == "metadata" && event.Meta != nil {
-				e.responseMetadata = event.Meta
-				// Capture external session ID from metadata
-				if event.Meta.SessionID != "" {
-					e.captureExternalSessionID(event.Meta.SessionID)
-				}
-			}
-
-			// Incremental persistence (every 5 events)
-			e.eventCount++
-			if e.eventCount%5 == 0 {
-				e.flushStreamingMessage()
+			if e.handleNonTerminalEvent(event) {
+				return e.buildResult(e.receivedTerminal, wallStart)
 			}
 
 		case <-e.ctx.Done():
@@ -334,23 +344,15 @@ func (e *SessionExecutor) handleResumeSplit() {
 	}
 }
 
-// Finalize persists the RunResult to the database: builds the content JSON,
-// finalizes the streaming message, saves metadata, drains remaining events,
-// and saves raw output. Returns the finalized RunResult with DB message ID.
-//
-// This replaces the old finalizeStreamRun function from handler/chat.go.
-// The caller is still responsible for SSE terminal events and drain loop logic.
-func (e *SessionExecutor) Finalize(result RunResult, eventCh <-chan ai.StreamEvent) RunResult {
-	blocks := result.Blocks
-	responseMetadata := result.Metadata
-
-	// Inject ACP mode/thinking/transport/model into metadata
+// injectSessionMetadata populates ACP mode, thinking effort, transport, and model
+// into the response metadata from session-level state.
+func (e *SessionExecutor) injectSessionMetadata(meta *ai.Metadata) {
 	if s := ai.GetACPConnManager().GetCachedStateByClawbenchSID(e.cfg.SessionID); s.Mode != nil || s.Effort != nil {
 		if s.Mode != nil && s.Mode.CurrentModeID != "" {
-			responseMetadata.Mode = s.Mode.CurrentModeID
+			meta.Mode = s.Mode.CurrentModeID
 		}
 		if s.Effort != nil && s.Effort.CurrentID != "" {
-			responseMetadata.ThinkingEffort = s.Effort.CurrentID
+			meta.ThinkingEffort = s.Effort.CurrentID
 		}
 	}
 	effectiveTransport := "cli"
@@ -359,14 +361,16 @@ func (e *SessionExecutor) Finalize(result RunResult, eventCh <-chan ai.StreamEve
 	} else if agent, ok := model.Agents[e.cfg.AgentID]; ok && agent.SupportsACP() {
 		effectiveTransport = "acp-stdio"
 	}
-	responseMetadata.Transport = effectiveTransport
+	meta.Transport = effectiveTransport
 
 	if sessionModel := GetSessionModel(e.cfg.SessionID); sessionModel != "" {
-		responseMetadata.Model = sessionModel
+		meta.Model = sessionModel
 	}
+}
 
-	// Build content JSON for DB storage
-	var content string
+// buildContentJSON serializes blocks and metadata into the DB content format,
+// handling empty-response warnings and cancellation markers.
+func (e *SessionExecutor) buildContentJSON(blocks []model.ContentBlock, result RunResult, meta *ai.Metadata) (string, []model.ContentBlock) {
 	if len(blocks) == 0 {
 		var errMsg string
 		var reason string
@@ -381,25 +385,63 @@ func (e *SessionExecutor) Finalize(result RunResult, eventCh <-chan ai.StreamEve
 			errMsg, reason = "AI returned no content", ai.ReasonEmpty
 		}
 		blocks = append(blocks, model.ContentBlock{Type: "warning", Text: errMsg, Reason: reason})
-		contentMap := map[string]any{contentKeyBlocks: blocks, "metadata": responseMetadata}
+		contentMap := map[string]any{contentKeyBlocks: blocks, "metadata": meta}
 		if result.CancelReason == cancelReasonUser || e.ctx.Err() == context.Canceled {
 			contentMap["cancelled"] = true
 		}
 		blocksJSON, _ := json.Marshal(contentMap)
-		content = string(blocksJSON)
-	} else {
-		contentMap := map[string]any{contentKeyBlocks: blocks, "metadata": responseMetadata}
-		if result.CancelReason == cancelReasonUser {
-			contentMap["cancelled"] = true
-		} else if e.ctx.Err() == context.Canceled {
-			contentMap["cancelled"] = true
-		} else if e.ctx.Err() == context.DeadlineExceeded {
-			blocks = append(blocks, model.ContentBlock{Type: "warning", Text: "AI response timed out (30 min)", Reason: ai.ReasonTimeout})
-		}
-		contentMap[contentKeyBlocks] = blocks
-		blocksJSON, _ := json.Marshal(contentMap)
-		content = string(blocksJSON)
+		return string(blocksJSON), blocks
 	}
+
+	contentMap := map[string]any{contentKeyBlocks: blocks, "metadata": meta}
+	if result.CancelReason == cancelReasonUser {
+		contentMap["cancelled"] = true
+	} else if e.ctx.Err() == context.Canceled {
+		contentMap["cancelled"] = true
+	} else if e.ctx.Err() == context.DeadlineExceeded {
+		blocks = append(blocks, model.ContentBlock{Type: "warning", Text: "AI response timed out (30 min)", Reason: ai.ReasonTimeout})
+	}
+	contentMap[contentKeyBlocks] = blocks
+	blocksJSON, _ := json.Marshal(contentMap)
+	return string(blocksJSON), blocks
+}
+
+// drainRawOutput reads remaining raw_output events from the channel without blocking.
+func drainRawOutput(eventCh <-chan ai.StreamEvent, rawOutput string) string {
+	if eventCh == nil {
+		return rawOutput
+	}
+	for {
+		select {
+		case event, ok := <-eventCh:
+			if !ok {
+				return rawOutput
+			}
+			if event.Type == "raw_output" {
+				if rawOutput != "" {
+					rawOutput += "\n"
+				}
+				rawOutput += event.RawOutput
+			}
+		default:
+			return rawOutput
+		}
+	}
+}
+
+// Finalize persists the RunResult to the database: builds the content JSON,
+// finalizes the streaming message, saves metadata, drains remaining events,
+// and saves raw output. Returns the finalized RunResult with DB message ID.
+//
+// This replaces the old finalizeStreamRun function from handler/chat.go.
+// The caller is still responsible for SSE terminal events and drain loop logic.
+func (e *SessionExecutor) Finalize(result RunResult, eventCh <-chan ai.StreamEvent) RunResult {
+	blocks := result.Blocks
+	responseMetadata := result.Metadata
+
+	e.injectSessionMetadata(responseMetadata)
+
+	content, blocks := e.buildContentJSON(blocks, result, responseMetadata)
 
 	msgID, err := FinalizeStreamingMessage(e.cfg.ProjectPath, e.cfg.BackendName, e.cfg.SessionID, content)
 	if err != nil {
@@ -416,27 +458,8 @@ func (e *SessionExecutor) Finalize(result RunResult, eventCh <-chan ai.StreamEve
 	}
 
 	// Drain any remaining events from channel (collect raw_output)
-	rawOutput := result.RawOutput
-	if eventCh != nil {
-		for {
-			select {
-			case event, ok := <-eventCh:
-				if !ok {
-					goto saveRaw
-				}
-				if event.Type == "raw_output" {
-					if rawOutput != "" {
-						rawOutput += "\n"
-					}
-					rawOutput += event.RawOutput
-				}
-			default:
-				goto saveRaw
-			}
-		}
-	}
+	rawOutput := drainRawOutput(eventCh, result.RawOutput)
 
-saveRaw:
 	// Save raw AI backend output for debugging/analysis
 	if rawOutput != "" {
 		if streamMsgID := GetStreamingMessageID(e.cfg.SessionID); streamMsgID > 0 {


### PR DESCRIPTION
Extracts helper methods to fix 5 golangci-lint complexity violations blocking v0.49.0 release:

- **GetFile** (gocyclo 21→<15): extract `resolveFilePath` for path resolution logic
- **extractXMLCandidate** (gocyclo 16→<15): extract `validateAskQuestionJSON`
- **parseAskQuestionJSON** (gocyclo 16→<15): extract `parseJSONOptions`
- **RunWithChannel** (gocognit 53→<30): extract `handleNonTerminalEvent`
- **Finalize** (gocognit 54→<30): extract `injectSessionMetadata`, `buildContentJSON`, `drainRawOutput`

All existing tests pass. golangci-lint reports 0 issues.