### PR TITLE
fix: include provider_models.json in Docker image

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -415,6 +415,9 @@ jobs:
           cp -r pkg-linux/clawbench/public .
           mkdir -p docker-staging/pi
           chmod +x ./clawbench
+          # Copy provider_models.json so Anthropic-format providers have KnownModels
+          mkdir -p docker-staging
+          cp pkg-linux/clawbench/.clawbench/provider_models.json docker-staging/provider_models.json
 
       - name: Resolve latest Pi version
         id: pi-version

--- a/Dockerfile
+++ b/Dockerfile
@@ -51,6 +51,7 @@ RUN if [ -n "$PI_VERSION" ]; then \
 # Copy local docker-staging/ as fallback (local builds only; no-op in CI since PI_VERSION is set).
 # When PI_VERSION is set above, the RUN step already populated .clawbench/pi/,
 # and this COPY overlays an empty directory (harmless).
+# In CI, docker-staging/ also contains provider_models.json from the Linux build artifact.
 COPY docker-staging/ .clawbench/
 
 # Data directory (mounted as volume for persistence)


### PR DESCRIPTION
Anthropic-format providers (MiniMax, Kimi, etc.) have no `/v1/models` endpoint and rely on `KnownModels` loaded from `provider_models.json`. The Docker build step only copied the binary and `public/`, omitting this file, causing `ModelsEndpointNotAvailable` in the setup wizard.

Changes:
- **release.yml**: Copy `provider_models.json` from Linux artifact into `docker-staging/`
- **Dockerfile**: Updated comment to note that `docker-staging/` also carries `provider_models.json`

The existing `COPY docker-staging/ .clawbench/` in the Dockerfile already handles the file — it was just never placed into the staging directory.