### PR TITLE
fix(android): stub performHealthCheck in PreAuthTest to fix CI

### DIFF
--- a/android/app/src/main/java/com/clawbench/app/MainActivity.java
+++ b/android/app/src/main/java/com/clawbench/app/MainActivity.java
@@ -817,7 +817,7 @@ public class MainActivity extends AppCompatActivity {
      * Perform GET /api/health and verify the response contains {"app":"clawbench"}.
      * Returns null on success, or an error message string on failure.
      */
-    private String performHealthCheck(String url, OkHttpClient client) throws Exception {
+    String performHealthCheck(String url, OkHttpClient client) throws Exception {
         Request request = new Request.Builder()
                 .url(url + "/api/health")
                 .get()

--- a/android/app/src/test/java/com/clawbench/app/MainActivityPreAuthTest.java
+++ b/android/app/src/test/java/com/clawbench/app/MainActivityPreAuthTest.java
@@ -24,7 +24,11 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.ArgumentMatchers.anyString;
+
+import okhttp3.OkHttpClient;
+
 import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.doCallRealMethod;
 import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.doThrow;
@@ -106,6 +110,9 @@ public class MainActivityPreAuthTest {
         setField(activity, "loadErrorPending", false);
         setField(activity, "connectionTimeoutRunnable", null);
         setField(activity, "pendingLoginErrorMessage", null);
+
+        // Stub performHealthCheck to return null (no error) by default
+        doReturn(null).when(activity).performHealthCheck(anyString(), any(OkHttpClient.class));
     }
 
     @After
@@ -600,6 +607,75 @@ public class MainActivityPreAuthTest {
 
         assertEquals(200, result.statusCode);
         assertTrue(result.cookies.isEmpty());
+
+        server.shutdown();
+    }
+
+    // =====================================================
+    // performHealthCheck: real HTTP via MockWebServer
+    // =====================================================
+
+    @Test
+    public void performHealthCheck_200_clawbenchServer_returnsNull() throws Exception {
+        MockWebServer server = new MockWebServer();
+        server.enqueue(new MockResponse()
+                .setResponseCode(200)
+                .setBody("{\"app\":\"clawbench\",\"version\":\"1.0.0\"}"));
+        server.start();
+
+        String url = "http://" + server.getHostName() + ":" + server.getPort();
+        OkHttpClient client = new OkHttpClient.Builder()
+                .connectTimeout(5, java.util.concurrent.TimeUnit.SECONDS)
+                .readTimeout(5, java.util.concurrent.TimeUnit.SECONDS)
+                .build();
+        // Call real method for this test
+        doCallRealMethod().when(activity).performHealthCheck(anyString(), any(OkHttpClient.class));
+        String result = activity.performHealthCheck(url, client);
+
+        assertNull(result);
+
+        RecordedRequest request = server.takeRequest();
+        assertTrue(request.getPath().endsWith("/api/health"));
+
+        server.shutdown();
+    }
+
+    @Test
+    public void performHealthCheck_200_nonClawbenchServer_returnsError() throws Exception {
+        MockWebServer server = new MockWebServer();
+        server.enqueue(new MockResponse()
+                .setResponseCode(200)
+                .setBody("{\"app\":\"other\",\"version\":\"1.0.0\"}"));
+        server.start();
+
+        String url = "http://" + server.getHostName() + ":" + server.getPort();
+        OkHttpClient client = new OkHttpClient.Builder()
+                .connectTimeout(5, java.util.concurrent.TimeUnit.SECONDS)
+                .readTimeout(5, java.util.concurrent.TimeUnit.SECONDS)
+                .build();
+        doCallRealMethod().when(activity).performHealthCheck(anyString(), any(OkHttpClient.class));
+        String result = activity.performHealthCheck(url, client);
+
+        assertNotNull(result);
+
+        server.shutdown();
+    }
+
+    @Test
+    public void performHealthCheck_non200_returnsError() throws Exception {
+        MockWebServer server = new MockWebServer();
+        server.enqueue(new MockResponse().setResponseCode(404));
+        server.start();
+
+        String url = "http://" + server.getHostName() + ":" + server.getPort();
+        OkHttpClient client = new OkHttpClient.Builder()
+                .connectTimeout(5, java.util.concurrent.TimeUnit.SECONDS)
+                .readTimeout(5, java.util.concurrent.TimeUnit.SECONDS)
+                .build();
+        doCallRealMethod().when(activity).performHealthCheck(anyString(), any(OkHttpClient.class));
+        String result = activity.performHealthCheck(url, client);
+
+        assertNotNull(result);
 
         server.shutdown();
     }


### PR DESCRIPTION
## Summary

Fix 6 failing `MainActivityPreAuthTest` tests that cause the non-blocking "Coverage Gate (Android)" CI check to fail.

## Root Cause

`handleAuthResponse(200, ...)` now calls `performHealthCheck()` which creates a real `OkHttpClient` and makes an HTTP request. In the test environment there's no server, so the health check fails → `showLoginPage()` is called instead of `webView.loadUrl(url)`.

`performHealthCheck` was `private`, so Mockito couldn't stub it.

## Changes

- **MainActivity.java**: Change `performHealthCheck` from `private` to package-private (matching the existing pattern of `performLoginRequest` which is already package-private for testability)
- **MainActivityPreAuthTest.java**: Add `doReturn(null).when(activity).performHealthCheck(anyString(), any(OkHttpClient.class))` in `setUp()` to stub the health check to return success

## Verification

- All 355 Android unit tests pass locally
- The 6 previously failing tests now pass:
  - `authenticateAndNavigate_200_navigatesWebView`
  - `authenticateAndNavigate_200_startsConnectionTimeout`
  - `handleAuthResponse_200_withCookies_navigatesWebView`
  - `handleAuthResponse_200_withCookies_startsConnectionTimeout`
  - `handleAuthResponse_200_emptyCookies_stillNavigates`
  - `handleAuthResponse_200_nullCookies_stillNavigates`