### PR TITLE
fix: include hidden files in upload-artifact for Docker build

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -145,6 +145,7 @@ jobs:
         with:
           name: linux-package
           path: pkg-linux/clawbench/
+          include-hidden-files: true
 
   build-windows:
     name: Build Windows amd64


### PR DESCRIPTION
## Problem

The v0.49.1 release CI failed on the Docker build step. `actions/upload-artifact@v4` excludes hidden directories by default, so `.clawbench/` (containing `provider_models.json` and `pi/`) was missing from the `linux-package` artifact. The Docker job then failed when trying to `cp pkg-linux/clawbench/.clawbench/provider_models.json`.

## Fix

Add `include-hidden-files: true` to the Linux job's `upload-artifact` step so that `.clawbench/` directory is included in the artifact.

## Related
- Caused by commit b044239 (fix: include provider_models.json in Docker image) which added the hidden directory to the package but didn't account for upload-artifact's default exclusion
- v0.49.1 release run: https://github.com/clawbench-dev/clawbench/actions/runs/27699923967