### PR TITLE
fix(ci): override .npmrc to use official npm registry for publishing

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -617,6 +617,13 @@ jobs:
 
           echo "All npm packages assembled"
 
+      - name: Configure npm registry for publishing
+        run: |
+          echo "registry=https://registry.npmjs.org/" > .npmrc
+          echo "//registry.npmjs.org/:_authToken=${NPM_TOKEN}" >> .npmrc
+        env:
+          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
+
       - name: Publish @xulongzhe/clawbench-linux-x64
         run: npm publish npm/platforms/linux-x64 --access public
         env:


### PR DESCRIPTION
The project `.npmrc` sets `registry=npmmirror` for install speed, but this overrides the `setup-node` `registry-url` in CI, causing `npm publish` to hit npmmirror which lacks auth. 

This PR adds a step before npm publish that writes a fresh `.npmrc` pointing to the official `registry.npmjs.org` with the `NPM_TOKEN` secret.

Fixes the `ENEEDAUTH` failure in the v0.57.0 release workflow.