### PR TITLE
fix(ci): remove project .npmrc before npm publish

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -619,12 +619,14 @@ jobs:
 
       - name: Configure npm registry for publishing
         run: |
-          # setup-node sets NPM_CONFIG_USERCONFIG which takes priority over
-          # project .npmrc, so we must write to that file instead.
-          cat > "${NPM_CONFIG_USERCONFIG}" <<EOF
-          registry=https://registry.npmjs.org/
-          //registry.npmjs.org/:_authToken=${NPM_TOKEN}
-          EOF
+          # The project .npmrc sets registry=npmmirror which overrides even
+          # NPM_CONFIG_USERCONFIG (project config has higher priority).
+          # Remove it and write auth config to the userconfig file instead.
+          rm -f .npmrc
+          {
+            echo "registry=https://registry.npmjs.org/"
+            echo "//registry.npmjs.org/:_authToken=${NPM_TOKEN}"
+          } >> "${NPM_CONFIG_USERCONFIG}"
         env:
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
 


### PR DESCRIPTION
npm config priority: project .npmrc > NPM_CONFIG_USERCONFIG. The project .npmrc sets registry=npmmirror, overriding everything. Fix: remove project .npmrc and append registry+auth to the userconfig file.