### PR TITLE
fix(android): update test expectations INVISIBLE→GONE

### DIFF
--- a/android/app/src/test/java/com/clawbench/app/MainActivityConnectionRecoveryTest.java
+++ b/android/app/src/test/java/com/clawbench/app/MainActivityConnectionRecoveryTest.java
@@ -373,7 +373,7 @@ public class MainActivityConnectionRecoveryTest {
         onPageStarted.invoke(client, mockWebView, "https://192.168.1.100:20000", null);
 
         // Remote page should hide WebView during loading
-        verify(mockWebView).setVisibility(android.view.View.INVISIBLE);
+        verify(mockWebView).setVisibility(android.view.View.GONE);
         assertFalse(getBooleanField(activity, "webViewConnected"));
     }
 
@@ -473,7 +473,7 @@ public class MainActivityConnectionRecoveryTest {
         onReceivedError.invoke(client, mockWebView, mockRequest, null);
 
         assertTrue(getBooleanField(activity, "loadErrorPending"));
-        verify(mockWebView).setVisibility(android.view.View.INVISIBLE);
+        verify(mockWebView).setVisibility(android.view.View.GONE);
 
         // Execute the captured runnable to verify showLoginPage is called
         assertNotNull("postDelayed runnable should be captured", capturedRunnable[0]);
@@ -526,7 +526,7 @@ public class MainActivityConnectionRecoveryTest {
         onReceivedHttpError.invoke(client, mockWebView, mockRequest, mockResponse);
 
         assertTrue(getBooleanField(activity, "loadErrorPending"));
-        verify(mockWebView).setVisibility(android.view.View.INVISIBLE);
+        verify(mockWebView).setVisibility(android.view.View.GONE);
 
         // Execute the captured runnable to verify showLoginPage is called
         assertNotNull("postDelayed runnable should be captured", capturedRunnable[0]);
@@ -761,7 +761,7 @@ public class MainActivityConnectionRecoveryTest {
         // Should set loadErrorPending
         assertTrue(getBooleanField(activity, "loadErrorPending"));
         // Should hide WebView
-        verify(mockWebView).setVisibility(android.view.View.INVISIBLE);
+        verify(mockWebView).setVisibility(android.view.View.GONE);
 
         // Execute the captured runnable to verify showLoginPage is called
         assertNotNull(capturedRunnable[0]);


### PR DESCRIPTION
The cold-start white flash fix (v0.59.0) changed WebView visibility from INVISIBLE to GONE in MainActivity.java, but 4 Mockito tests in MainActivityConnectionRecoveryTest still expected INVISIBLE. This updates the test expectations to match the new behavior.

Failed tests:
- onPageStarted_remotePage_hidesWebView
- onReceivedError_mainFrame_setsLoadErrorPendingAndSchedulesShowLoginPage
- onReceivedHttpError_mainFrameNotConnected_401_setsErrorAndSchedulesLogin
- onReceivedSslError_httpsServer_cancelsAndSchedulesLogin