### PR TITLE
fix(ci): write npmrc to NPM_CONFIG_USERCONFIG path

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -619,8 +619,12 @@ jobs:
 
       - name: Configure npm registry for publishing
         run: |
-          echo "registry=https://registry.npmjs.org/" > .npmrc
-          echo "//registry.npmjs.org/:_authToken=${NPM_TOKEN}" >> .npmrc
+          # setup-node sets NPM_CONFIG_USERCONFIG which takes priority over
+          # project .npmrc, so we must write to that file instead.
+          cat > "${NPM_CONFIG_USERCONFIG}" <<EOF
+          registry=https://registry.npmjs.org/
+          //registry.npmjs.org/:_authToken=${NPM_TOKEN}
+          EOF
         env:
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
 


### PR DESCRIPTION
Root cause of npm publish E403 in CI:

`actions/setup-node@v4` sets `NPM_CONFIG_USERCONFIG` env var pointing to a temp .npmrc file. This file takes **highest priority** in npm's config resolution, overriding the project .npmrc we were writing to.

Fix: write the registry and auth token directly to the `NPM_CONFIG_USERCONFIG` file path instead of the project .npmrc.

This is why local publish works (no NPM_CONFIG_USERCONFIG override) but CI fails.