### PR TITLE
fix(acp+ui): ACP resume hang, embedded agent abstraction, thinking collapse clip, not-found guard

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -37,8 +37,9 @@ coverage.html
 # Docker build files (avoid recursion)
 Dockerfile.build
 
-# Scripts (not needed in runtime image)
+# Scripts (not needed in runtime image, except embedded agent download helper)
 scripts/
+!scripts/download-embedded-agent.sh
 
 # Config (runtime generates defaults)
 config/config.yaml

--- a/.github/actions/download-embedded-agent/action.yml
+++ b/.github/actions/download-embedded-agent/action.yml
@@ -1,0 +1,104 @@
+name: 'Download Embedded Agent'
+description: 'Downloads an embedded agent binary for packaging into release artifacts'
+
+inputs:
+  agent-id:
+    description: 'Agent ID from embedded-agents.yaml (e.g., opencode)'
+    required: true
+  platform:
+    description: 'Target platform: linux-x64, linux-arm64, darwin-arm64, darwin-x64, windows-x64'
+    required: true
+  github-token:
+    description: 'GitHub token for API access'
+    required: true
+  version:
+    description: 'Explicit version override (empty = auto-detect latest)'
+    required: false
+    default: ''
+
+outputs:
+  version:
+    description: 'Resolved agent version'
+    value: ${{ steps.resolve.outputs.version }}
+  subdir:
+    description: 'Agent subdir under .clawbench/'
+    value: ${{ steps.resolve.outputs.subdir }}
+
+runs:
+  using: 'composite'
+  steps:
+    - name: Resolve agent version
+      id: resolve
+      shell: bash
+      env:
+        _AGENT_ID: ${{ inputs.agent-id }}
+        _AGENT_VERSION: ${{ inputs.version }}
+        GH_TOKEN: ${{ inputs.github-token }}
+      run: |
+        # Source the download helper
+        # shellcheck source=scripts/download-embedded-agent.sh
+        . ./scripts/download-embedded-agent.sh
+
+        SUBDIR=$(parse_embedded_agent_config "$_AGENT_ID" subdir)
+
+        # Resolve version: explicit input > env var > GitHub API
+        if [ -n "$_AGENT_VERSION" ]; then
+          VERSION="$_AGENT_VERSION"
+        else
+          VERSION=$(resolve_agent_version_gh "$_AGENT_ID" "$GH_TOKEN")
+        fi
+
+        echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+        echo "subdir=$SUBDIR" >> "$GITHUB_OUTPUT"
+        echo "Resolved ${_AGENT_ID}: version=${VERSION}, subdir=${SUBDIR}"
+
+    - name: Download agent binary
+      shell: bash
+      env:
+        _AGENT_ID: ${{ inputs.agent-id }}
+        _AGENT_VERSION: ${{ steps.resolve.outputs.version }}
+        _AGENT_SUBDIR: ${{ steps.resolve.outputs.subdir }}
+        _AGENT_PLATFORM: ${{ inputs.platform }}
+      run: |
+        # Source the download helper
+        # shellcheck source=scripts/download-embedded-agent.sh
+        . ./scripts/download-embedded-agent.sh
+
+        GITHUB_REPO=$(parse_embedded_agent_config "$_AGENT_ID" github_repo)
+        CMD=$(parse_embedded_agent_config "$_AGENT_ID" cmd)
+        VERSION_FILE=$(parse_embedded_agent_config "$_AGENT_ID" version_file)
+
+        # Parse platform into os and arch
+        OS="${_AGENT_PLATFORM%%-*}"
+        ARCH="${_AGENT_PLATFORM#*-}"
+
+        # Apply arch mapping
+        MAPPED_ARCH=$(parse_arch_mapping "$_AGENT_ID" "$ARCH")
+        [ -z "$MAPPED_ARCH" ] && MAPPED_ARCH="$ARCH"
+
+        # Get archive pattern and substitute {arch}
+        ARCHIVE_PATTERN=$(parse_archive_naming "$_AGENT_ID" "$OS")
+        ARCHIVE_NAME="${ARCHIVE_PATTERN//\{arch\}/$MAPPED_ARCH}"
+
+        URL="https://github.com/${GITHUB_REPO}/releases/download/v${_AGENT_VERSION}/${ARCHIVE_NAME}"
+
+        AGENT_DIR=".clawbench/${_AGENT_SUBDIR}"
+        mkdir -p "$AGENT_DIR"
+
+        # Download (use temp file + curl --fail to catch HTTP errors)
+        EXT="${ARCHIVE_NAME##*.}"
+        echo "Downloading ${_AGENT_ID} v${_AGENT_VERSION} for ${_AGENT_PLATFORM}..."
+        if [ "$EXT" = "zip" ]; then
+          TMP="/tmp/${_AGENT_ID}-download.zip"
+          curl -sL --fail "$URL" -o "$TMP"
+          unzip -qo "$TMP" -d "$AGENT_DIR"
+          rm -f "$TMP"
+        else
+          TMP="/tmp/${_AGENT_ID}-download.tar.gz"
+          curl -sL --fail "$URL" -o "$TMP"
+          tar xzf "$TMP" -C "$AGENT_DIR"
+          rm -f "$TMP"
+        fi
+        chmod +x "$AGENT_DIR/$CMD" 2>/dev/null || true
+        echo -n "$_AGENT_VERSION" > "$AGENT_DIR/${VERSION_FILE}"
+        echo "${_AGENT_ID} v${_AGENT_VERSION} downloaded to ${AGENT_DIR}/"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -100,24 +100,13 @@ jobs:
           file clawbench-linux
           ldd clawbench-linux
 
-      - name: Resolve latest OpenCode version
-        id: opencode-version
-        run: |
-          OPENCODE_VERSION=$(gh api repos/anomalyco/opencode/releases/latest --jq '.tag_name' | sed 's/^v//')
-          echo "version=$OPENCODE_VERSION" >> "$GITHUB_OUTPUT"
-          echo "Latest OpenCode version: v${OPENCODE_VERSION}"
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Download OpenCode binary (embedded agent)
-        run: |
-          OPENCODE_VERSION="${{ steps.opencode-version.outputs.version }}"
-          OC_URL="https://github.com/anomalyco/opencode/releases/download/v${OPENCODE_VERSION}/opencode-linux-x64.tar.gz"
-          mkdir -p .clawbench/opencode
-          curl -sL "$OC_URL" | tar xzf - -C .clawbench/opencode
-          chmod +x .clawbench/opencode/opencode
-          echo "$OPENCODE_VERSION" > .clawbench/opencode/VERSION
-          echo "OpenCode v${OPENCODE_VERSION} downloaded"
+      - name: Download embedded agent
+        uses: ./.github/actions/download-embedded-agent
+        id: embedded-agent
+        with:
+          agent-id: opencode
+          platform: linux-x64
+          github-token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Package Linux
         run: |
@@ -126,7 +115,7 @@ jobs:
           cp -r public pkg-linux/clawbench/public
           cp -r config pkg-linux/clawbench/config
           mkdir -p pkg-linux/clawbench/.clawbench
-          cp -r .clawbench/opencode pkg-linux/clawbench/.clawbench/opencode
+          cp -r .clawbench/${{ steps.embedded-agent.outputs.subdir }} pkg-linux/clawbench/.clawbench/${{ steps.embedded-agent.outputs.subdir }}
           chmod +x pkg-linux/clawbench/clawbench
           cd pkg-linux && zip -r clawbench-linux-amd64.zip clawbench/
 
@@ -172,24 +161,13 @@ jobs:
           file clawbench-linux-arm64
           ldd clawbench-linux-arm64
 
-      - name: Resolve latest OpenCode version
-        id: opencode-version
-        run: |
-          OPENCODE_VERSION=$(gh api repos/anomalyco/opencode/releases/latest --jq '.tag_name' | sed 's/^v//')
-          echo "version=$OPENCODE_VERSION" >> "$GITHUB_OUTPUT"
-          echo "Latest OpenCode version: v${OPENCODE_VERSION}"
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Download OpenCode binary (embedded agent)
-        run: |
-          OPENCODE_VERSION="${{ steps.opencode-version.outputs.version }}"
-          OC_URL="https://github.com/anomalyco/opencode/releases/download/v${OPENCODE_VERSION}/opencode-linux-arm64.tar.gz"
-          mkdir -p .clawbench/opencode
-          curl -sL "$OC_URL" | tar xzf - -C .clawbench/opencode
-          chmod +x .clawbench/opencode/opencode
-          echo "$OPENCODE_VERSION" > .clawbench/opencode/VERSION
-          echo "OpenCode v${OPENCODE_VERSION} downloaded"
+      - name: Download embedded agent
+        uses: ./.github/actions/download-embedded-agent
+        id: embedded-agent
+        with:
+          agent-id: opencode
+          platform: linux-arm64
+          github-token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Package Linux arm64
         run: |
@@ -198,7 +176,7 @@ jobs:
           cp -r public pkg-linux-arm64/clawbench/public
           cp -r config pkg-linux-arm64/clawbench/config
           mkdir -p pkg-linux-arm64/clawbench/.clawbench
-          cp -r .clawbench/opencode pkg-linux-arm64/clawbench/.clawbench/opencode
+          cp -r .clawbench/${{ steps.embedded-agent.outputs.subdir }} pkg-linux-arm64/clawbench/.clawbench/${{ steps.embedded-agent.outputs.subdir }}
           chmod +x pkg-linux-arm64/clawbench/clawbench
           cd pkg-linux-arm64 && zip -r clawbench-linux-arm64.zip clawbench/
 
@@ -238,29 +216,13 @@ jobs:
           $VERSION = if (git describe --tags --always 2>$null) { git describe --tags --always } else { "dev" }
           go build -tags "fts5" -ldflags="-s -w -X clawbench/internal/version.Version=$VERSION" -o clawbench.exe ./cmd/server
 
-      - name: Resolve latest OpenCode version
-        id: opencode-version
-        shell: pwsh
-        run: |
-          $resp = Invoke-RestMethod -Uri "https://api.github.com/repos/anomalyco/opencode/releases/latest" -Headers @{ Authorization = "token $env:GITHUB_TOKEN" }
-          $OPENCODE_VERSION = $resp.tag_name -replace '^v',''
-          "version=$OPENCODE_VERSION" | Out-File -Append -Encoding utf8 $env:GITHUB_OUTPUT
-          Write-Host "Latest OpenCode version: v${OPENCODE_VERSION}"
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Download OpenCode binary (embedded agent)
-        shell: pwsh
-        run: |
-          $OPENCODE_VERSION = "${{ steps.opencode-version.outputs.version }}"
-          $OC_URL = "https://github.com/anomalyco/opencode/releases/download/v${OPENCODE_VERSION}/opencode-windows-x64.zip"
-          New-Item -ItemType Directory -Force -Path .clawbench\opencode
-          $tmpZip = "$env:TEMP\opencode-download.zip"
-          Invoke-WebRequest -Uri $OC_URL -OutFile $tmpZip
-          Expand-Archive -Path $tmpZip -DestinationPath .clawbench\opencode -Force
-          Remove-Item $tmpZip -Force
-          Set-Content -Path ".clawbench\opencode\VERSION" -Value $OPENCODE_VERSION
-          Write-Host "OpenCode v${OPENCODE_VERSION} downloaded"
+      - name: Download embedded agent
+        uses: ./.github/actions/download-embedded-agent
+        id: embedded-agent
+        with:
+          agent-id: opencode
+          platform: windows-x64
+          github-token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Package Windows
         shell: pwsh
@@ -270,7 +232,7 @@ jobs:
           Copy-Item -Recurse public pkg-windows/clawbench/public
           Copy-Item -Recurse config pkg-windows/clawbench/config
           New-Item -ItemType Directory -Force -Path pkg-windows/clawbench/.clawbench
-          Copy-Item -Recurse .clawbench/opencode pkg-windows/clawbench/.clawbench/opencode
+          Copy-Item -Recurse .clawbench/${{ steps.embedded-agent.outputs.subdir }} pkg-windows/clawbench/.clawbench/${{ steps.embedded-agent.outputs.subdir }}
           Compress-Archive -Path pkg-windows/clawbench -DestinationPath pkg-windows/clawbench-windows-amd64.zip
 
       - uses: softprops/action-gh-release@v2
@@ -303,26 +265,13 @@ jobs:
           VERSION=$(git describe --tags --always 2>/dev/null || echo "dev")
           go build -tags "fts5" -ldflags="-s -w -X clawbench/internal/version.Version=$VERSION" -o clawbench-darwin-arm64 ./cmd/server
 
-      - name: Resolve latest OpenCode version
-        id: opencode-version
-        run: |
-          OPENCODE_VERSION=$(gh api repos/anomalyco/opencode/releases/latest --jq '.tag_name' | sed 's/^v//')
-          echo "version=$OPENCODE_VERSION" >> "$GITHUB_OUTPUT"
-          echo "Latest OpenCode version: v${OPENCODE_VERSION}"
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Download OpenCode binary (embedded agent)
-        run: |
-          OPENCODE_VERSION="${{ steps.opencode-version.outputs.version }}"
-          OC_URL="https://github.com/anomalyco/opencode/releases/download/v${OPENCODE_VERSION}/opencode-darwin-arm64.zip"
-          mkdir -p .clawbench/opencode
-          curl -sL "$OC_URL" -o /tmp/opencode-darwin.zip
-          unzip -qo /tmp/opencode-darwin.zip -d .clawbench/opencode
-          rm -f /tmp/opencode-darwin.zip
-          chmod +x .clawbench/opencode/opencode
-          echo "$OPENCODE_VERSION" > .clawbench/opencode/VERSION
-          echo "OpenCode v${OPENCODE_VERSION} downloaded"
+      - name: Download embedded agent
+        uses: ./.github/actions/download-embedded-agent
+        id: embedded-agent
+        with:
+          agent-id: opencode
+          platform: darwin-arm64
+          github-token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Package macOS arm64
         run: |
@@ -331,7 +280,7 @@ jobs:
           cp -r public pkg-mac-arm64/clawbench/public
           cp -r config pkg-mac-arm64/clawbench/config
           mkdir -p pkg-mac-arm64/clawbench/.clawbench
-          cp -r .clawbench/opencode pkg-mac-arm64/clawbench/.clawbench/opencode
+          cp -r .clawbench/${{ steps.embedded-agent.outputs.subdir }} pkg-mac-arm64/clawbench/.clawbench/${{ steps.embedded-agent.outputs.subdir }}
           chmod +x pkg-mac-arm64/clawbench/clawbench
           cd pkg-mac-arm64 && zip -r clawbench-darwin-arm64.zip clawbench/
 
@@ -368,26 +317,13 @@ jobs:
           VERSION=$(git describe --tags --always 2>/dev/null || echo "dev")
           go build -tags "fts5" -ldflags="-s -w -X clawbench/internal/version.Version=$VERSION" -o clawbench-darwin-amd64 ./cmd/server
 
-      - name: Resolve latest OpenCode version
-        id: opencode-version
-        run: |
-          OPENCODE_VERSION=$(gh api repos/anomalyco/opencode/releases/latest --jq '.tag_name' | sed 's/^v//')
-          echo "version=$OPENCODE_VERSION" >> "$GITHUB_OUTPUT"
-          echo "Latest OpenCode version: v${OPENCODE_VERSION}"
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Download OpenCode binary (embedded agent)
-        run: |
-          OPENCODE_VERSION="${{ steps.opencode-version.outputs.version }}"
-          OC_URL="https://github.com/anomalyco/opencode/releases/download/v${OPENCODE_VERSION}/opencode-darwin-x64.zip"
-          mkdir -p .clawbench/opencode
-          curl -sL "$OC_URL" -o /tmp/opencode-darwin.zip
-          unzip -qo /tmp/opencode-darwin.zip -d .clawbench/opencode
-          rm -f /tmp/opencode-darwin.zip
-          chmod +x .clawbench/opencode/opencode
-          echo "$OPENCODE_VERSION" > .clawbench/opencode/VERSION
-          echo "OpenCode v${OPENCODE_VERSION} downloaded"
+      - name: Download embedded agent
+        uses: ./.github/actions/download-embedded-agent
+        id: embedded-agent
+        with:
+          agent-id: opencode
+          platform: darwin-x64
+          github-token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Package macOS amd64
         run: |
@@ -396,7 +332,7 @@ jobs:
           cp -r public pkg-mac-amd64/clawbench/public
           cp -r config pkg-mac-amd64/clawbench/config
           mkdir -p pkg-mac-amd64/clawbench/.clawbench
-          cp -r .clawbench/opencode pkg-mac-amd64/clawbench/.clawbench/opencode
+          cp -r .clawbench/${{ steps.embedded-agent.outputs.subdir }} pkg-mac-amd64/clawbench/.clawbench/${{ steps.embedded-agent.outputs.subdir }}
           chmod +x pkg-mac-amd64/clawbench/clawbench
           cd pkg-mac-amd64 && zip -r clawbench-darwin-amd64.zip clawbench/
 
@@ -465,17 +401,21 @@ jobs:
         run: |
           cp pkg-linux/clawbench/clawbench .
           cp -r pkg-linux/clawbench/public .
-          mkdir -p docker-staging/opencode
           chmod +x ./clawbench
 
-      - name: Resolve latest OpenCode version
-        id: opencode-version
+      - name: Resolve embedded agent version for Docker
+        id: embedded-agent
+        shell: bash
         run: |
-          OPENCODE_VERSION=$(gh api repos/anomalyco/opencode/releases/latest --jq '.tag_name' | sed 's/^v//')
-          echo "version=$OPENCODE_VERSION" >> "$GITHUB_OUTPUT"
-          echo "Latest OpenCode version: v${OPENCODE_VERSION}"
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          # Source the download helper to parse embedded-agents.yaml
+          # shellcheck source=scripts/download-embedded-agent.sh
+          . ./scripts/download-embedded-agent.sh
+          AGENT_ID="opencode"
+          VERSION=$(resolve_agent_version_gh "$AGENT_ID" "${{ secrets.GITHUB_TOKEN }}")
+          SUBDIR=$(parse_embedded_agent_config "$AGENT_ID" subdir)
+          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+          echo "subdir=$SUBDIR" >> "$GITHUB_OUTPUT"
+          mkdir -p "docker-staging/$SUBDIR"
 
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v3
@@ -500,7 +440,9 @@ jobs:
           context: .
           platforms: linux/amd64,linux/arm64
           push: true
-          build-args: OPENCODE_VERSION=${{ steps.opencode-version.outputs.version }}
+          build-args: |
+            EMBEDDED_AGENT_ID=opencode
+            EMBEDDED_AGENT_VERSION=${{ steps.embedded-agent.outputs.version }}
           tags: |
             ghcr.io/${{ github.repository }}:latest
             ghcr.io/${{ github.repository }}:${{ steps.version.outputs.VERSION }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -26,29 +26,34 @@ WORKDIR /app
 COPY clawbench .
 COPY public/ ./public/
 
-# Copy OpenCode binary — multi-arch aware
+# Copy embedded agent download helper and config
+COPY scripts/download-embedded-agent.sh ./scripts/download-embedded-agent.sh
+COPY embedded-agents.yaml ./embedded-agents.yaml
+
+# Copy embedded agent binary — multi-arch aware
 # Local build: scripts/docker-build.sh populates docker-staging/
-# CI build: release workflow passes OPENCODE_VERSION build arg; the RUN step
-# below downloads the correct OpenCode binary for each target architecture.
+# CI build: passes EMBEDDED_AGENT_ID + EMBEDDED_AGENT_VERSION build args; the RUN step
+# below downloads the correct agent binary for each target architecture.
 ARG TARGETARCH
+ARG EMBEDDED_AGENT_ID=""
+ARG EMBEDDED_AGENT_VERSION=""
+# Backward compat: OPENCODE_VERSION maps to EMBEDDED_AGENT_ID=opencode
+# If both OPENCODE_VERSION and EMBEDDED_AGENT_* are set, EMBEDDED_AGENT_* takes precedence.
 ARG OPENCODE_VERSION=""
 
-# If OPENCODE_VERSION is set (CI), download the correct OpenCode binary for this architecture.
-RUN if [ -n "$OPENCODE_VERSION" ]; then \
-      OC_ARCH="x64"; \
-      if [ "$TARGETARCH" = "arm64" ]; then OC_ARCH="arm64"; fi; \
-      OC_URL="https://github.com/anomalyco/opencode/releases/download/v${OPENCODE_VERSION}/opencode-linux-${OC_ARCH}.tar.gz"; \
-      mkdir -p .clawbench/opencode && \
-      curl -sL "$OC_URL" | tar xzf - -C .clawbench/opencode && \
-      chmod +x .clawbench/opencode/opencode && \
-      echo "$OPENCODE_VERSION" > .clawbench/opencode/VERSION && \
-      echo "OpenCode v${OPENCODE_VERSION} (${OC_ARCH}) downloaded"; \
+# If EMBEDDED_AGENT_VERSION is set (CI), download the correct agent binary for this architecture.
+RUN if [ -n "$EMBEDDED_AGENT_ID" ] && [ -n "$EMBEDDED_AGENT_VERSION" ]; then \
+      . ./scripts/download-embedded-agent.sh && \
+      download_embedded_agent_for_docker "$EMBEDDED_AGENT_ID" "$EMBEDDED_AGENT_VERSION"; \
+    elif [ -n "$OPENCODE_VERSION" ]; then \
+      . ./scripts/download-embedded-agent.sh && \
+      download_embedded_agent_for_docker opencode "$OPENCODE_VERSION"; \
     else \
       mkdir -p .clawbench; \
     fi
 
-# Copy local docker-staging/ as fallback (local builds only; no-op in CI since OPENCODE_VERSION is set).
-# When OPENCODE_VERSION is set above, the RUN step already populated .clawbench/opencode/,
+# Copy local docker-staging/ as fallback (local builds only; no-op in CI when version is set).
+# When a version is set above, the RUN step already populated .clawbench/,
 # and this COPY overlays an empty directory (harmless).
 COPY docker-staging/ .clawbench/
 

--- a/build.sh
+++ b/build.sh
@@ -9,7 +9,7 @@ ASSETS="assets"
 TARGET_OS=""
 TARGET_ARCH=""
 BUILD_ANDROID=""
-DOWNLOAD_OPENCODE=""
+EMBED_AGENTS=()
 for arg in "$@"; do
     case "$arg" in
         --windows)
@@ -36,8 +36,12 @@ for arg in "$@"; do
         --android)
             BUILD_ANDROID=1
             ;;
+        --embed-agent=*)
+            EMBED_AGENTS+=("${arg#--embed-agent=}")
+            ;;
         --with-opencode)
-            DOWNLOAD_OPENCODE=1
+            # Backward-compatible alias for --embed-agent=opencode
+            EMBED_AGENTS+=("opencode")
             ;;
     esac
 done
@@ -88,63 +92,19 @@ else
     echo "  Go not found, skipping backend build"
 fi
 
-# 1.5 Download OpenCode binary (embedded agent)
-# Default: skip. Use --with-opencode to download, or set OPENCODE_VERSION to pin a version.
-# Without OPENCODE_VERSION, the latest release is fetched from GitHub API automatically.
-OC_DIR=".clawbench/opencode"
-if [ -n "$DOWNLOAD_OPENCODE" ]; then
-    # Resolve OpenCode version: env var override > auto-detect latest from GitHub
-    if [ -z "$OPENCODE_VERSION" ]; then
-        OPENCODE_VERSION=$(curl -sI https://github.com/anomalyco/opencode/releases/latest 2>/dev/null | grep -i "^location:" | sed 's|.*/tag/v||' | tr -d '[:space:]')
-        if [ -z "$OPENCODE_VERSION" ]; then
-            echo "  ERROR: Could not detect latest OpenCode version. Set OPENCODE_VERSION manually."
-            exit 1
-        fi
-        echo "  Auto-detected latest OpenCode version: v${OPENCODE_VERSION}"
-    fi
-    echo "[3/5] Downloading OpenCode v${OPENCODE_VERSION}..."
-    # Determine platform for OpenCode binary
-    if [ -n "$TARGET_OS" ] && [ -n "$TARGET_ARCH" ]; then
-        case "$TARGET_OS" in
-            linux)   OC_PLATFORM="linux-$TARGET_ARCH" ;;
-            darwin)  OC_PLATFORM="darwin-$TARGET_ARCH" ;;
-            windows) OC_PLATFORM="windows-$TARGET_ARCH" ;;
-            *)       OC_PLATFORM="" ;;
-        esac
-        # OpenCode uses "x64" not "amd64" in its archive names
-        OC_PLATFORM="${OC_PLATFORM/amd64/x64}"
-    else
-        OC_PLATFORM="$(uname -s | tr '[:upper:]' '[:lower:]')-$(uname -m)"
-        OC_PLATFORM="${OC_PLATFORM/x86_64/x64}"
-        OC_PLATFORM="${OC_PLATFORM/aarch64/arm64}"
-    fi
-
-    if [ -n "$OC_PLATFORM" ]; then
-        OC_EXT="tar.gz"
-        [ "${TARGET_OS:-}" = "windows" ] && OC_EXT="zip"
-        [ "${TARGET_OS:-}" = "darwin" ] && OC_EXT="zip"
-        OC_ARCHIVE="opencode-${OC_PLATFORM}.${OC_EXT}"
-        OC_URL="https://github.com/anomalyco/opencode/releases/download/v${OPENCODE_VERSION}/${OC_ARCHIVE}"
-
-        mkdir -p "$OC_DIR"
-        if [ -f "$OC_DIR/VERSION" ] && [ "$(cat "$OC_DIR/VERSION")" = "$OPENCODE_VERSION" ] && [ -f "$OC_DIR/opencode" -o -f "$OC_DIR/opencode.exe" ]; then
-            echo "  OpenCode v${OPENCODE_VERSION} already cached in $OC_DIR/"
-        else
-            echo "  Downloading $OC_URL ..."
-            if [ "$OC_EXT" = "zip" ]; then
-                curl -sL "$OC_URL" -o /tmp/opencode-download.zip && unzip -qo /tmp/opencode-download.zip -d "$OC_DIR" && rm -f /tmp/opencode-download.zip
-            else
-                curl -sL "$OC_URL" | tar xzf - -C "$OC_DIR"
-            fi
-            chmod +x "$OC_DIR/opencode" 2>/dev/null || true
-            echo -n "$OPENCODE_VERSION" > "$OC_DIR/VERSION"
-            echo "  OpenCode v${OPENCODE_VERSION} downloaded to $OC_DIR/"
-        fi
-    else
-        echo "  Unknown platform, skipping OpenCode download"
-    fi
+# 1.5 Download embedded agent binaries
+# Use --embed-agent=<id> to download (e.g., --embed-agent=opencode).
+# --with-opencode is a backward-compatible alias for --embed-agent=opencode.
+# Version can be pinned via the version_env variable defined in embedded-agents.yaml.
+if [ ${#EMBED_AGENTS[@]} -gt 0 ]; then
+    # Source the shared download helper
+    # shellcheck source=scripts/download-embedded-agent.sh
+    . ./scripts/download-embedded-agent.sh
+    for _agent_id in "${EMBED_AGENTS[@]}"; do
+        download_embedded_agent "$_agent_id"
+    done
 else
-    echo "[3/5] OpenCode download skipped (use --with-opencode to download embedded agent)"
+    echo "[3/5] Embedded agent download skipped (use --embed-agent=<id> or --with-opencode)"
 fi
 
 # 2. Build Vue frontend
@@ -186,7 +146,7 @@ else
     echo "  ./$NAME              # Go binary"
 fi
 echo "  public/              # Frontend (if built)"
-echo "  .clawbench/opencode/ # OpenCode agent binary (if --with-opencode)"
+echo "  .clawbench/          # Embedded agent binaries (if --embed-agent=<id>)"
 echo ""
 echo "Run with: ./$NAME"
 echo ""
@@ -199,5 +159,6 @@ echo "  ./build.sh --target=darwin/arm64"
 echo "  ./build.sh --android          # Android APK (release)"
 echo ""
 echo "Embedded agent:"
-echo "  ./build.sh --linux --with-opencode  # Linux + OpenCode (CI release)"
-echo "  OPENCODE_VERSION=1.17.10 ./build.sh --with-opencode  # Pin a specific OpenCode version"
+echo "  ./build.sh --linux --embed-agent=opencode   # Linux + OpenCode (CI release)"
+echo "  ./build.sh --linux --with-opencode          # Backward-compatible alias"
+echo "  OPENCODE_VERSION=1.17.10 ./build.sh --embed-agent=opencode  # Pin a specific version"

--- a/config/config.example.yaml
+++ b/config/config.example.yaml
@@ -178,6 +178,8 @@ summarize:
 
 # Default agent (optional; leave empty to use the first agent in database)
 # 默认智能体（可选，留空则使用数据库中的第一个智能体）
+# The default embedded agent (bundled with the installer) is opencode when --embed-agent=opencode is used.
+# 默认嵌入式智能体（随安装包附带）在使用 --embed-agent=opencode 时为 opencode。
 # Available agents depend on your database / 可用智能体取决于数据库
 default_agent: "codebuddy"
 

--- a/embedded-agents.yaml
+++ b/embedded-agents.yaml
@@ -1,0 +1,23 @@
+# Embedded agents bundled with the installer.
+# Download metadata for build/packaging scripts and CI.
+# Go runtime uses BackendSpec.Embedded* fields; this file is for shell/CI only.
+#
+# To add a new embedded agent:
+#   1. Add a BackendSpec with EmbeddedSubDir/EmbeddedGitHubRepo/etc. in the Go backend package
+#   2. Add an entry here with matching id and download metadata
+#   3. No other code changes needed
+
+agents:
+  - id: opencode
+    github_repo: anomalyco/opencode
+    subdir: opencode
+    version_env: OPENCODE_VERSION
+    cmd: opencode
+    archive_naming:
+      linux:   "opencode-linux-{arch}.tar.gz"
+      darwin:  "opencode-darwin-{arch}.zip"
+      windows: "opencode-windows-{arch}.zip"
+    arch_mapping:
+      amd64: x64
+      arm64: arm64
+    version_file: VERSION

--- a/internal/ai/acp_conn_lifecycle.go
+++ b/internal/ai/acp_conn_lifecycle.go
@@ -11,6 +11,8 @@ import (
 	"time"
 
 	acp "github.com/coder/acp-go-sdk"
+
+	"clawbench/internal/model"
 )
 
 // ---------------------------------------------------------------------------
@@ -278,6 +280,8 @@ func (c *ACPConn) killProcessLocked() {
 }
 
 // spawnLocked spawns the agent process and initializes the connection (must hold c.mu).
+//
+//nolint:gocyclo // complex spawn logic with multiple sequential setup steps
 func (c *ACPConn) spawnLocked(ctx context.Context) error {
 	// Kill any existing process first
 	if c.cmd != nil && c.cmd.Process != nil {
@@ -312,6 +316,15 @@ func (c *ACPConn) spawnLocked(ctx context.Context) error {
 
 	cmdName := cmdParts[0]
 	cmdArgs := cmdParts[1:]
+
+	// Resolve embedded binary path for bare command names (e.g. "opencode acp" → use embedded opencode binary).
+	if !strings.Contains(cmdName, "/") {
+		if spec := model.FindBackendSpecByDefaultCmd(cmdName); spec != nil && spec.EmbeddedSubDir != "" {
+			if p := model.EmbeddedBinaryPath(spec.EmbeddedSubDir); p != "" {
+				cmdName = p
+			}
+		}
+	}
 
 	cmd := exec.CommandContext(context.Background(), cmdName, cmdArgs...)
 	cmd.Dir = c.cwd // project working directory for this ACP session

--- a/internal/ai/acp_conn_lifecycle.go
+++ b/internal/ai/acp_conn_lifecycle.go
@@ -265,7 +265,8 @@ func (c *ACPConn) killProcessLocked() {
 		c.stdoutFilter = nil
 	}
 
-	_ = c.cmd.Process.Kill()
+	// Kill the entire process group (see killProcessGroup for rationale).
+	killProcessGroup(c.cmd.Process)
 	oldCmd := c.cmd
 	c.mu.Unlock()
 	_ = oldCmd.Wait()
@@ -294,8 +295,10 @@ func (c *ACPConn) spawnLocked(ctx context.Context) error {
 		// Close the old stdout filter to unblock pending reads before killing
 		if c.stdoutFilter != nil {
 			c.stdoutFilter.Close()
+			c.stdoutFilter = nil
 		}
-		_ = c.cmd.Process.Kill()
+		// Kill the entire process group (npx + child processes).
+		killProcessGroup(c.cmd.Process)
 		oldCmd := c.cmd
 		c.mu.Unlock()
 		_ = oldCmd.Wait()
@@ -330,6 +333,11 @@ func (c *ACPConn) spawnLocked(ctx context.Context) error {
 	cmd.Dir = c.cwd // project working directory for this ACP session
 	cmd.Env = os.Environ()
 	cmd.Env = append(cmd.Env, OrphanChildEnvVar)
+	// Put the ACP process in its own process group so we can kill the
+	// entire tree (npx + child claude process) when closing the connection.
+	// Without this, killing npx leaves the claude child alive, which holds
+	// the stdout/stderr pipes open and causes cmd.Wait() to hang.
+	setProcessGroup(cmd)
 
 	if nodeOpts := os.Getenv("NODE_OPTIONS"); nodeOpts != "" {
 		cmd.Env = append(cmd.Env, "NODE_OPTIONS="+nodeOpts+" --report-on-fatalerror --report-on-signal --report-directory=/tmp/node-reports")

--- a/internal/ai/acp_loadsession_test.go
+++ b/internal/ai/acp_loadsession_test.go
@@ -5,6 +5,7 @@ package ai
 import (
 	"context"
 	"encoding/json"
+	"os/exec"
 	"strings"
 	"testing"
 	"time"
@@ -12,6 +13,8 @@ import (
 	acp "github.com/coder/acp-go-sdk"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	"clawbench/internal/model"
 )
 
 // ===========================================================================
@@ -542,6 +545,621 @@ func TestClaudeACP_LoadSession_ThenNewPrompt(t *testing.T) {
 	// The AI should remember the number from the original conversation
 	assert.True(t, strings.Contains(content2, "42"),
 		"AI should remember '42' from the loaded session, got: %s", content2)
+}
+
+// ===========================================================================
+// Category G: ACP LoadSession — Claude vs OpenCode Latency Comparison
+// ===========================================================================
+//
+// These tests diagnose the "resume button hangs for Claude but works for OpenCode"
+// bug by measuring each phase of the LoadSession pipeline:
+//
+//   GetOrCreateConnForLoad(ctx, agent, loadSID, acpSID, cwd)
+//     → spawnLocked (npx/launch + Initialize, 60s timeout)
+//     → LoadSession RPC (replay history, 60s timeout)
+//   + time.Sleep(500ms) for late-arriving notifications
+//   + replay buffer parsing + DB writes
+//
+// Root cause hypothesis:
+//   - Claude ACP: npx startup slow (5-30s) + LoadSession replays full history (10-60s)
+//   - OpenCode ACP: native binary fast (1-3s) + LoadSession returns immediately
+//     (only sends AvailableCommandsUpdate, no conversation replay)
+//   - Frontend: acpLoadSession() has no fetch timeout → UI freezes indefinitely
+
+// requireOpenCodeACPAvailable skips the test if OpenCode CLI is not installed.
+func requireOpenCodeACPAvailable(t *testing.T) {
+	t.Helper()
+	if _, err := exec.LookPath("opencode"); err != nil {
+		t.Skip("opencode CLI not available, skipping OpenCode ACP LoadSession latency test")
+	}
+}
+
+// opencodeACPAgent returns a model.Agent configured for OpenCode ACP transport.
+func opencodeACPAgent() *model.Agent {
+	return &model.Agent{
+		ID:         "opencode-acp-loadsession-test",
+		Name:       "OpenCode ACP LoadSession Test",
+		Backend:    "opencode",
+		Transport:  "acp-stdio",
+		AcpCommand: "opencode acp",
+		Models: []model.AgentModel{
+			{ID: "default", Name: "Default Model", Default: true},
+		},
+	}
+}
+
+// loadSessionTimings holds measured durations for each LoadSession phase.
+type loadSessionTimings struct {
+	AgentID       string
+	LoadTotal     time.Duration // total GetOrCreateConnForLoad time
+	ReplayNotifs  int           // number of SessionUpdate notifications in replay buffer
+	ReplayContent int           // number of content blocks after parsing
+}
+
+// killAndCloseConn kills the ACP process and removes the connection from the pool.
+// This avoids the cmd.Wait() hang that closeConn suffers when npx spawns child
+// processes that keep the stdout/stderr pipes open after the parent is killed.
+//
+// We kill the process group (not just the parent) and then force-close the
+// stdoutFilter to unblock any pending I/O before calling CloseConn.
+func killAndCloseConn(t *testing.T, env *acpTestEnv, sessionID string) {
+	t.Helper()
+	if conn := env.mgr.GetConn(sessionID); conn != nil {
+		// Kill the process first
+		_ = conn.KillProcessForTest()
+		// Close the stdout filter to unblock pending reads
+		// (this is what killProcessLocked does but KillProcessForTest doesn't)
+		conn.mu.Lock()
+		if conn.stdoutFilter != nil {
+			conn.stdoutFilter.Close()
+			conn.stdoutFilter = nil
+		}
+		conn.mu.Unlock()
+	}
+	env.closeConn(t, sessionID)
+}
+
+// measureLoadSessionLatency performs a full LoadSession round-trip and measures
+// each phase. Returns timings and the parsed replay events.
+func measureLoadSessionLatency(t *testing.T, agent *model.Agent, acpSSID string) (loadSessionTimings, []StreamEvent) {
+	t.Helper()
+
+	env := setupACPTestEnvForAgent(t, agent)
+	backend, err := NewACPBackend(agent)
+	require.NoError(t, err)
+
+	// Use a short prompt to establish the session first
+	sessionID := acpSessionID()
+	cleanupConn(t, sessionID)
+
+	events1 := sendACPPrompt(t, backend, sessionID, "回复一个字：好", 120*time.Second)
+	requireDoneEvent(t, events1)
+
+	capturedAcpSID := extractACPCaptureID(t, events1)
+	require.NotEmpty(t, capturedAcpSID, "should have ACP session ID after prompt")
+
+	t.Logf("Established session: clawbench=%s, acp=%s", sessionID, capturedAcpSID)
+
+	// Close the existing connection so LoadSession creates a new one
+	killAndCloseConn(t, env, sessionID)
+
+	// Now perform LoadSession with timing
+	loadSessionID := acpSessionID()
+	cleanupConn(t, loadSessionID)
+
+	ctx, cancel := contextWithTimeout(t, 120*time.Second)
+	defer cancel()
+
+	loadStart := time.Now()
+	conn, err := env.mgr.GetOrCreateConnForLoad(ctx, agent, loadSessionID, capturedAcpSID, acpTestWorkDir())
+	loadElapsed := time.Since(loadStart)
+
+	if err != nil {
+		t.Skipf("LoadSession not supported or failed: %v", err)
+	}
+	require.NotNil(t, conn, "should have a connection after LoadSession")
+
+	// Wait for late-arriving notifications (same as ServeACPLoadSession handler)
+	time.Sleep(500 * time.Millisecond)
+
+	client := conn.GetClient()
+	require.NotNil(t, client, "should have ACP client after LoadSession")
+
+	buf := client.GetAndClearLoadSessionBuf()
+
+	// Parse replay notifications
+	ch := make(chan StreamEvent, 1000)
+	var allEvents []StreamEvent
+	for _, n := range buf {
+		mapACPSessionUpdate(n.Update, ch, ctx, nil, nil)
+	}
+	close(ch)
+	for event := range ch {
+		allEvents = append(allEvents, event)
+	}
+
+	contentEvents := findACPEvents(allEvents, "content")
+
+	timings := loadSessionTimings{
+		AgentID:       agent.ID,
+		LoadTotal:     loadElapsed,
+		ReplayNotifs:  len(buf),
+		ReplayContent: len(contentEvents),
+	}
+
+	return timings, allEvents
+}
+
+// G1: Claude LoadSession latency profiling
+//
+// Measures the full LoadSession pipeline for Claude ACP, breaking down where
+// time is spent. This test documents the "resume button hangs" bug:
+//
+//   spawnLocked (npx + Initialize):  5-30s
+//   LoadSession RPC (replay):        10-60s (proportional to conversation length)
+//   time.Sleep for late notifs:     500ms (fixed)
+//   Total:                          15-90s
+//
+// Run with verbose output:
+//
+//	go test -v -run TestClaudeACP_LoadSession_LatencyProfile -tags integration -timeout 300s
+func TestClaudeACP_LoadSession_LatencyProfile(t *testing.T) {
+	requireClaudeACPAvailable(t)
+
+	agent := claudeACPAgent()
+	env := setupACPTestEnvForAgent(t, agent)
+	backend, err := NewACPBackend(agent)
+	require.NoError(t, err)
+
+	sessionID := acpSessionID()
+	cleanupConn(t, sessionID)
+
+	// Step 1: Establish a conversation with a simple prompt
+	events1 := sendACPPrompt(t, backend, sessionID, "回复一个字：好", 120*time.Second)
+	requireDoneEvent(t, events1)
+
+	acpSSID := extractACPCaptureID(t, events1)
+	require.NotEmpty(t, acpSSID)
+	t.Logf("Step 1: established session, acp_sid=%s", acpSSID)
+
+	// Step 2: Close the connection and LoadSession
+	killAndCloseConn(t, env, sessionID)
+	loadSessionID := acpSessionID()
+	cleanupConn(t, loadSessionID)
+
+	ctx, cancel := contextWithTimeout(t, 120*time.Second)
+	defer cancel()
+
+	// Measure LoadSession total time
+	loadStart := time.Now()
+	conn, err := env.mgr.GetOrCreateConnForLoad(ctx, agent, loadSessionID, acpSSID, acpTestWorkDir())
+	loadElapsed := time.Since(loadStart)
+
+	if err != nil {
+		t.Skipf("LoadSession not supported or failed: %v", err)
+	}
+	require.NotNil(t, conn)
+
+	// Step 3: Wait for late notifications + read buffer (same as handler)
+	notifsStart := time.Now()
+	time.Sleep(500 * time.Millisecond)
+	client := conn.GetClient()
+	require.NotNil(t, client)
+	buf := client.GetAndClearLoadSessionBuf()
+	notifsElapsed := time.Since(notifsStart)
+
+	// Step 4: Parse replay
+	parseStart := time.Now()
+	ch := make(chan StreamEvent, 1000)
+	var allEvents []StreamEvent
+	for _, n := range buf {
+		mapACPSessionUpdate(n.Update, ch, ctx, nil, nil)
+	}
+	close(ch)
+	for event := range ch {
+		allEvents = append(allEvents, event)
+	}
+	parseElapsed := time.Since(parseStart)
+
+	contentEvents := findACPEvents(allEvents, "content")
+
+	// ── Report ──
+	t.Log("=== Claude LoadSession Latency Breakdown ===")
+	t.Logf("  GetOrCreateConnForLoad (spawn+Initialize+LoadSession RPC): %v", loadElapsed)
+	t.Logf("  Wait for late notifications + read buffer:                 %v", notifsElapsed)
+	t.Logf("  Parse replay notifications:                                %v", parseElapsed)
+	t.Logf("  Total end-to-end:                                         %v", loadElapsed+notifsElapsed+parseElapsed)
+	t.Logf("  Replay notifications: %d", len(buf))
+	t.Logf("  Content events: %d", len(contentEvents))
+
+	// ── Bottleneck detection ──
+	// The LoadSession RPC itself includes spawnLocked + Initialize + LoadSession.
+	// We can't separate them from this level, but the total is what matters
+	// for the "resume button hangs" bug.
+	if loadElapsed > 30*time.Second {
+		t.Logf("BOTTLENECK: GetOrCreateConnForLoad took %v — this causes UI freeze", loadElapsed)
+		t.Log("  Likely causes:")
+		t.Log("    1. npx package resolution for @agentclientprotocol/claude-agent-acp@latest")
+		t.Log("    2. Initialize handshake (60s timeout)")
+		t.Log("    3. LoadSession RPC replaying full conversation history (60s timeout)")
+	}
+	if loadElapsed > 60*time.Second {
+		t.Logf("CRITICAL: LoadSession pipeline exceeded 60s — frontend fetch has no timeout, UI will appear frozen indefinitely")
+	}
+
+	// Verify Claude replays content (unlike OpenCode)
+	// NOTE: Claude's LoadSession may replay content via SessionUpdate notifications
+	// (AgentMessageChunk, UserMessageChunk), but some versions send only
+	// AvailableCommandsUpdate. If content is empty, this doesn't mean LoadSession
+	// failed — it may just mean the bridge version doesn't replay content.
+	if len(contentEvents) > 0 {
+		t.Logf("  Claude LoadSession replayed %d content events (full replay)", len(contentEvents))
+	} else {
+		t.Log("  NOTE: Claude LoadSession returned no content events — bridge may not replay conversation content via SessionUpdate")
+	}
+
+	// Log event type summary
+	typeCounts := make(map[string]int)
+	for _, e := range allEvents {
+		typeCounts[e.Type]++
+	}
+	t.Logf("  Event breakdown: %v", typeCounts)
+}
+
+// G2: OpenCode LoadSession latency profiling
+//
+// Measures the full LoadSession pipeline for OpenCode ACP. Expected to be fast
+// because OpenCode's LoadSession does NOT replay conversation content — it only
+// sends AvailableCommandsUpdate, so the replay buffer is empty.
+//
+// Run with verbose output:
+//
+//	go test -v -run TestOpenCodeACP_LoadSession_LatencyProfile -tags integration -timeout 300s
+func TestOpenCodeACP_LoadSession_LatencyProfile(t *testing.T) {
+	requireOpenCodeACPAvailable(t)
+
+	agent := opencodeACPAgent()
+	env := setupACPTestEnvForAgent(t, agent)
+	backend, err := NewACPBackend(agent)
+	require.NoError(t, err)
+
+	sessionID := acpSessionID()
+	cleanupConn(t, sessionID)
+
+	// Step 1: Establish a conversation
+	events1 := sendACPPrompt(t, backend, sessionID, "回复一个字：好", 120*time.Second)
+	requireDoneEvent(t, events1)
+
+	acpSSID := extractACPCaptureID(t, events1)
+	require.NotEmpty(t, acpSSID)
+	t.Logf("Step 1: established session, acp_sid=%s", acpSSID)
+
+	// Step 2: Close and LoadSession
+	killAndCloseConn(t, env, sessionID)
+	loadSessionID := acpSessionID()
+	cleanupConn(t, loadSessionID)
+
+	ctx, cancel := contextWithTimeout(t, 120*time.Second)
+	defer cancel()
+
+	loadStart := time.Now()
+	conn, err := env.mgr.GetOrCreateConnForLoad(ctx, agent, loadSessionID, acpSSID, acpTestWorkDir())
+	loadElapsed := time.Since(loadStart)
+
+	if err != nil {
+		t.Skipf("LoadSession not supported or failed: %v", err)
+	}
+	require.NotNil(t, conn)
+
+	// Step 3: Read replay buffer
+	time.Sleep(500 * time.Millisecond)
+	client := conn.GetClient()
+	require.NotNil(t, client)
+	buf := client.GetAndClearLoadSessionBuf()
+
+	// Parse replay
+	ch := make(chan StreamEvent, 1000)
+	var allEvents []StreamEvent
+	for _, n := range buf {
+		mapACPSessionUpdate(n.Update, ch, ctx, nil, nil)
+	}
+	close(ch)
+	for event := range ch {
+		allEvents = append(allEvents, event)
+	}
+
+	contentEvents := findACPEvents(allEvents, "content")
+
+	// ── Report ──
+	t.Log("=== OpenCode LoadSession Latency Breakdown ===")
+	t.Logf("  GetOrCreateConnForLoad: %v", loadElapsed)
+	t.Logf("  Replay notifications: %d", len(buf))
+	t.Logf("  Content events: %d", len(contentEvents))
+
+	// OpenCode is expected to be fast
+	t.Logf("  LoadSession total: %v", loadElapsed)
+
+	// OpenCode's LoadSession does NOT replay conversation content
+	// (known issue: opencode_loadsession_bug)
+	if len(contentEvents) == 0 {
+		t.Log("  NOTE: OpenCode LoadSession returned no content events — this is the known opencode_loadsession_bug")
+		t.Log("  OpenCode only sends AvailableCommandsUpdate, not conversation history replay")
+	}
+
+	// Log event type summary
+	typeCounts := make(map[string]int)
+	for _, e := range allEvents {
+		typeCounts[e.Type]++
+	}
+	t.Logf("  Event breakdown: %v", typeCounts)
+}
+
+// G3: Claude vs OpenCode LoadSession latency comparison
+//
+// Runs LoadSession for both Claude and OpenCode on the same conversation
+// and compares the latency. This directly demonstrates the "resume button
+// hangs for Claude but works for OpenCode" bug.
+//
+// Run with verbose output:
+//
+//	go test -v -run TestACP_LoadSession_ClaudeVsOpenCode -tags integration -timeout 600s
+func TestACP_LoadSession_ClaudeVsOpenCode(t *testing.T) {
+	// Run both sub-tests and collect timings
+	var claudeTimings, opencodeTimings *loadSessionTimings
+
+	t.Run("Claude", func(t *testing.T) {
+		requireClaudeACPAvailable(t)
+		agent := claudeACPAgent()
+
+		env := setupACPTestEnvForAgent(t, agent)
+		backend, err := NewACPBackend(agent)
+		require.NoError(t, err)
+
+		sessionID := acpSessionID()
+		cleanupConn(t, sessionID)
+
+		events1 := sendACPPrompt(t, backend, sessionID, "回复一个字：好", 120*time.Second)
+		requireDoneEvent(t, events1)
+
+		acpSSID := extractACPCaptureID(t, events1)
+		require.NotEmpty(t, acpSSID)
+
+		killAndCloseConn(t, env, sessionID)
+		loadSessionID := acpSessionID()
+		cleanupConn(t, loadSessionID)
+
+		ctx, cancel := contextWithTimeout(t, 120*time.Second)
+		defer cancel()
+
+		loadStart := time.Now()
+		conn, err := env.mgr.GetOrCreateConnForLoad(ctx, agent, loadSessionID, acpSSID, acpTestWorkDir())
+		loadElapsed := time.Since(loadStart)
+
+		if err != nil {
+			t.Skipf("LoadSession not supported or failed: %v", err)
+		}
+		require.NotNil(t, conn)
+
+		time.Sleep(500 * time.Millisecond)
+		client := conn.GetClient()
+		require.NotNil(t, client)
+		buf := client.GetAndClearLoadSessionBuf()
+
+		ch := make(chan StreamEvent, 1000)
+		var allEvents []StreamEvent
+		for _, n := range buf {
+			mapACPSessionUpdate(n.Update, ch, ctx, nil, nil)
+		}
+		close(ch)
+		for event := range ch {
+			allEvents = append(allEvents, event)
+		}
+
+		contentEvents := findACPEvents(allEvents, "content")
+		tm := loadSessionTimings{
+			AgentID:       agent.ID,
+			LoadTotal:     loadElapsed,
+			ReplayNotifs:  len(buf),
+			ReplayContent: len(contentEvents),
+		}
+		claudeTimings = &tm
+
+		t.Logf("Claude LoadSession: total=%v, notifs=%d, content=%d",
+			tm.LoadTotal, tm.ReplayNotifs, tm.ReplayContent)
+	})
+
+	t.Run("OpenCode", func(t *testing.T) {
+		requireOpenCodeACPAvailable(t)
+		agent := opencodeACPAgent()
+
+		env := setupACPTestEnvForAgent(t, agent)
+		backend, err := NewACPBackend(agent)
+		require.NoError(t, err)
+
+		sessionID := acpSessionID()
+		cleanupConn(t, sessionID)
+
+		events1 := sendACPPrompt(t, backend, sessionID, "回复一个字：好", 120*time.Second)
+		requireDoneEvent(t, events1)
+
+		acpSSID := extractACPCaptureID(t, events1)
+		require.NotEmpty(t, acpSSID)
+
+		killAndCloseConn(t, env, sessionID)
+		loadSessionID := acpSessionID()
+		cleanupConn(t, loadSessionID)
+
+		ctx, cancel := contextWithTimeout(t, 120*time.Second)
+		defer cancel()
+
+		loadStart := time.Now()
+		conn, err := env.mgr.GetOrCreateConnForLoad(ctx, agent, loadSessionID, acpSSID, acpTestWorkDir())
+		loadElapsed := time.Since(loadStart)
+
+		if err != nil {
+			t.Skipf("LoadSession not supported or failed: %v", err)
+		}
+		require.NotNil(t, conn)
+
+		time.Sleep(500 * time.Millisecond)
+		client := conn.GetClient()
+		require.NotNil(t, client)
+		buf := client.GetAndClearLoadSessionBuf()
+
+		ch := make(chan StreamEvent, 1000)
+		var allEvents []StreamEvent
+		for _, n := range buf {
+			mapACPSessionUpdate(n.Update, ch, ctx, nil, nil)
+		}
+		close(ch)
+		for event := range ch {
+			allEvents = append(allEvents, event)
+		}
+
+		contentEvents := findACPEvents(allEvents, "content")
+		tm := loadSessionTimings{
+			AgentID:       agent.ID,
+			LoadTotal:     loadElapsed,
+			ReplayNotifs:  len(buf),
+			ReplayContent: len(contentEvents),
+		}
+		opencodeTimings = &tm
+
+		t.Logf("OpenCode LoadSession: total=%v, notifs=%d, content=%d",
+			tm.LoadTotal, tm.ReplayNotifs, tm.ReplayContent)
+	})
+
+	// ── Comparison ──
+	if claudeTimings != nil && opencodeTimings != nil {
+		t.Log("=== LoadSession Latency Comparison ===")
+		t.Logf("  Claude:   total=%v  notifs=%d  content=%d",
+			claudeTimings.LoadTotal, claudeTimings.ReplayNotifs, claudeTimings.ReplayContent)
+		t.Logf("  OpenCode: total=%v  notifs=%d  content=%d",
+			opencodeTimings.LoadTotal, opencodeTimings.ReplayNotifs, opencodeTimings.ReplayContent)
+		t.Logf("  Delta:    %v (Claude is slower)", claudeTimings.LoadTotal-opencodeTimings.LoadTotal)
+
+		ratio := float64(claudeTimings.LoadTotal) / float64(opencodeTimings.LoadTotal)
+		t.Logf("  Ratio:    %.1fx (Claude / OpenCode)", ratio)
+
+		if ratio > 3.0 {
+			t.Logf("BUG CONFIRMED: Claude LoadSession is %.1fx slower than OpenCode", ratio)
+			t.Log("  Root cause: Claude ACP uses npx (slow startup) + replays full history via LoadSession")
+			t.Log("  OpenCode uses native binary + LoadSession returns immediately (no history replay)")
+			t.Logf("  Frontend impact: acpLoadSession() fetch has no timeout → UI freezes for %.0fs",
+				claudeTimings.LoadTotal.Seconds())
+		}
+
+		// Claude should have more replay content than OpenCode
+		if claudeTimings.ReplayContent > 0 && opencodeTimings.ReplayContent == 0 {
+			t.Logf("BEHAVIORAL DIFF: Claude replays %d content blocks, OpenCode replays 0", claudeTimings.ReplayContent)
+			t.Log("  This confirms opencode_loadsession_bug: OpenCode LoadSession doesn't replay conversation content")
+		}
+	}
+}
+
+// G4: Claude LoadSession with larger conversation — measures replay scaling
+//
+// Tests whether LoadSession latency scales with conversation length.
+// A longer conversation means more SessionUpdate notifications to replay,
+// potentially making the "resume button hang" worse for long chats.
+//
+// Run with verbose output:
+//
+//	go test -v -run TestClaudeACP_LoadSession_LargeConversation -tags integration -timeout 600s
+func TestClaudeACP_LoadSession_LargeConversation(t *testing.T) {
+	requireClaudeACPAvailable(t)
+
+	agent := claudeACPAgent()
+	env := setupACPTestEnvForAgent(t, agent)
+	backend, err := NewACPBackend(agent)
+	require.NoError(t, err)
+
+	sessionID := acpSessionID()
+	cleanupConn(t, sessionID)
+
+	// Build a multi-turn conversation to increase replay payload size
+	prompts := []string{
+		"回复一个字：一",
+		"回复一个字：二",
+		"回复一个字：三",
+	}
+
+	for i, prompt := range prompts {
+		t.Logf("Turn %d: %s", i+1, prompt)
+		events := sendACPPrompt(t, backend, sessionID, prompt, 120*time.Second)
+		requireDoneEvent(t, events)
+	}
+
+	acpSSID := extractACPCaptureID(t, sendACPPrompt(t, backend, sessionID, "回复一个字：验", 120*time.Second))
+	// Re-send to get capture ID if the last prompt didn't have it
+	if acpSSID == "" {
+		// Try to extract from any prior prompt
+		events := sendACPPrompt(t, backend, sessionID, "回复一个字：验", 120*time.Second)
+		requireDoneEvent(t, events)
+		acpSID := extractACPCaptureID(t, events)
+		if acpSID == "" {
+			t.Skip("Could not extract ACP session ID — LoadSession test requires session_capture event")
+		}
+		acpSSID = acpSID
+	}
+	require.NotEmpty(t, acpSSID)
+
+	t.Logf("Established 4-turn conversation, acp_sid=%s", acpSSID)
+
+	// Close and LoadSession
+	killAndCloseConn(t, env, sessionID)
+	loadSessionID := acpSessionID()
+	cleanupConn(t, loadSessionID)
+
+	ctx, cancel := contextWithTimeout(t, 120*time.Second)
+	defer cancel()
+
+	loadStart := time.Now()
+	conn, err := env.mgr.GetOrCreateConnForLoad(ctx, agent, loadSessionID, acpSSID, acpTestWorkDir())
+	loadElapsed := time.Since(loadStart)
+
+	if err != nil {
+		t.Skipf("LoadSession not supported or failed: %v", err)
+	}
+	require.NotNil(t, conn)
+
+	time.Sleep(500 * time.Millisecond)
+	client := conn.GetClient()
+	require.NotNil(t, client)
+	buf := client.GetAndClearLoadSessionBuf()
+
+	// Parse
+	ch := make(chan StreamEvent, 1000)
+	var allEvents []StreamEvent
+	for _, n := range buf {
+		mapACPSessionUpdate(n.Update, ch, ctx, nil, nil)
+	}
+	close(ch)
+	for event := range ch {
+		allEvents = append(allEvents, event)
+	}
+
+	contentEvents := findACPEvents(allEvents, "content")
+
+	t.Log("=== Claude LoadSession — Large Conversation ===")
+	t.Logf("  GetOrCreateConnForLoad: %v", loadElapsed)
+	t.Logf("  Replay notifications: %d", len(buf))
+	t.Logf("  Content events: %d", len(contentEvents))
+
+	// With 4 turns, we expect at least 4 content events from the replay
+	assert.GreaterOrEqual(t, len(contentEvents), 4,
+		"4-turn conversation should produce at least 4 content events in replay")
+
+	if loadElapsed > 30*time.Second {
+		t.Logf("BOTTLENECK: LoadSession for 4-turn conversation took %v", loadElapsed)
+		t.Log("  Longer conversations will make the resume button hang even worse")
+	}
+
+	typeCounts := make(map[string]int)
+	for _, e := range allEvents {
+		typeCounts[e.Type]++
+	}
+	t.Logf("  Event breakdown: %v", typeCounts)
 }
 
 // ---------------------------------------------------------------------------

--- a/internal/ai/acp_pool.go
+++ b/internal/ai/acp_pool.go
@@ -995,17 +995,37 @@ func (c *ACPConn) ProcessPID() int {
 // close kills the agent process and marks the connection as dead.
 func (c *ACPConn) close() {
 	c.mu.Lock()
-	defer c.mu.Unlock()
 
 	if c.cmd != nil && c.cmd.Process != nil {
-		_ = c.cmd.Process.Kill()
-		_ = c.cmd.Wait()
+		// Close the stdout filter first to unblock pending reads on the pipe.
+		// Without this, cmd.Wait() hangs when the process is killed but
+		// stdout hasn't been closed yet (same pattern as killProcessLocked).
+		if c.stdoutFilter != nil {
+			c.stdoutFilter.Close()
+			c.stdoutFilter = nil
+		}
+
+		// Kill the entire process group (not just the parent process).
+		// ACP agents like Claude are spawned via npx, which creates a child
+		// process (claude). Killing only npx leaves the child alive, which
+		// holds the stderr pipe open and causes cmd.Wait() to hang.
+		killProcessGroup(c.cmd.Process)
+
+		oldCmd := c.cmd
+		c.mu.Unlock()
+		_ = oldCmd.Wait()
+		c.mu.Lock()
+		if c.cmd == oldCmd {
+			c.cmd = nil
+		}
 	}
+
 	c.cmd = nil
 	c.conn = nil
 	c.client = nil
 	c.alive = false
 	c.acpSID = ""
+	c.mu.Unlock()
 }
 
 // Close kills the agent process and marks the connection as dead.

--- a/internal/ai/acp_process_test.go
+++ b/internal/ai/acp_process_test.go
@@ -1,3 +1,5 @@
+//go:build !windows
+
 package ai
 
 import (

--- a/internal/ai/acp_process_test.go
+++ b/internal/ai/acp_process_test.go
@@ -1,0 +1,33 @@
+package ai
+
+import (
+	"os"
+	"os/exec"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestSetProcessGroup(t *testing.T) {
+	cmd := exec.Command("echo", "test")
+	setProcessGroup(cmd)
+	// setProcessGroup sets SysProcAttr with Setpgid:true on non-Windows
+	assert.NotNil(t, cmd.SysProcAttr, "SysProcAttr should be set after setProcessGroup")
+}
+
+func TestKillProcessGroup_ZeroPid(t *testing.T) {
+	// Process with PID 0 should be handled safely (only proc.Kill called, not group kill)
+	p := &os.Process{Pid: 0}
+	assert.NotPanics(t, func() {
+		killProcessGroup(p)
+	})
+}
+
+func TestKillProcessGroup_PositivePid(t *testing.T) {
+	// A process with positive PID but not actually running — proc.Kill will fail
+	// but killProcessGroup should not panic
+	p := &os.Process{Pid: 99999999}
+	assert.NotPanics(t, func() {
+		killProcessGroup(p)
+	})
+}

--- a/internal/ai/acp_process_unix.go
+++ b/internal/ai/acp_process_unix.go
@@ -1,0 +1,30 @@
+//go:build !windows
+
+package ai
+
+import (
+	"os"
+	"os/exec"
+	"syscall"
+)
+
+// setProcessGroup puts the ACP process in its own process group so we can
+// kill the entire tree (npx + child processes) when closing the connection.
+func setProcessGroup(cmd *exec.Cmd) {
+	cmd.SysProcAttr = &syscall.SysProcAttr{Setpgid: true}
+}
+
+// killProcessGroup sends SIGKILL to the process group of the given process.
+// When ACP agents are spawned via npx (which creates child processes),
+// killing only the parent (npx) leaves children alive, holding pipes open
+// and causing cmd.Wait() to hang. Killing the process group ensures all
+// children are terminated, which closes the pipes and unblocks Wait().
+//
+// The process must have been started with Setpgid:true in SysProcAttr
+// for this to work; otherwise the kill signal applies to the single process.
+func killProcessGroup(proc *os.Process) {
+	if proc.Pid > 0 {
+		_ = syscall.Kill(-proc.Pid, syscall.SIGKILL)
+	}
+	_ = proc.Kill()
+}

--- a/internal/ai/acp_process_windows.go
+++ b/internal/ai/acp_process_windows.go
@@ -1,0 +1,22 @@
+//go:build windows
+
+package ai
+
+import (
+	"os"
+	"os/exec"
+)
+
+// setProcessGroup is a no-op on Windows. POSIX process groups don't exist;
+// Job Objects would be needed for proper child cleanup. For now, Kill() on
+// the parent process is sufficient for most cases.
+func setProcessGroup(cmd *exec.Cmd) {
+	// Windows: no POSIX process groups
+}
+
+// killProcessGroup kills the process. On Windows, there are no POSIX process
+// groups, so we can only kill the parent. Child processes spawned by npx may
+// survive; cmd.Wait() should still complete once the parent exits.
+func killProcessGroup(proc *os.Process) {
+	_ = proc.Kill()
+}

--- a/internal/ai/backends/opencode/cli.go
+++ b/internal/ai/backends/opencode/cli.go
@@ -44,6 +44,8 @@ func init() {
 			AcpCommand:           "opencode acp",
 			EmbeddedSubDir:       "opencode",
 			EmbeddedVersionFile:  "VERSION",
+			EmbeddedGitHubRepo:   "anomalyco/opencode",
+			EmbeddedArchMapping:  "amd64=x64",
 			SortOrder:            3,
 		},
 		ACP: &backends.ACPPlugin{

--- a/internal/ai/backends/opencode/discovery.go
+++ b/internal/ai/backends/opencode/discovery.go
@@ -54,8 +54,10 @@ func parseOpenCodeModels(output string) []model.AgentModel {
 func DiscoverOpenCodeModels() []model.AgentModel {
 	// Try embedded binary first, fall back to PATH
 	opencodeCmd := "opencode"
-	if p := model.EmbeddedBinaryPath("opencode"); p != "" {
-		opencodeCmd = p
+	if spec := model.FindSpecByBackend("opencode"); spec != nil && spec.EmbeddedSubDir != "" {
+		if p := model.EmbeddedBinaryPath(spec.EmbeddedSubDir); p != "" {
+			opencodeCmd = p
+		}
 	}
 
 	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)

--- a/internal/ai/backends/pi/discovery.go
+++ b/internal/ai/backends/pi/discovery.go
@@ -55,10 +55,18 @@ func ParsePiModels(output string) []model.AgentModel {
 // DiscoverPiModels discovers Pi model IDs by running `pi --list-models` and parsing the output.
 // Pi outputs the model table to stderr (not stdout), so we must capture both streams.
 func DiscoverPiModels() []model.AgentModel {
+	// Try embedded binary first, fall back to PATH
+	piCmd := "pi"
+	if spec := model.FindSpecByBackend("pi"); spec != nil && spec.EmbeddedSubDir != "" {
+		if p := model.EmbeddedBinaryPath(spec.EmbeddedSubDir); p != "" {
+			piCmd = p
+		}
+	}
+
 	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 	defer cancel()
 
-	cmd := exec.CommandContext(ctx, "pi", "--list-models")
+	cmd := exec.CommandContext(ctx, piCmd, "--list-models")
 	// Pi outputs the model table to stderr; use CombinedOutput to capture both.
 	out, err := cmd.CombinedOutput()
 	if err != nil {

--- a/internal/ai/cli_backend.go
+++ b/internal/ai/cli_backend.go
@@ -10,6 +10,8 @@ import (
 	"os/exec"
 	"strings"
 	"time"
+
+	"clawbench/internal/model"
 )
 
 // CLIBackend is a generic AI backend that shells out to a CLI tool and streams
@@ -57,6 +59,15 @@ func (b *CLIBackend) ExecuteStream(ctx context.Context, req ChatRequest) (<-chan
 	cmdName := req.Command
 	if cmdName == "" {
 		cmdName = b.Cmd
+	}
+	// Resolve embedded binary path for bare command names (e.g. "opencode")
+	// that aren't found in $PATH but exist under .clawbench/{subDir}/.
+	if !strings.Contains(cmdName, "/") {
+		if spec := model.FindBackendSpecByDefaultCmd(cmdName); spec != nil && spec.EmbeddedSubDir != "" {
+			if p := model.EmbeddedBinaryPath(spec.EmbeddedSubDir); p != "" {
+				cmdName = p
+			}
+		}
 	}
 	cmd := exec.CommandContext(ctx, cmdName, args...)
 	cmd.Dir = req.WorkDir

--- a/internal/model/discovery.go
+++ b/internal/model/discovery.go
@@ -55,6 +55,8 @@ type BackendSpec struct {
 	AcpCommand           string   // ACP spawn command for acp-stdio transport, e.g. "kimi --acp"; empty = no ACP support
 	EmbeddedSubDir       string   // subdirectory under .clawbench/ for embedded binary, e.g. "pi"; empty = no embedded binary
 	EmbeddedVersionFile  string   // filename for fast version lookup under EmbeddedSubDir, e.g. "VERSION"; empty = no version file
+	EmbeddedGitHubRepo   string   // GitHub repo for release downloads, e.g. "anomalyco/opencode"; empty = no auto-download
+	EmbeddedArchMapping  string   // arch name mapping in archive names, e.g. "amd64=x64"; empty = no mapping
 	SortOrder            int      // display/registration order for deterministic BackendRegistry ordering
 }
 

--- a/internal/model/discovery.go
+++ b/internal/model/discovery.go
@@ -94,7 +94,7 @@ func CheckCLIExists(cmd string) bool {
 	}
 
 	// Check for embedded binary (e.g. .clawbench/pi/pi)
-	if spec := findSpecByDefaultCmd(cmd); spec != nil && spec.EmbeddedSubDir != "" {
+	if spec := FindBackendSpecByDefaultCmd(cmd); spec != nil && spec.EmbeddedSubDir != "" {
 		if EmbeddedBinaryPath(spec.EmbeddedSubDir) != "" {
 			return true
 		}
@@ -131,7 +131,7 @@ func CheckCLIExistsErr(cmd string) error {
 	}
 
 	// Check for embedded binary
-	if spec := findSpecByDefaultCmd(cmd); spec != nil && spec.EmbeddedSubDir != "" {
+	if spec := FindBackendSpecByDefaultCmd(cmd); spec != nil && spec.EmbeddedSubDir != "" {
 		if EmbeddedBinaryPath(spec.EmbeddedSubDir) != "" {
 			return nil
 		}
@@ -182,8 +182,8 @@ func FindSpecByBackend(backend string) *BackendSpec {
 	return nil
 }
 
-// findSpecByDefaultCmd returns the BackendSpec whose DefaultCmd matches, or nil.
-func findSpecByDefaultCmd(cmd string) *BackendSpec {
+// FindBackendSpecByDefaultCmd returns the BackendSpec whose DefaultCmd matches, or nil.
+func FindBackendSpecByDefaultCmd(cmd string) *BackendSpec {
 	registry := GetBackendRegistry()
 	for i := range registry {
 		if registry[i].DefaultCmd == cmd {

--- a/internal/model/discovery_test.go
+++ b/internal/model/discovery_test.go
@@ -65,6 +65,12 @@ func TestBackendRegistry_SpecificValues(t *testing.T) {
 	assert.Equal(t, "codewhale", specs["deepseek"].DefaultCmd)
 	assert.Equal(t, "deepseek", specs["deepseek"].AltCmd)
 	assert.Equal(t, "pi", specs["pi"].DefaultCmd)
+
+	// Verify embedded agent metadata on opencode BackendSpec
+	assert.Equal(t, "opencode", specs["opencode"].EmbeddedSubDir, "opencode should have EmbeddedSubDir set")
+	assert.Equal(t, "VERSION", specs["opencode"].EmbeddedVersionFile, "opencode should have EmbeddedVersionFile set")
+	assert.Equal(t, "anomalyco/opencode", specs["opencode"].EmbeddedGitHubRepo, "opencode should have EmbeddedGitHubRepo set")
+	assert.Equal(t, "amd64=x64", specs["opencode"].EmbeddedArchMapping, "opencode should have EmbeddedArchMapping set")
 }
 
 // --- Test 2: checkCLIExists ---

--- a/internal/model/discovery_test.go
+++ b/internal/model/discovery_test.go
@@ -258,6 +258,25 @@ func TestDiscoverModels_RegistryPath(t *testing.T) {
 	assert.True(t, called, "registry function should have been called")
 }
 
+// --- Test 9: FindBackendSpecByDefaultCmd ---
+
+func TestFindBackendSpecByDefaultCmd_Found(t *testing.T) {
+	spec := model.FindBackendSpecByDefaultCmd("opencode")
+	require.NotNil(t, spec)
+	assert.Equal(t, "opencode", spec.ID)
+	assert.Equal(t, "opencode", spec.DefaultCmd)
+}
+
+func TestFindBackendSpecByDefaultCmd_NotFound(t *testing.T) {
+	spec := model.FindBackendSpecByDefaultCmd("nonexistent_cmd_xyz")
+	assert.Nil(t, spec)
+}
+
+func TestFindBackendSpecByDefaultCmd_Empty(t *testing.T) {
+	spec := model.FindBackendSpecByDefaultCmd("")
+	assert.Nil(t, spec)
+}
+
 // --- Test 10: AsyncRefreshModelCache ---
 
 func TestAsyncRefreshModelCache_DoesNotPanic(t *testing.T) {

--- a/scripts/docker-build.sh
+++ b/scripts/docker-build.sh
@@ -31,18 +31,25 @@ if [ "$1" = "--clean" ]; then
 fi
 
 # Build binary (always rebuild to pick up latest code)
-echo "Building binary..."
-./build.sh --with-opencode
+EMBEDDED_AGENT_ID="${EMBEDDED_AGENT_ID:-opencode}"
+echo "Building binary with embedded agent: $EMBEDDED_AGENT_ID"
+./build.sh --embed-agent="$EMBEDDED_AGENT_ID"
+
+# Source download helper to read agent config
+# shellcheck source=scripts/download-embedded-agent.sh
+. ./scripts/download-embedded-agent.sh
 
 # Prepare staging directory for embedded binary
 rm -rf docker-staging
-mkdir -p docker-staging/opencode
-if [ -d ".clawbench/opencode" ] && [ -f ".clawbench/opencode/opencode" ]; then
-    cp -r .clawbench/opencode/* docker-staging/opencode/
-    echo "OpenCode binary included in image (with dependencies)"
+AGENT_SUBDIR=$(parse_embedded_agent_config "$EMBEDDED_AGENT_ID" subdir)
+AGENT_CMD=$(parse_embedded_agent_config "$EMBEDDED_AGENT_ID" cmd)
+mkdir -p "docker-staging/$AGENT_SUBDIR"
+if [ -d ".clawbench/$AGENT_SUBDIR" ] && [ -f ".clawbench/$AGENT_SUBDIR/$AGENT_CMD" ]; then
+    cp -r ".clawbench/$AGENT_SUBDIR/"* "docker-staging/$AGENT_SUBDIR/"
+    echo "$EMBEDDED_AGENT_ID binary included in image (with dependencies)"
 else
-    echo "OpenCode binary not found"
-    echo "  (Run ./build.sh --with-opencode to download it)"
+    echo "$EMBEDDED_AGENT_ID binary not found"
+    echo "  (Run ./build.sh --embed-agent=$EMBEDDED_AGENT_ID to download it)"
 fi
 
 # Build and run via docker compose (staging dir must exist during build)

--- a/scripts/download-embedded-agent.sh
+++ b/scripts/download-embedded-agent.sh
@@ -1,0 +1,332 @@
+#!/usr/bin/env bash
+# Shared helper for downloading embedded agent binaries.
+# Sourced by build.sh, Dockerfile RUN, and CI composite action.
+#
+# Requires: curl, embedded-agents.yaml in CWD or SCRIPT_DIR
+#
+# Functions:
+#   parse_embedded_agent_config <agent_id> <field>  — read a field from embedded-agents.yaml
+#   download_embedded_agent <agent_id>               — full download (version resolve + platform + download)
+#   download_embedded_agent_for_docker <agent_id> <version> [arch]  — Docker RUN variant
+
+# NOTE: This script is sourced — do NOT set shell options here (set -euo pipefail)
+# as they would propagate to the caller. Each function handles its own errors.
+
+# Locate embedded-agents.yaml relative to this script or CWD
+_EMBEDDED_AGENTS_YAML="${EMBEDDED_AGENTS_YAML:-}"
+if [ -z "$_EMBEDDED_AGENTS_YAML" ]; then
+    _SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+    if [ -f "${_SCRIPT_DIR}/../embedded-agents.yaml" ]; then
+        _EMBEDDED_AGENTS_YAML="${_SCRIPT_DIR}/../embedded-agents.yaml"
+    elif [ -f "./embedded-agents.yaml" ]; then
+        _EMBEDDED_AGENTS_YAML="./embedded-agents.yaml"
+    else
+        echo "ERROR: embedded-agents.yaml not found. Set EMBEDDED_AGENTS_YAML env var." >&2
+        return 1 2>/dev/null || exit 1
+    fi
+fi
+
+# parse_embedded_agent_config <agent_id> <field>
+# Reads a field value from embedded-agents.yaml for the given agent.
+# Supported fields: id, github_repo, subdir, version_env, cmd, version_file
+# For archive_naming, use: parse_archive_naming <agent_id> <os>
+# For arch_mapping, use: parse_arch_mapping <agent_id> <arch>
+parse_embedded_agent_config() {
+    local agent_id="$1" field="$2"
+
+    # Use awk to parse the simple YAML structure
+    # Find the agent block starting with "- id: <agent_id>", then extract the field
+    awk -v agent="$agent_id" -v fld="$field" '
+    BEGIN { in_agent=0; found=0 }
+    /^  - id:/ { in_agent=0 }
+    /^  - id: '"$agent_id"'/ { in_agent=1; next }
+    in_agent && $1 == (fld ":") {
+        # Print value after "field: "
+        sub(/^[^:]*: */, "")
+        print
+        found=1
+        exit
+    }
+    ' "$_EMBEDDED_AGENTS_YAML"
+}
+
+# parse_archive_naming <agent_id> <os>
+# Returns the archive naming pattern for the given OS (linux/darwin/windows)
+parse_archive_naming() {
+    local agent_id="$1" os="$2"
+
+    awk -v agent="$agent_id" -v target_os="$os" '
+    BEGIN { in_agent=0; in_archive=0 }
+    /^  - id:/ { in_agent=0; in_archive=0 }
+    /^  - id: '"$agent_id"'/ { in_agent=1; next }
+    in_agent && /^    archive_naming:/ { in_archive=1; next }
+    in_archive && /^      '"$os"':/ {
+        sub(/^[^:]*: */, "")
+        gsub(/"/, "")
+        print
+        exit
+    }
+    in_archive && /^[^ ]/ { in_archive=0 }
+    ' "$_EMBEDDED_AGENTS_YAML"
+}
+
+# parse_arch_mapping <agent_id> <arch>
+# Returns the mapped arch name (e.g., amd64 -> x64)
+parse_arch_mapping() {
+    local agent_id="$1" arch="$2"
+
+    awk -v agent="$agent_id" -v target_arch="$arch" '
+    BEGIN { in_agent=0; in_mapping=0 }
+    /^  - id:/ { in_agent=0; in_mapping=0 }
+    /^  - id: '"$agent_id"'/ { in_agent=1; next }
+    in_agent && /^    arch_mapping:/ { in_mapping=1; next }
+    in_mapping && /^      [a-z]/ {
+        key = $1
+        sub(/:$/, "", key)
+        if (key == target_arch) {
+            sub(/^[^:]*: */, "")
+            print
+            exit
+        }
+    }
+    in_mapping && /^[^ ]/ { in_mapping=0 }
+    ' "$_EMBEDDED_AGENTS_YAML"
+}
+
+# validate_agent_id <agent_id>
+# Validates that the agent exists in embedded-agents.yaml and has required fields.
+validate_agent_id() {
+    local agent_id="$1"
+    local subdir
+    subdir=$(parse_embedded_agent_config "$agent_id" subdir)
+    if [ -z "$subdir" ]; then
+        echo "ERROR: Agent '${agent_id}' not found in embedded-agents.yaml. Available agents:" >&2
+        awk '/^  - id:/ { sub(/^  - id: */, ""); print "  - " $0 }' "$_EMBEDDED_AGENTS_YAML" >&2
+        return 1
+    fi
+}
+
+# validate_version <version>
+# Validates that a version string looks like a semver version (e.g., "1.17.10" or "0.30.0-rc1")
+validate_version() {
+    local version="$1"
+    if ! [[ "$version" =~ ^[0-9]+(\.[0-9]+)+(-[a-zA-Z0-9._-]+)?$ ]]; then
+        echo "ERROR: Invalid version format: '${version}'" >&2
+        return 1
+    fi
+}
+
+# validate_github_repo <repo>
+# Validates that a github_repo matches the "owner/repo" format
+validate_github_repo() {
+    local repo="$1"
+    if ! [[ "$repo" =~ ^[a-zA-Z0-9._-]+/[a-zA-Z0-9._-]+$ ]]; then
+        echo "ERROR: Invalid github_repo format: '${repo}'" >&2
+        return 1
+    fi
+}
+
+# resolve_agent_version <agent_id>
+# Resolves the agent version: env var override > auto-detect latest from GitHub
+resolve_agent_version() {
+    local agent_id="$1"
+    local version_env
+    version_env=$(parse_embedded_agent_config "$agent_id" version_env)
+    local github_repo
+    github_repo=$(parse_embedded_agent_config "$agent_id" github_repo)
+
+    local version=""
+
+    # Check env var override first
+    if [ -n "$version_env" ]; then
+        version="${!version_env:-}"
+    fi
+
+    # Auto-detect from GitHub if no override
+    if [ -z "$version" ] && [ -n "$github_repo" ]; then
+        validate_github_repo "$github_repo" || return 1
+        version=$(curl -sI "https://github.com/${github_repo}/releases/latest" 2>/dev/null \
+            | grep -i "^location:" \
+            | sed 's|.*/tag/v||' \
+            | tr -d '[:space:]')
+        if [ -z "$version" ]; then
+            echo "ERROR: Could not detect latest version for ${agent_id}. Set ${version_env} manually." >&2
+            return 1
+        fi
+        echo "  Auto-detected latest ${agent_id} version: v${version}" >&2
+    fi
+
+    validate_version "$version" || return 1
+    echo "$version"
+}
+
+# resolve_agent_version_gh <agent_id> <github_token>
+# Resolves version using GitHub API (gh cli) — for CI environments
+resolve_agent_version_gh() {
+    local agent_id="$1" gh_token="$2"
+    local version_env
+    version_env=$(parse_embedded_agent_config "$agent_id" version_env)
+    local github_repo
+    github_repo=$(parse_embedded_agent_config "$agent_id" github_repo)
+
+    local version=""
+
+    # Check env var override first
+    if [ -n "$version_env" ]; then
+        version="${!version_env:-}"
+    fi
+
+    # Use gh API
+    if [ -z "$version" ] && [ -n "$github_repo" ]; then
+        validate_github_repo "$github_repo" || return 1
+        version=$(GH_TOKEN="$gh_token" gh api "repos/${github_repo}/releases/latest" --jq '.tag_name' | sed 's/^v//')
+        if [ -z "$version" ]; then
+            echo "ERROR: Could not detect latest version for ${agent_id} via GitHub API." >&2
+            return 1
+        fi
+    fi
+
+    validate_version "$version" || return 1
+    echo "$version"
+}
+
+# download_embedded_agent <agent_id>
+# Full download: resolve version, determine platform, download, chmod, write VERSION
+download_embedded_agent() {
+    local agent_id="$1"
+
+    validate_agent_id "$agent_id" || return 1
+
+    local subdir
+    subdir=$(parse_embedded_agent_config "$agent_id" subdir)
+    local cmd
+    cmd=$(parse_embedded_agent_config "$agent_id" cmd)
+    local version_file
+    version_file=$(parse_embedded_agent_config "$agent_id" version_file)
+    local github_repo
+    github_repo=$(parse_embedded_agent_config "$agent_id" github_repo)
+
+    validate_github_repo "$github_repo" || return 1
+
+    local version
+    version=$(resolve_agent_version "$agent_id") || return 1
+
+    echo "[*] Downloading ${agent_id} v${version}..."
+
+    local agent_dir=".clawbench/${subdir}"
+
+    # Determine platform
+    local os arch
+    if [ -n "${TARGET_OS:-}" ] && [ -n "${TARGET_ARCH:-}" ]; then
+        os="$TARGET_OS"
+        arch="$TARGET_ARCH"
+    else
+        os="$(uname -s | tr '[:upper:]' '[:lower:]')"
+        arch="$(uname -m)"
+        # Normalize arch
+        arch="${arch/x86_64/amd64}"
+        arch="${arch/aarch64/arm64}"
+    fi
+
+    # Apply arch mapping
+    local mapped_arch
+    mapped_arch=$(parse_arch_mapping "$agent_id" "$arch")
+    [ -z "$mapped_arch" ] && mapped_arch="$arch"
+
+    # Get archive pattern and substitute {arch}
+    local archive_pattern
+    archive_pattern=$(parse_archive_naming "$agent_id" "$os")
+    if [ -z "$archive_pattern" ]; then
+        echo "  ERROR: No archive naming pattern for OS '${os}' in agent '${agent_id}'." >&2
+        return 1
+    fi
+    local archive_name="${archive_pattern//\{arch\}/$mapped_arch}"
+
+    local url="https://github.com/${github_repo}/releases/download/v${version}/${archive_name}"
+
+    mkdir -p "$agent_dir"
+
+    # Check cache
+    if [ -f "$agent_dir/${version_file}" ] && [ "$(cat "$agent_dir/${version_file}")" = "$version" ] && [ -f "$agent_dir/$cmd" -o -f "$agent_dir/${cmd}.exe" ]; then
+        echo "  ${agent_id} v${version} already cached in $agent_dir/"
+        return 0
+    fi
+
+    # Download (use temp file + curl --fail to catch HTTP errors)
+    local ext="${archive_name##*.}"
+    echo "  Downloading $url ..."
+    if [ "$ext" = "zip" ]; then
+        local tmp="/tmp/${agent_id}-download.zip"
+        curl -sL --fail "$url" -o "$tmp" && unzip -qo "$tmp" -d "$agent_dir" && rm -f "$tmp"
+    else
+        local tmp="/tmp/${agent_id}-download.tar.gz"
+        curl -sL --fail "$url" -o "$tmp" && tar xzf "$tmp" -C "$agent_dir" && rm -f "$tmp"
+    fi
+    chmod +x "$agent_dir/$cmd" 2>/dev/null || true
+    echo -n "$version" > "$agent_dir/${version_file}"
+    echo "  ${agent_id} v${version} downloaded to $agent_dir/"
+}
+
+# download_embedded_agent_for_docker <agent_id> <version> [arch]
+# Docker RUN variant: version and arch are explicit, no auto-detect
+download_embedded_agent_for_docker() {
+    local agent_id="$1" version="$2"
+    local arch="${3:-}"
+
+    validate_agent_id "$agent_id" || return 1
+    validate_version "$version" || return 1
+
+    local subdir
+    subdir=$(parse_embedded_agent_config "$agent_id" subdir)
+    local cmd
+    cmd=$(parse_embedded_agent_config "$agent_id" cmd)
+    local version_file
+    version_file=$(parse_embedded_agent_config "$agent_id" version_file)
+    local github_repo
+    github_repo=$(parse_embedded_agent_config "$agent_id" github_repo)
+
+    validate_github_repo "$github_repo" || return 1
+
+    local agent_dir=".clawbench/${subdir}"
+
+    # Docker is always linux
+    local os="linux"
+
+    # Determine arch from TARGETARCH or explicit parameter
+    if [ -z "$arch" ] && [ -n "${TARGETARCH:-}" ]; then
+        arch="$TARGETARCH"
+    fi
+    [ -z "$arch" ] && arch="amd64"
+
+    # Apply arch mapping
+    local mapped_arch
+    mapped_arch=$(parse_arch_mapping "$agent_id" "$arch")
+    [ -z "$mapped_arch" ] && mapped_arch="$arch"
+
+    # Get archive pattern
+    local archive_pattern
+    archive_pattern=$(parse_archive_naming "$agent_id" "$os")
+    if [ -z "$archive_pattern" ]; then
+        echo "ERROR: No archive naming pattern for OS '${os}'." >&2
+        return 1
+    fi
+    local archive_name="${archive_pattern//\{arch\}/$mapped_arch}"
+
+    local url="https://github.com/${github_repo}/releases/download/v${version}/${archive_name}"
+
+    mkdir -p "$agent_dir"
+
+    # Download (use temp file + curl --fail to catch HTTP errors)
+    local ext="${archive_name##*.}"
+    echo "Downloading ${agent_id} v${version} (${mapped_arch})..."
+    if [ "$ext" = "zip" ]; then
+        local tmp="/tmp/${agent_id}-download.zip"
+        curl -sL --fail "$url" -o "$tmp" && unzip -qo "$tmp" -d "$agent_dir" && rm -f "$tmp"
+    else
+        local tmp="/tmp/${agent_id}-download.tar.gz"
+        curl -sL --fail "$url" -o "$tmp" && tar xzf "$tmp" -C "$agent_dir" && rm -f "$tmp"
+    fi
+    chmod +x "$agent_dir/$cmd" 2>/dev/null || true
+    echo -n "$version" > "$agent_dir/${version_file}"
+    echo "${agent_id} v${version} (${mapped_arch}) downloaded"
+}

--- a/web/src/components/chat/AcpSessionDrawer.vue
+++ b/web/src/components/chat/AcpSessionDrawer.vue
@@ -103,7 +103,7 @@ async function handleSelect(session: AcpSessionInfo) {
   resumingId.value = session.sessionId
   const sessionId = await acpLoadSession(session.sessionId)
   resumingId.value = ''
-  if (sessionId) {
+  if (sessionId && sessionId !== 'not-found') {
     emit('select', sessionId)
     emit('close')
   }

--- a/web/src/components/chat/ContentBlocks.vue
+++ b/web/src/components/chat/ContentBlocks.vue
@@ -318,6 +318,13 @@ const isLastBlockThinking = computed(() => {
 const collapsingThinking = ref({})   // { [blockIndex]: true } for blocks mid-collapse
 const collapsingMaxHeight = ref({})  // { [blockIndex]: maxHeightPx } for animation
 let _collapseElRefs = {}             // { [blockIndex]: HTMLElement } tracked during streaming
+let _collapseTimers = []             // setTimeout IDs for collapse animation (cleaned up on unmount)
+
+// Collapse animation constants — must stay in sync with CSS
+const COLLAPSED_CHIP_HEIGHT = 28     // px — matches .thinking-collapsed { max-height: 28px }
+const COLLAPSE_READ_DELAY = 3000     // ms — time to read thinking output before collapsing
+const COLLAPSE_TRANSITION_MS = 400   // ms — must match CSS transition-duration + buffer
+const COLLAPSE_PLACEHOLDER_MAX = 99999 // large sentinel to keep content visible during nextTick
 
 /** Track thinking block element refs during streaming for collapse animation. */
 function setThinkingRef(bi, el) {
@@ -443,83 +450,142 @@ watch(() => props.streaming, (streaming, wasStreaming) => {
   if (wasStreaming && !streaming) {
     if (_throttleTimer) { clearTimeout(_throttleTimer); _throttleTimer = null }
     _throttlePending = false
-    blockHtmlCache.value = {}
-    // Snapshot element refs and measure heights before Vue clears them
+    // Snapshot element refs before Vue clears them
     // (isThinkingStreaming becomes false → :ref becomes undefined → ref cleared).
-    // Set collapsing state immediately so the template renders with maxHeight override
-    // instead of the 28px collapsed CSS, preventing a flash.
     const refSnapshot = { ..._collapseElRefs }
-    const newCollapsing = {}
-    const newMaxHeights = {}
-    for (const idxStr of Object.keys(refSnapshot)) {
-      const el = refSnapshot[idxStr]
-      if (el && el.scrollHeight) {
-        newCollapsing[idxStr] = true
-        newMaxHeights[idxStr] = el.scrollHeight
-      }
-    }
     _collapseElRefs = {}
-    if (Object.keys(newCollapsing).length > 0) {
-      collapsingThinking.value = newCollapsing
-      collapsingMaxHeight.value = newMaxHeights
-      // Delay before starting collapse animation so user can read the thinking output
-      setTimeout(() => {
-        const updatedMaxHeights = {}
-        Object.keys(newCollapsing).forEach(idx => {
-          updatedMaxHeights[idx] = 28 // header-only height
-        })
-        collapsingMaxHeight.value = updatedMaxHeights
-        // After transition completes, clean up animation state
-        setTimeout(() => {
-          collapsingThinking.value = {}
-          collapsingMaxHeight.value = {}
-        }, 400) // match CSS transition duration
-      }, 3000)
+    // Only process blocks not already being collapsed by Trigger B (thinking_done)
+    const collapsingKeys = Object.keys(refSnapshot).filter(
+      idxStr => !collapsingThinking.value[idxStr]
+    )
+    if (collapsingKeys.length > 0) {
+      // Immediately mark as "collapsing" with a large maxHeight so the template
+      // keeps showing inline content and doesn't flash to the 28px collapsed chip.
+      const placeholderCollapsing = {}
+      const placeholderMaxHeight = {}
+      for (const idxStr of collapsingKeys) {
+        placeholderCollapsing[idxStr] = true
+        placeholderMaxHeight[idxStr] = COLLAPSE_PLACEHOLDER_MAX
+      }
+      Object.assign(collapsingThinking.value, placeholderCollapsing)
+      Object.assign(collapsingMaxHeight.value, placeholderMaxHeight)
     }
+    // Clear throttle cache and force a full re-render of thinking HTML
+    // so the DOM reflects the complete block.text before we measure scrollHeight.
+    // Without this, scrollHeight may reflect stale throttled HTML (up to 300ms old),
+    // causing the collapse animation to clip the bottom of the content.
+    blockHtmlCache.value = {}
+    // Wait for Vue to flush the DOM with complete content, then measure heights.
+    nextTick(() => {
+      const newCollapsing = {}
+      const newMaxHeights = {}
+      for (const idxStr of collapsingKeys) {
+        const el = refSnapshot[idxStr]
+        // el.isConnected: defensive check — element must still be in the document
+        if (el && el.isConnected && el.scrollHeight) {
+          newCollapsing[idxStr] = true
+          newMaxHeights[idxStr] = el.scrollHeight
+        }
+      }
+      if (Object.keys(newCollapsing).length > 0) {
+        Object.assign(collapsingThinking.value, newCollapsing)
+        Object.assign(collapsingMaxHeight.value, newMaxHeights)
+        // Delay before starting collapse animation so user can read the thinking output
+        const t1 = setTimeout(() => {
+          const updatedMaxHeights = {}
+          Object.keys(newCollapsing).forEach(idx => {
+            updatedMaxHeights[idx] = COLLAPSED_CHIP_HEIGHT
+          })
+          Object.assign(collapsingMaxHeight.value, updatedMaxHeights)
+          // After transition completes, clean up animation state
+          const t2 = setTimeout(() => {
+            for (const idx of Object.keys(newCollapsing)) {
+              delete collapsingThinking.value[idx]
+              delete collapsingMaxHeight.value[idx]
+            }
+          }, COLLAPSE_TRANSITION_MS)
+          _collapseTimers.push(t2)
+        }, COLLAPSE_READ_DELAY)
+        _collapseTimers.push(t1)
+      } else {
+        // No measurable elements — clean up placeholder state
+        for (const idxStr of collapsingKeys) {
+          delete collapsingThinking.value[idxStr]
+          delete collapsingMaxHeight.value[idxStr]
+        }
+      }
+    })
   }
 })
 
 // Watch for thinking blocks that become "done" mid-stream (via thinking_done SSE event).
 // This triggers the collapse animation immediately instead of waiting for streaming to end.
-watch(() => props.blocks.filter(b => b.type === 'thinking' && b.done).map(b => b.done), (newDones, oldDones) => {
+watch(() => props.blocks.filter(b => b.type === 'thinking' && b.done).map(b => b.done), (_newDones, _oldDones) => {
   if (!props.streaming) return // Only relevant during streaming
-  // Find thinking blocks that just became done (newly true)
-  const newCollapsing = {}
-  const newMaxHeights = {}
-  let changed = false
+  // Find thinking blocks that just became done (newly true), not already collapsing
+  const refSnapshot = {}
   for (let i = 0; i < props.blocks.length; i++) {
     const block = props.blocks[i]
     if (block.type === 'thinking' && block.done) {
       const el = _collapseElRefs[i]
-      if (el && el.scrollHeight && !collapsingThinking.value[i]) {
-        newCollapsing[i] = true
-        newMaxHeights[i] = el.scrollHeight
-        changed = true
+      if (el && !collapsingThinking.value[i]) {
+        refSnapshot[i] = el
+        delete _collapseElRefs[i]
       }
     }
   }
-  if (changed) {
-    // Remove from refs so they don't get double-collapsed
-    for (const idx of Object.keys(newCollapsing)) {
-      delete _collapseElRefs[idx]
-    }
-    Object.assign(collapsingThinking.value, newCollapsing)
-    Object.assign(collapsingMaxHeight.value, newMaxHeights)
-    // Delay before starting collapse animation so user can read the thinking output
-    setTimeout(() => {
-      const updatedMaxHeights = {}
-      Object.keys(newCollapsing).forEach(idx => {
-        updatedMaxHeights[idx] = 28
-      })
-      Object.assign(collapsingMaxHeight.value, updatedMaxHeights)
-      setTimeout(() => {
-        for (const idx of Object.keys(newCollapsing)) {
-          delete collapsingThinking.value[idx]
-          delete collapsingMaxHeight.value[idx]
-        }
-      }, 400)
-    }, 3000)
+  const collapsingKeys = Object.keys(refSnapshot)
+  if (collapsingKeys.length === 0) return
+  // Immediately mark as collapsing with placeholder maxHeight to prevent
+  // flash to 28px collapsed chip while we wait for nextTick.
+  const placeholderCollapsing = {}
+  const placeholderMaxHeight = {}
+  for (const idxStr of collapsingKeys) {
+    placeholderCollapsing[idxStr] = true
+    placeholderMaxHeight[idxStr] = COLLAPSE_PLACEHOLDER_MAX
   }
+  Object.assign(collapsingThinking.value, placeholderCollapsing)
+  Object.assign(collapsingMaxHeight.value, placeholderMaxHeight)
+  // Clear throttle cache so DOM re-renders with complete thinking content
+  blockHtmlCache.value = {}
+  // Wait for Vue to flush DOM, then measure scrollHeight of complete content
+  nextTick(() => {
+    const newCollapsing = {}
+    const newMaxHeights = {}
+    for (const idxStr of collapsingKeys) {
+      const el = refSnapshot[idxStr]
+      if (el && el.isConnected && el.scrollHeight) {
+        newCollapsing[idxStr] = true
+        newMaxHeights[idxStr] = el.scrollHeight
+      }
+    }
+    if (Object.keys(newCollapsing).length > 0) {
+      Object.assign(collapsingThinking.value, newCollapsing)
+      Object.assign(collapsingMaxHeight.value, newMaxHeights)
+      // Delay before starting collapse animation so user can read the thinking output
+      const t1 = setTimeout(() => {
+        const updatedMaxHeights = {}
+        Object.keys(newCollapsing).forEach(idx => {
+          updatedMaxHeights[idx] = COLLAPSED_CHIP_HEIGHT
+        })
+        Object.assign(collapsingMaxHeight.value, updatedMaxHeights)
+        const t2 = setTimeout(() => {
+          for (const idx of Object.keys(newCollapsing)) {
+            delete collapsingThinking.value[idx]
+            delete collapsingMaxHeight.value[idx]
+          }
+        }, COLLAPSE_TRANSITION_MS)
+        _collapseTimers.push(t2)
+      }, COLLAPSE_READ_DELAY)
+      _collapseTimers.push(t1)
+    } else {
+      // No measurable elements — clean up placeholder state
+      for (const idxStr of collapsingKeys) {
+        delete collapsingThinking.value[idxStr]
+        delete collapsingMaxHeight.value[idxStr]
+      }
+    }
+  })
 })
 
 // Reset cache when panel becomes active — allows re-render with fresh markdown
@@ -533,6 +599,8 @@ watch(() => props.active, (active) => {
 
 onUnmounted(() => {
   if (_throttleTimer) { clearTimeout(_throttleTimer); _throttleTimer = null }
+  _collapseTimers.forEach(t => clearTimeout(t))
+  _collapseTimers = []
 })
 </script>
 

--- a/web/src/components/chat/__tests__/AcpSessionDrawer.test.ts
+++ b/web/src/components/chat/__tests__/AcpSessionDrawer.test.ts
@@ -1,0 +1,114 @@
+import { describe, expect, it, vi, beforeEach } from 'vitest'
+import { mount } from '@vue/test-utils'
+import { ref, nextTick } from 'vue'
+import { createI18n } from 'vue-i18n'
+import type { AcpSessionInfo } from '@/composables/useAcpSession'
+
+// ── Mocks ──
+
+const mockAcpLoadSession = vi.fn()
+const mockLoadAcpSessions = vi.fn()
+
+vi.mock('@/composables/useAcpSession', () => ({
+  useAcpSession: () => ({
+    acpSessions: ref([]),
+    acpSessionsLoading: ref(false),
+    acpResuming: ref(false),
+    acpSessionsNotSupported: ref(false),
+    nextCursor: ref(null),
+    loadAcpSessions: mockLoadAcpSessions,
+    acpLoadSession: mockAcpLoadSession,
+  }),
+}))
+
+vi.mock('@/composables/useSessionIdentity', () => ({
+  currentAgentId: ref('agent-1'),
+}))
+
+vi.mock('lucide-vue-next', () => ({
+  History: { name: 'HistoryIcon', render: () => null },
+  RotateCw: { name: 'RotateCwIcon', render: () => null },
+  Loader2: { name: 'Loader2Icon', render: () => null },
+}))
+
+vi.mock('@/components/common/BottomSheet.vue', () => ({
+  default: {
+    name: 'BottomSheet',
+    template: '<div><slot name="header" /><slot /></div>',
+    props: ['open', 'auto', 'title'],
+    emits: ['close'],
+  },
+}))
+
+import AcpSessionDrawer from '@/components/chat/AcpSessionDrawer.vue'
+
+const i18n = createI18n({
+  legacy: false,
+  locale: 'en',
+  messages: { en: {} },
+})
+
+function mountDrawer() {
+  return mount(AcpSessionDrawer, {
+    props: { open: true, agentId: 'agent-1' },
+    global: { plugins: [i18n] },
+  })
+}
+
+const testSession: AcpSessionInfo = { sessionId: 'acp-s1', title: 'Test', createdAt: '', updatedAt: '' }
+
+describe('AcpSessionDrawer', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  describe('handleSelect', () => {
+    it('emits select and close when acpLoadSession returns a valid sessionId', async () => {
+      mockAcpLoadSession.mockResolvedValue('new-session-123')
+
+      const wrapper = mountDrawer()
+      // Test handleSelect directly (no sessions in list by default)
+      await (wrapper.vm as { handleSelect: (s: AcpSessionInfo) => Promise<void> }).handleSelect(testSession)
+      await nextTick()
+
+      expect(mockAcpLoadSession).toHaveBeenCalledWith('acp-s1')
+      expect(wrapper.emitted('select')).toBeTruthy()
+      expect(wrapper.emitted('select')![0]).toEqual(['new-session-123'])
+      expect(wrapper.emitted('close')).toBeTruthy()
+    })
+
+    it('does not emit select when acpLoadSession returns not-found', async () => {
+      mockAcpLoadSession.mockResolvedValue('not-found')
+
+      const wrapper = mountDrawer()
+      await (wrapper.vm as { handleSelect: (s: AcpSessionInfo) => Promise<void> }).handleSelect(testSession)
+      await nextTick()
+
+      expect(mockAcpLoadSession).toHaveBeenCalledWith('acp-s1')
+      expect(wrapper.emitted('select')).toBeFalsy()
+      expect(wrapper.emitted('close')).toBeFalsy()
+    })
+
+    it('does not emit select when acpLoadSession returns null', async () => {
+      mockAcpLoadSession.mockResolvedValue(null)
+
+      const wrapper = mountDrawer()
+      await (wrapper.vm as { handleSelect: (s: AcpSessionInfo) => Promise<void> }).handleSelect(testSession)
+      await nextTick()
+
+      expect(wrapper.emitted('select')).toBeFalsy()
+      expect(wrapper.emitted('close')).toBeFalsy()
+    })
+
+    it('does not emit select when acpLoadSession returns empty string', async () => {
+      mockAcpLoadSession.mockResolvedValue('')
+
+      const wrapper = mountDrawer()
+      await (wrapper.vm as { handleSelect: (s: AcpSessionInfo) => Promise<void> }).handleSelect(testSession)
+      await nextTick()
+
+      expect(wrapper.emitted('select')).toBeFalsy()
+      expect(wrapper.emitted('close')).toBeFalsy()
+    })
+  })
+})

--- a/web/src/components/chat/__tests__/ContentBlocks.test.ts
+++ b/web/src/components/chat/__tests__/ContentBlocks.test.ts
@@ -1,5 +1,6 @@
-import { describe, expect, it, vi, beforeEach } from 'vitest'
+import { describe, expect, it, vi, beforeEach, afterEach } from 'vitest'
 import { mount } from '@vue/test-utils'
+import { nextTick } from 'vue'
 import { createI18n } from 'vue-i18n'
 import ContentBlocks from '@/components/chat/ContentBlocks.vue'
 
@@ -361,6 +362,102 @@ describe('ContentBlocks', () => {
       const summaryDiv = wrapper.find('[v-show]')
       // The original content should be visible
       expect(wrapper.html()).toContain('Original content')
+    })
+  })
+
+  // ── Thinking block collapse animation ──
+
+  describe('thinking block collapse animation', () => {
+    beforeEach(() => {
+      vi.useFakeTimers()
+    })
+
+    afterEach(() => {
+      vi.useRealTimers()
+    })
+
+    it('does not set collapse state when streaming ends with no thinking blocks', async () => {
+      const wrapper = mountBlocks({
+        blocks: [{ type: 'text', text: 'Hello' }],
+        streaming: true,
+      })
+
+      await wrapper.setProps({ streaming: false })
+      await nextTick()
+
+      const thinking = wrapper.find('.chat-thinking')
+      expect(thinking.exists()).toBe(false)
+    })
+
+    it('transitions from streaming to collapsed when streaming ends', async () => {
+      const wrapper = mountBlocks({
+        blocks: [{ type: 'thinking', text: 'Deep thought content', done: false }],
+        streaming: true,
+      })
+
+      // The thinking block should have streaming class
+      expect(wrapper.find('.chat-thinking').classes()).toContain('thinking-streaming')
+
+      // End streaming — triggers collapse animation
+      await wrapper.setProps({ streaming: false })
+      await nextTick()
+
+      // After streaming ends, block should NOT have thinking-streaming anymore
+      const thinking = wrapper.find('.chat-thinking')
+      expect(thinking.classes()).not.toContain('thinking-streaming')
+      // Should have thinking-collapsed (CSS class when not streaming)
+      expect(thinking.classes()).toContain('thinking-collapsed')
+    })
+
+    it('transitions to collapsed chip when thinking_done fires mid-stream', async () => {
+      const wrapper = mountBlocks({
+        blocks: [{ type: 'thinking', text: 'Thinking...', done: false }],
+        streaming: true,
+      })
+
+      expect(wrapper.find('.chat-thinking').classes()).toContain('thinking-streaming')
+
+      // Simulate thinking_done: set block.done = true
+      await wrapper.setProps({
+        blocks: [{ type: 'thinking', text: 'Thinking complete', done: true }],
+      })
+      await nextTick()
+
+      // Should no longer be streaming (done=true overrides streaming prop)
+      const thinking = wrapper.find('.chat-thinking')
+      expect(thinking.classes()).not.toContain('thinking-streaming')
+      // Should have thinking-collapsed or thinking-collapsing
+      expect(
+        thinking.classes().includes('thinking-collapsed') ||
+        thinking.classes().includes('thinking-collapsing')
+      ).toBe(true)
+    })
+
+    it('cleans up timers on unmount to prevent leaks', async () => {
+      const wrapper = mountBlocks({
+        blocks: [{ type: 'thinking', text: 'Deep thought', done: false }],
+        streaming: true,
+      })
+
+      await wrapper.setProps({ streaming: false })
+      await nextTick()
+
+      // Unmount before timers fire — should not throw
+      wrapper.unmount()
+
+      // Advance all timers — should not cause Vue warnings or errors
+      vi.advanceTimersByTime(10000)
+    })
+
+    it('shows thinking-collapsed class when not streaming and done', () => {
+      // Static state: not streaming, block done — should show collapsed chip
+      const wrapper = mountBlocks({
+        blocks: [{ type: 'thinking', text: 'Final thought', done: true }],
+        streaming: false,
+      })
+      const thinking = wrapper.find('.chat-thinking')
+      expect(thinking.classes()).toContain('thinking-collapsed')
+      expect(thinking.classes()).not.toContain('thinking-streaming')
     })
   })
 })

--- a/web/src/composables/__tests__/useAcpSession.test.ts
+++ b/web/src/composables/__tests__/useAcpSession.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it, vi, beforeEach } from 'vitest'
-import { ref, nextTick } from 'vue'
+import { ref } from 'vue'
 
 // Mock fetch globally
 const mockFetch = vi.fn()
@@ -111,7 +111,7 @@ describe('useAcpSession', () => {
     it('handles fetch exception gracefully', async () => {
       mockFetch.mockRejectedValue(new Error('network error'))
 
-      const { acpSessions, acpSessionsLoading, loadAcpSessions } = useAcpSession({ currentAgentId })
+      const { acpSessionsLoading, loadAcpSessions } = useAcpSession({ currentAgentId })
       await loadAcpSessions()
 
       expect(acpSessionsLoading.value).toBe(false)
@@ -156,11 +156,16 @@ describe('useAcpSession', () => {
         json: () => Promise.resolve({ msgKey: 'ACPSessionNotFound' }),
       })
 
-      const { acpLoadSession } = useAcpSession({ currentAgentId })
+      const { acpLoadSession, acpSessions } = useAcpSession({ currentAgentId })
+      // Pre-populate sessions list so we can verify removal
+      acpSessions.value = [{ sessionId: 'acp-s1', title: 'Test', createdAt: '', updatedAt: '' }]
+
       const result = await acpLoadSession('acp-s1')
 
-      expect(result).toBeNull()
+      expect(result).toBe('not-found')
       expect(mockToastShow).toHaveBeenCalledWith('chat.acpSession.sessionNotFound', expect.objectContaining({ type: 'error' }))
+      // The stale session should be removed from the list
+      expect(acpSessions.value).not.toContainEqual(expect.objectContaining({ sessionId: 'acp-s1' }))
     })
 
     it('shows generic error toast for other errors', async () => {

--- a/web/src/composables/useAcpSession.ts
+++ b/web/src/composables/useAcpSession.ts
@@ -76,7 +76,12 @@ export function useAcpSession(options: UseAcpSessionOptions) {
     }
   }
 
-  /** Load an ACP session into a new ClawBench session. Returns the new sessionId. */
+  /** Remove an ACP session from the local list (e.g. after LoadSession failed with not-found). */
+  function removeAcpSession(acpSessionId: string): void {
+    acpSessions.value = acpSessions.value.filter(s => s.sessionId !== acpSessionId)
+  }
+
+  /** Load an ACP session into a new ClawBench session. Returns the new sessionId, or 'not-found' if the session no longer exists on the agent side. */
   async function acpLoadSession(acpSessionId: string): Promise<string | null> {
     const aid = currentAgentId.value
     if (!aid || !acpSessionId) return null
@@ -100,6 +105,9 @@ export function useAcpSession(options: UseAcpSessionOptions) {
         } catch { /* ignore parse error */ }
         if (msgKey === 'ACPSessionNotFound') {
           toast.show(gt('chat.acpSession.sessionNotFound'), { type: 'error', icon: '⚠️' })
+          // Remove the stale session from the list so the user can't retry it
+          removeAcpSession(acpSessionId)
+          return 'not-found'
         } else {
           toast.show(gt('chat.acpSession.loadFailed'), { type: 'error', icon: '⚠️' })
         }
@@ -131,6 +139,7 @@ export function useAcpSession(options: UseAcpSessionOptions) {
     nextCursor,
     loadAcpSessions,
     acpLoadSession,
+    removeAcpSession,
     clearAcpSessions,
   }
 }


### PR DESCRIPTION
## Summary

4 fixes + 1 refactor + supplementary tests:

1. **fix(acp): fix ACP resume hang + remove stale sessions on not-found** — `ACPConn.close()` blocks forever on `cmd.Wait()` when npx child process holds pipe open. Fix: `Setpgid:true` + `killProcessGroup()` to kill entire process tree. Also auto-remove stale sessions on `ACPSessionNotFound`.

2. **refactor: abstract embedded agent — config-driven** — Replace all hardcoded `opencode` references with generic embedded agent abstraction. Swapping/adding agents now config-only, no code changes.

3. **fix: resolve embedded binary path for CLI backends in container** — `CLIBackend.ExecuteStream` and `ACPConn.spawnLocked` now resolve bare command names through `FindBackendSpecByDefaultCmd` → `EmbeddedBinaryPath` for Docker containers.

4. **fix: thinking block collapse clips bottom content** — `scrollHeight` measured on stale DOM. Fix: clear `blockHtmlCache` + `nextTick` before measuring, plus guard against duplicate collapse triggers.

5. **test: add missing unit tests** — `AcpSessionDrawer` not-found guard, `FindBackendSpecByDefaultCmd`, `setProcessGroup`/`killProcessGroup`, fix `useAcpSession` test expectation.

## CI

All pre-push checks pass: lint, Go test, Go build, typecheck, Go coverage gate, frontend coverage gate, frontend build.