### PR TITLE
fix(npm): use createRequire for require.resolve in ESM

### DIFF
--- a/npm/main/bin/clawbench.js
+++ b/npm/main/bin/clawbench.js
@@ -2,9 +2,11 @@
 import { spawn } from "child_process";
 import { resolve, dirname } from "path";
 import { fileURLToPath } from "url";
+import { createRequire } from "module";
 import os from "os";
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
+const require = createRequire(import.meta.url);
 
 const PLATFORM_MAP = {
   "linux-x64": "@xulongzhe/clawbench-linux-x64",

--- a/npm/main/install.js
+++ b/npm/main/install.js
@@ -4,8 +4,10 @@
 import { readFileSync } from "fs";
 import { dirname, join } from "path";
 import { fileURLToPath } from "url";
+import { createRequire } from "module";
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
+const require = createRequire(import.meta.url);
 
 const PLATFORM_MAP = {
   "linux-x64": "@xulongzhe/clawbench-linux-x64",


### PR DESCRIPTION
The main package has `"type": "module"`, so .js files run as ESM where `require.resolve` is not defined. Add `createRequire(import.meta.url)` bridge to fix platform package resolution.