### PR TITLE
fix(dock,chat): UI improvements and test coverage

### DIFF
--- a/web/src/App.vue
+++ b/web/src/App.vue
@@ -211,22 +211,22 @@
     <Teleport to="body">
       <Transition name="dock-popup">
         <div v-if="overflowMenuOpen" class="dock-overflow-popup" :style="overflowPopupStyle" @keydown.escape="overflowMenuOpen = false">
-          <button class="dock-overflow-item" :class="{ active: activeTab === 'tasks' }" @click.stop="handleOverflowSelect('tasks')">
+          <button v-if="dockSlot4Tab !== 'tasks'" class="dock-overflow-item" :class="{ active: activeTab === 'tasks' }" @click.stop="handleOverflowSelect('tasks')">
             <CalendarClock :size="16" />
             <span>{{ t('nav.tasks') }}</span>
             <span v-if="store.state.taskUnreadCount > 0" class="dock-overflow-count" :class="{ 'dock-badge-pop': taskBadgeAnim }" @animationend="taskBadgeAnim = false">{{ formatBadgeCount(store.state.taskUnreadCount) }}</span>
           </button>
-          <button v-if="!isSSHDisabled" class="dock-overflow-item" :class="{ active: activeTab === 'proxy' }" @click.stop="handleOverflowSelect('proxy')">
+          <button v-if="!isSSHDisabled && dockSlot4Tab !== 'proxy'" class="dock-overflow-item" :class="{ active: activeTab === 'proxy' }" @click.stop="handleOverflowSelect('proxy')">
             <EthernetPort :size="16" />
             <span>{{ t('nav.portForward') }}</span>
             <span v-if="store.state.portForwardActiveCount > 0" class="dock-overflow-count" :class="{ 'dock-badge-pop': proxyBadgeAnim }" @animationend="proxyBadgeAnim = false">{{ formatBadgeCount(store.state.portForwardActiveCount) }}</span>
           </button>
-          <button v-if="!isTerminalDisabled" class="dock-overflow-item" :class="{ active: activeTab === 'terminal' }" @click.stop="handleOverflowSelect('terminal')">
+          <button v-if="!isTerminalDisabled && dockSlot4Tab !== 'terminal'" class="dock-overflow-item" :class="{ active: activeTab === 'terminal' }" @click.stop="handleOverflowSelect('terminal')">
             <TerminalIcon :size="16" />
             <span>{{ t('terminal.title') }}</span>
             <span v-if="store.state.terminalSessionCount > 0" class="dock-overflow-count" :class="{ 'dock-badge-pop': terminalBadgeAnim }" @animationend="terminalBadgeAnim = false">{{ formatBadgeCount(store.state.terminalSessionCount) }}</span>
           </button>
-          <button class="dock-overflow-item" :class="{ active: activeTab === 'settings' }" @click.stop="handleOverflowSelect('settings')">
+          <button v-if="dockSlot4Tab !== 'settings'" class="dock-overflow-item" :class="{ active: activeTab === 'settings' }" @click.stop="handleOverflowSelect('settings')">
             <Settings :size="16" />
             <span>{{ t('nav.settings') }}</span>
           </button>
@@ -1048,24 +1048,29 @@ watch(() => store.state.gitWorkingTreeChangeCount, (n, o) => { if (o !== undefin
 watch(() => store.state.taskUnreadCount, (n, o) => {
   if (o !== undefined && n !== o) {
     triggerBadgeAnim(taskBadgeAnim)
-    triggerBadgeAnim(overflowBadgeAnim)
+    if (dockSlot4Tab.value !== 'tasks') triggerBadgeAnim(overflowBadgeAnim)
   }
 })
 watch(() => store.state.terminalSessionCount, (n, o) => {
   if (o !== undefined && n !== o) {
     triggerBadgeAnim(terminalBadgeAnim)
-    triggerBadgeAnim(overflowBadgeAnim)
+    if (dockSlot4Tab.value !== 'terminal') triggerBadgeAnim(overflowBadgeAnim)
   }
 })
 watch(() => store.state.portForwardActiveCount, (n, o) => {
   if (o !== undefined && n !== o) {
     triggerBadgeAnim(proxyBadgeAnim)
-    triggerBadgeAnim(overflowBadgeAnim)
+    if (dockSlot4Tab.value !== 'proxy') triggerBadgeAnim(overflowBadgeAnim)
   }
 })
 
 const overflowBadgeCount = computed(() => {
-  return store.state.taskUnreadCount + store.state.portForwardActiveCount + store.state.terminalSessionCount
+  let count = store.state.taskUnreadCount + store.state.portForwardActiveCount + store.state.terminalSessionCount
+  // Subtract the count shown on slot4 to avoid double-counting
+  if (dockSlot4Tab.value === 'tasks') count -= store.state.taskUnreadCount
+  else if (dockSlot4Tab.value === 'proxy') count -= store.state.portForwardActiveCount
+  else if (dockSlot4Tab.value === 'terminal') count -= store.state.terminalSessionCount
+  return count
 })
 
 const overflowButtonTitle = computed(() => {

--- a/web/src/components/chat/ChatInputBar.vue
+++ b/web/src/components/chat/ChatInputBar.vue
@@ -869,6 +869,7 @@ defineExpose({
   onQuickSendTouchEnd,
   cancelQuickSendPress,
   quickSendPressingId,
+  closeAcpSessionDrawer: () => { showAcpSessionDrawer.value = false },
 })
 </script>
 

--- a/web/src/components/chat/ChatMessageList.vue
+++ b/web/src/components/chat/ChatMessageList.vue
@@ -560,6 +560,7 @@ defineExpose({
   isAtBottom: () => isAtBottom.value,
   scrolledUp,
   scrolledDown,
+  closeUserMsgIndex,
 })
 </script>
 

--- a/web/src/components/chat/ChatMessageList.vue
+++ b/web/src/components/chat/ChatMessageList.vue
@@ -376,7 +376,10 @@ function onDocumentClick(e) {
 }
 
 onMounted(() => document.addEventListener('click', onDocumentClick, true))
-onBeforeUnmount(() => document.removeEventListener('click', onDocumentClick, true))
+onBeforeUnmount(() => {
+  document.removeEventListener('click', onDocumentClick, true)
+  clearTimeout(scrollTickTimer)
+})
 
 function scrollToBottom(force = false) {
   nextTick(() => {
@@ -539,6 +542,9 @@ const nearestUserMsgId = computed(() => {
 
 // Watch session switch to reset user msg index
 watch(() => props.currentSessionId, () => {
+  clearTimeout(scrollTickTimer)
+  scrollTickTimer = null
+  scrollTick.value = 0
   showUserMsgIndex.value = false
   userMsgIndexList.value = []
 })

--- a/web/src/components/chat/ChatMessageList.vue
+++ b/web/src/components/chat/ChatMessageList.vue
@@ -98,42 +98,16 @@
     </div>
   </Transition>
 
-  <!-- User message index overlay -->
-  <Transition name="user-msg-overlay">
-    <div v-if="showUserMsgIndex" class="user-msg-overlay" @click.self="closeUserMsgIndex" @keydown.escape="closeUserMsgIndex">
-      <div ref="popoverRef" class="user-msg-panel" role="dialog" :aria-label="t('chat.messageList.userMsgIndexTitle')">
-        <div class="user-msg-panel-header">
-          <MessageSquare :size="16" class="user-msg-panel-icon" />
-          <span>{{ t('chat.messageList.userMsgIndexTitle') }}</span>
-          <span class="user-msg-panel-count">{{ userMsgIndexList.length }}</span>
-        </div>
-        <div v-if="loadingIndex" class="user-msg-panel-loading">
-          <span class="chat-load-spinner"></span>
-          <span>{{ t('chat.messageList.loadingMore') }}</span>
-        </div>
-        <div v-else-if="loadingTarget" class="user-msg-panel-loading">
-          <span class="chat-load-spinner"></span>
-          <span>{{ t('chat.messageList.loadingMore') }}</span>
-        </div>
-        <div class="user-msg-panel-list">
-          <div
-            v-for="(um, idx) in userMsgIndexList"
-            :key="um.id || idx"
-            class="user-msg-item"
-            tabindex="0"
-            role="button"
-            @click="jumpToUserMessage(um)"
-            @keydown.enter="jumpToUserMessage(um)"
-          >
-            <span class="user-msg-item-node">
-              <span class="user-msg-item-index">{{ idx + 1 }}</span>
-            </span>
-            <span class="user-msg-item-text">{{ formatTruncateUserMsg(um) }}</span>
-          </div>
-        </div>
-      </div>
-    </div>
-  </Transition>
+  <!-- User message index drawer -->
+  <UserMsgIndexSheet
+    :open="showUserMsgIndex"
+    :messages="userMsgIndexList"
+    :active-id="nearestUserMsgId"
+    :loading="loadingIndex"
+    :jumping="loadingTarget"
+    @close="closeUserMsgIndex"
+    @select="jumpToUserMessage"
+  />
 
   </div>
 </template>
@@ -141,8 +115,9 @@
 <script setup>
 import { ref, nextTick, inject, computed, watch, onMounted, onBeforeUnmount } from 'vue'
 import { useI18n } from 'vue-i18n'
-import { ChevronUp, ChevronsUp, ArrowUp, ChevronsDown, ArrowDown, List, MessageSquare } from 'lucide-vue-next'
+import { ChevronUp, ChevronsUp, ArrowUp, ChevronsDown, ArrowDown, List } from 'lucide-vue-next'
 import ChatMessageItem from './ChatMessageItem.vue'
+import UserMsgIndexSheet from './UserMsgIndexSheet.vue'
 import { useDoubleClickCopy } from '@/composables/useDoubleClickCopy.ts'
 import { useFilePathAnnotation } from '@/composables/useFilePathAnnotation.ts'
 import { useLocalhostUrlClickHandler } from '@/composables/useLocalhostAnnotation.ts'
@@ -312,7 +287,13 @@ const SCROLL_DELTA_THRESHOLD = 10
 // Flag to suppress handleScroll button logic during programmatic smooth scroll
 let programmaticScrolling = false
 
+// Throttle scrollTick for nearestUserMsgId recomputation
+let scrollTickTimer = null
+
 function handleScroll() {
+  if (!scrollTickTimer) {
+    scrollTickTimer = setTimeout(() => { scrollTick.value++; scrollTickTimer = null }, 100)
+  }
   if (!messagesRef.value) return
   const el = messagesRef.value
 
@@ -516,7 +497,6 @@ const {
   showUserMsgIndex,
   loadingTarget,
   loadingIndex,
-  formatTruncateUserMsg,
   toggleUserMsgIndex,
   closeUserMsgIndex,
   jumpToUserMessage,
@@ -531,12 +511,37 @@ const {
   hideScrollFab,
   setProgrammaticScrolling: (val) => { programmaticScrolling = val },
 })
+
+// Nearest user message to viewport center — used for activeId highlight in index
+const scrollTick = ref(0)
+const nearestUserMsgId = computed(() => {
+  void scrollTick.value // dependency trigger
+  const el = messagesRef.value
+  if (!el) return null
+  const items = el.querySelectorAll('.chat-messages-list > .chat-message')
+  const containerRect = el.getBoundingClientRect()
+  const center = containerRect.top + containerRect.height / 2
+  let nearestUserIdx = null
+  let minDist = Infinity
+  for (let i = 0; i < items.length; i++) {
+    const msg = props.messages[i]
+    if (!msg || msg.role !== 'user') continue
+    const rect = items[i].getBoundingClientRect()
+    const dist = Math.abs(rect.top + rect.height / 2 - center)
+    if (dist < minDist) {
+      minDist = dist
+      nearestUserIdx = i
+    }
+  }
+  if (nearestUserIdx === null) return null
+  return props.messages[nearestUserIdx].id
+})
+
 // Watch session switch to reset user msg index
 watch(() => props.currentSessionId, () => {
   showUserMsgIndex.value = false
   userMsgIndexList.value = []
 })
-const popoverRef = ref(null)
 
 defineExpose({
   scrollToBottom,

--- a/web/src/components/chat/ChatPanelContent.vue
+++ b/web/src/components/chat/ChatPanelContent.vue
@@ -477,6 +477,9 @@ watch(() => props.active, async (val) => {
   if (!val) {
     identity.sessionDrawerOpen.value = false
     toolDetailOverlay.value.show = false
+    messageListRef.value?.closeUserMsgIndex()
+    inputBarRef.value?.closeAcpSessionDrawer()
+    ragDetailItem.value = null
   } else {
     // Open/Re-open: load history (with overlay) and fix stale layout state from v-show display:none
     await session.loadHistory(false, true)

--- a/web/src/components/chat/ChatPanelContent.vue
+++ b/web/src/components/chat/ChatPanelContent.vue
@@ -145,21 +145,7 @@
     @click="handleOverlayRetryClick"
   />
   <!-- RAG search result detail drawer -->
-  <BottomSheet :open="!!ragDetailItem" handleOnly auto @close="ragDetailItem = null">
-    <template v-if="ragDetailItem">
-      <div class="rag-detail-content">
-        <div class="rag-detail-title">{{ ragDetailItem.sessionTitle || t('chat.contentBlocks.ragUntitled') }}</div>
-        <div v-if="ragDetailItem.createdAt" class="rag-detail-time">{{ render.formatDetailTime(ragDetailItem.createdAt) }}</div>
-        <div v-if="ragDetailItem.summary" class="rag-detail-summary">{{ ragDetailItem.summary }}</div>
-      </div>
-      <div class="rag-detail-footer">
-        <button class="rag-detail-resume-btn" @click="handleResumeFromDetail">
-          {{ t('chat.contentBlocks.ragResume') }}
-          <ChevronRight :size="14" />
-        </button>
-      </div>
-    </template>
-  </BottomSheet>
+  <RagDetailSheet :item="ragDetailItem" @close="ragDetailItem = null" @resume="handleResumeFromDetail" />
 </template>
 
 <script setup>
@@ -168,7 +154,7 @@ import { useI18n } from 'vue-i18n'
 import { appLog } from '@/utils/appLog'
 import { gt } from '@/composables/useLocale'
 import HeaderMarquee from '@/components/common/HeaderMarquee.vue'
-import BottomSheet from '@/components/common/BottomSheet.vue'
+import RagDetailSheet from './RagDetailSheet.vue'
 import ChatMetadataModal from './ChatMetadataModal.vue'
 import ToolDetailOverlay from './ToolDetailOverlay.vue'
 import ChatInputBar from './ChatInputBar.vue'
@@ -197,7 +183,7 @@ import { useGlobalEvents } from '@/composables/useGlobalEvents'
 import { store } from '@/stores/app.ts'
 import { renderMarkdown } from '@/composables/useMarkdownRenderer.ts'
 import { useDialog } from '@/composables/useDialog'
-import { ChevronRight } from 'lucide-vue-next'
+
 import '@/assets/loading-mask.css'
 import { useToolDetailOverlay } from '@/composables/useToolDetailOverlay.ts'
 
@@ -871,8 +857,7 @@ function handleRagDetail(ragItem) {
     ragDetailItem.value = ragItem
 }
 
-async function handleResumeFromDetail() {
-    const item = ragDetailItem.value
+async function handleResumeFromDetail(item) {
     ragDetailItem.value = null
     if (!item?.sessionId) return
     const confirmed = await dialog.confirm(
@@ -1110,68 +1095,6 @@ onUnmounted(() => {
 .session-indicator-leave-to {
   opacity: 0;
   transform: scale(0.95);
-}
-
-/* RAG detail drawer */
-.rag-detail-content {
-  padding: 8px 16px 16px;
-}
-
-.rag-detail-title {
-  font-size: 15px;
-  font-weight: 600;
-  color: var(--text-primary);
-  line-height: 1.4;
-  margin-bottom: 8px;
-  word-break: break-word;
-}
-
-.rag-detail-time {
-  font-size: 12px;
-  color: var(--text-muted, #999);
-  margin-bottom: 12px;
-}
-
-.rag-detail-summary {
-  font-size: 13px;
-  line-height: 1.6;
-  color: var(--text-secondary, #495057);
-  white-space: pre-wrap;
-  word-break: break-word;
-}
-
-.rag-detail-footer {
-  padding: 12px 16px;
-  border-top: 1px solid var(--border-color, #e5e5e5);
-}
-
-.rag-detail-resume-btn {
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  gap: 6px;
-  width: 100%;
-  padding: 10px 0;
-  border: none;
-  border-radius: 8px;
-  background: #8b5cf6;
-  color: #fff;
-  font-size: 14px;
-  font-weight: 500;
-  cursor: pointer;
-  transition: opacity 0.15s;
-}
-
-:root[data-theme="dark"] .rag-detail-resume-btn {
-  background: #7c3aed;
-}
-
-.rag-detail-resume-btn:hover {
-  opacity: 0.85;
-}
-
-.rag-detail-resume-btn:active {
-  opacity: 0.7;
 }
 </style>
 

--- a/web/src/components/chat/RagDetailSheet.vue
+++ b/web/src/components/chat/RagDetailSheet.vue
@@ -1,0 +1,95 @@
+<template>
+  <BottomSheet :open="!!item" handleOnly auto @close="$emit('close')">
+    <template v-if="item">
+      <div class="rag-detail-content">
+        <div class="rag-detail-title">{{ item.sessionTitle || t('chat.contentBlocks.ragUntitled') }}</div>
+        <div v-if="item.createdAt" class="rag-detail-time">{{ formatDetailTime(item.createdAt) }}</div>
+        <div v-if="item.summary" class="rag-detail-summary">{{ item.summary }}</div>
+      </div>
+      <div class="rag-detail-footer">
+        <button class="rag-detail-resume-btn" @click="$emit('resume', item)">
+          {{ t('chat.contentBlocks.ragResume') }}
+          <ChevronRight :size="14" />
+        </button>
+      </div>
+    </template>
+  </BottomSheet>
+</template>
+
+<script setup>
+import { useI18n } from 'vue-i18n'
+import { ChevronRight } from 'lucide-vue-next'
+import BottomSheet from '@/components/common/BottomSheet.vue'
+import { formatDetailTime } from '@/utils/chatBlocks.ts'
+
+const { t } = useI18n()
+
+defineProps({
+  item: { type: Object, default: null },
+})
+
+defineEmits(['close', 'resume'])
+</script>
+
+<style scoped>
+.rag-detail-content {
+  padding: 8px 16px 16px;
+}
+
+.rag-detail-title {
+  font-size: 15px;
+  font-weight: 600;
+  color: var(--text-primary);
+  line-height: 1.4;
+  margin-bottom: 8px;
+  word-break: break-word;
+}
+
+.rag-detail-time {
+  font-size: 12px;
+  color: var(--text-muted, #999);
+  margin-bottom: 12px;
+}
+
+.rag-detail-summary {
+  font-size: 13px;
+  line-height: 1.6;
+  color: var(--text-secondary, #495057);
+  white-space: pre-wrap;
+  word-break: break-word;
+}
+
+.rag-detail-footer {
+  padding: 12px 16px;
+  border-top: 1px solid var(--border-color, #e5e5e5);
+}
+
+.rag-detail-resume-btn {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 6px;
+  width: 100%;
+  padding: 10px 0;
+  border: none;
+  border-radius: 8px;
+  background: #8b5cf6;
+  color: #fff;
+  font-size: 14px;
+  font-weight: 500;
+  cursor: pointer;
+  transition: opacity 0.15s;
+}
+
+:root[data-theme="dark"] .rag-detail-resume-btn {
+  background: #7c3aed;
+}
+
+.rag-detail-resume-btn:hover {
+  opacity: 0.85;
+}
+
+.rag-detail-resume-btn:active {
+  opacity: 0.7;
+}
+</style>

--- a/web/src/components/chat/UserMsgIndexSheet.vue
+++ b/web/src/components/chat/UserMsgIndexSheet.vue
@@ -40,6 +40,7 @@
 <script setup>
 import { useI18n } from 'vue-i18n'
 import { MessageSquare } from 'lucide-vue-next'
+import { truncateUserMsg } from '@/utils/userMsgIndexUtils.ts'
 import BottomSheet from '@/components/common/BottomSheet.vue'
 import { formatRelativeTime } from '@/utils/format.ts'
 
@@ -48,37 +49,15 @@ const { t } = useI18n()
 defineProps({
   open: Boolean,
   messages: { type: Array, default: () => [] },
-  activeId: { type: Number, default: null, required: false },
+  activeId: { type: [Number, String], default: null, required: false },
   loading: Boolean,
   jumping: Boolean,
 })
 
 defineEmits(['close', 'select'])
 
-const TRUNCATE_LEN = 40
-
-function extractPlainText(content) {
-  if (!content) return ''
-  if (content.startsWith('{"blocks":')) {
-    try {
-      const parsed = JSON.parse(content)
-      if (parsed.blocks && Array.isArray(parsed.blocks)) {
-        return parsed.blocks
-          .filter(b => b.type === 'text' && b.text)
-          .map(b => b.text)
-          .join(' ')
-      }
-    } catch { /* ignore */ }
-  }
-  return content
-}
-
 function truncateText(msg) {
-  const text = extractPlainText(msg.content || '')
-  if (!text && msg.files && msg.files.length > 0) {
-    return `[${t('chat.messageList.userMsgIndexAttachment')}]`
-  }
-  return text.length > TRUNCATE_LEN ? text.slice(0, TRUNCATE_LEN) + '…' : text
+  return truncateUserMsg(msg, t('chat.messageList.userMsgIndexAttachment'))
 }
 </script>
 

--- a/web/src/components/chat/__tests__/ChatMessageList.test.ts
+++ b/web/src/components/chat/__tests__/ChatMessageList.test.ts
@@ -130,7 +130,7 @@ function mountComponent(props = {}) {
         ArrowDown: { template: '<span />' },
         ChevronUp: { template: '<span />' },
         List: { template: '<span class="list-icon-stub" />' },
-        MessageSquare: { template: '<span />' },
+        UserMsgIndexSheet: { template: '<div class="user-msg-index-sheet-stub" />' },
       },
       plugins: [i18n],
     },
@@ -754,7 +754,7 @@ describe('ChatMessageList — highlightMessage', () => {
   })
 })
 
-describe('ChatMessageList — formatTruncateUserMsg', () => {
+describe('userMsgIndexUtils — truncateUserMsg', () => {
   it('formats user message with text content', () => {
     expect(truncateUserMsg({ content: 'Hello world' }, 'Attachment')).toBe('Hello world')
   })

--- a/web/src/components/chat/__tests__/UserMsgIndexSheet.test.ts
+++ b/web/src/components/chat/__tests__/UserMsgIndexSheet.test.ts
@@ -1,0 +1,92 @@
+import { describe, expect, it, vi } from 'vitest'
+import { mount } from '@vue/test-utils'
+import { createI18n } from 'vue-i18n'
+
+vi.mock('lucide-vue-next', () => ({
+  MessageSquare: { name: 'MessageSquareIcon', render: () => null },
+}))
+
+vi.mock('@/components/common/BottomSheet.vue', () => ({
+  default: {
+    name: 'BottomSheet',
+    template: '<div><slot name="header" /><slot /></div>',
+    props: ['open', 'auto', 'title'],
+    emits: ['close'],
+  },
+}))
+
+vi.mock('@/utils/format.ts', () => ({
+  formatRelativeTime: vi.fn(() => '2m ago'),
+}))
+
+import UserMsgIndexSheet from '@/components/chat/UserMsgIndexSheet.vue'
+
+const i18n = createI18n({
+  legacy: false,
+  locale: 'en',
+  messages: { en: {} },
+})
+
+function mountSheet(props = {}) {
+  return mount(UserMsgIndexSheet, {
+    props: { open: true, messages: [], ...props },
+    global: { plugins: [i18n] },
+  })
+}
+
+describe('UserMsgIndexSheet', () => {
+  describe('truncateText', () => {
+    it('renders truncated message text via truncateUserMsg', () => {
+      const messages = [
+        { id: 1, content: 'Hello world', role: 'user' },
+      ]
+      const wrapper = mountSheet({ messages })
+      const text = wrapper.find('.msg-text')
+      expect(text.exists()).toBe(true)
+      expect(text.text()).toContain('Hello world')
+    })
+
+    it('renders multiple messages with indices', () => {
+      const messages = [
+        { id: 1, content: 'First', role: 'user' },
+        { id: 2, content: 'Second', role: 'user' },
+      ]
+      const wrapper = mountSheet({ messages })
+      const items = wrapper.findAll('.msg-item')
+      expect(items).toHaveLength(2)
+      expect(items[0].find('.msg-index').text()).toBe('1')
+      expect(items[1].find('.msg-index').text()).toBe('2')
+    })
+
+    it('marks active message', () => {
+      const messages = [
+        { id: 1, content: 'A', role: 'user' },
+        { id: 2, content: 'B', role: 'user' },
+      ]
+      const wrapper = mountSheet({ messages, activeId: 2 })
+      const items = wrapper.findAll('.msg-item')
+      expect(items[0].classes()).not.toContain('active')
+      expect(items[1].classes()).toContain('active')
+    })
+
+    it('emits select on message click', async () => {
+      const messages = [
+        { id: 1, content: 'Click me', role: 'user' },
+      ]
+      const wrapper = mountSheet({ messages })
+      await wrapper.find('.msg-item').trigger('click')
+      expect(wrapper.emitted('select')).toBeTruthy()
+      expect(wrapper.emitted('select')![0]).toEqual([messages[0]])
+    })
+
+    it('shows loading state', () => {
+      const wrapper = mountSheet({ loading: true })
+      expect(wrapper.find('.panel-loading').exists()).toBe(true)
+    })
+
+    it('shows jumping state', () => {
+      const wrapper = mountSheet({ jumping: true })
+      expect(wrapper.find('.panel-loading').exists()).toBe(true)
+    })
+  })
+})


### PR DESCRIPTION
## Summary

- Hide slot4 extension from overflow menu and sync badge counts
- Extract RagDetailSheet as independent component
- Close UserMsgIndexSheet and AcpSessionDrawer on dock tab switch
- Wire UserMsgIndexSheet component with active highlight
- Add UserMsgIndexSheet unit tests for truncateText coverage

## CI Status
All pre-push checks pass: lint, tests, build, typecheck, coverage gates (Go + Frontend)