### PR TITLE
fix(acp): cancel pending prompt when agent process dies

### DIFF
--- a/internal/ai/acp_conn_lifecycle.go
+++ b/internal/ai/acp_conn_lifecycle.go
@@ -442,6 +442,11 @@ func (c *ACPConn) watchProcessDeath() {
 			GetAgentCapabilityRegistry().MarkStale(c.agent.ID)
 		}
 	}
+	// Cancel any pending prompt to unblock conn.Prompt call
+	if c.promptCancel != nil {
+		c.promptCancel()
+		c.promptCancel = nil
+	}
 	agentID := ""
 	if c.agent != nil {
 		agentID = c.agent.ID

--- a/internal/ai/acp_conn_prompt.go
+++ b/internal/ai/acp_conn_prompt.go
@@ -68,9 +68,22 @@ func (c *ACPConn) Prompt(ctx context.Context, prompt []acp.ContentBlock, streamC
 	}
 
 	// Send prompt. DO NOT add a hard timeout here — see acp_pool.go for rationale.
+	// Create a derived context that can be cancelled when the process dies,
+	// so conn.Prompt doesn't hang indefinitely if the agent is killed.
+	promptCtx, promptCancel := context.WithCancel(ctx)
+	c.mu.Lock()
+	c.promptCancel = promptCancel
+	c.mu.Unlock()
+	defer func() {
+		c.mu.Lock()
+		c.promptCancel = nil
+		c.mu.Unlock()
+		promptCancel()
+	}()
+
 	promptStart := time.Now()
 	slog.Info("acp conn: conn.Prompt starting", "clawbench_sid", c.clawbenchSID, "acp_sid", acpSID)
-	_, err := conn.Prompt(ctx, acp.PromptRequest{
+	_, err := conn.Prompt(promptCtx, acp.PromptRequest{
 		SessionId: acp.SessionId(acpSID),
 		Prompt:    prompt,
 	})

--- a/internal/ai/acp_pool.go
+++ b/internal/ai/acp_pool.go
@@ -578,6 +578,10 @@ type ACPConn struct {
 	// automatically approved with the first allow_* option.
 	autoApprove bool
 
+	// promptCancel is called when the agent process dies to unblock any
+	// pending conn.Prompt call that would otherwise hang indefinitely.
+	promptCancel context.CancelFunc
+
 	// unsupportedConfigs tracks config IDs that the agent reported as unknown.
 	unsupportedConfigs map[string]bool
 


### PR DESCRIPTION
## Summary

When an ACP agent process is killed (e.g. OOM), `watchProcessDeath` now cancels any pending `conn.Prompt` call via a stored `context.CancelFunc`. Previously, the prompt would hang indefinitely waiting for a response that would never come, causing the session to appear stuck until manually cancelled.

## Problem

The session would hang for 20+ minutes after the Claude ACP process was killed by the system. Logs showed:

```
ERROR "acp conn: agent process died" exit_code=-1 signal=killed uptime=22h22m28s
```

But `conn.Prompt` continued waiting, blocking the session from cleaning up.

## Solution

1. Added `promptCancel context.CancelFunc` field to `ACPConn`
2. `watchProcessDeath` calls `promptCancel()` when the process dies to unblock pending prompts
3. `Prompt()` uses a derived context that can be cancelled by the process death watcher

## Test plan

- [x] Verified the fix resolves the stuck session issue in production
- [x] Build succeeds (`go build ./cmd/server`)

🤖 Generated with [Claude Code](https://claude.ai/code)