### PR TITLE
revert: fix: resolve lint and test failures for CI compliance (#311)

### DIFF
--- a/internal/handler/chat_history.go
+++ b/internal/handler/chat_history.go
@@ -208,11 +208,6 @@ func ServeChatMessageUpdate(w http.ResponseWriter, r *http.Request) {
 
 // ServeToolCallDetail handles GET /api/ai/chat/tool-call — returns the full
 // input/output for a single tool call from the chat_tool_calls table.
-// Parameters: tool_id (required), message_id (required), session_id (optional).
-// When the tool_id+message_id lookup fails, falls back to tool_id+session_id
-// lookup if session_id is provided. This handles task executions where
-// AutoResumeBackend resume splits create multiple assistant messages and the
-// tool call may be stored under a different message_id.
 func ServeToolCallDetail(w http.ResponseWriter, r *http.Request) {
 	if r.Method != http.MethodGet {
 		writeLocalizedErrorf(w, r, http.StatusMethodNotAllowed, "MethodNotAllowed")
@@ -224,7 +219,6 @@ func ServeToolCallDetail(w http.ResponseWriter, r *http.Request) {
 	}
 	toolID := r.URL.Query().Get("tool_id")
 	messageIDStr := r.URL.Query().Get("message_id")
-	sessionID := r.URL.Query().Get("session_id")
 	if toolID == "" || messageIDStr == "" {
 		writeLocalizedErrorf(w, r, http.StatusBadRequest, "ToolIdAndMessageIdRequired")
 		return
@@ -237,16 +231,8 @@ func ServeToolCallDetail(w http.ResponseWriter, r *http.Request) {
 
 	record, err := service.GetToolCall(toolID, messageID)
 	if err != nil || record == nil {
-		// Fallback: look up by tool_id + session_id when message_id lookup fails.
-		// This handles task executions with resume splits where the tool call
-		// is stored under a different assistant message than the last one.
-		if sessionID != "" {
-			record, err = service.GetToolCallBySession(toolID, sessionID)
-		}
-		if err != nil || record == nil {
-			writeLocalizedError(w, r, model.NotFound(fmt.Errorf("tool call not found"), "ToolCallNotFound"))
-			return
-		}
+		writeLocalizedError(w, r, model.NotFound(fmt.Errorf("tool call not found"), "ToolCallNotFound"))
+		return
 	}
 
 	// Verify session is not soft-deleted, then check project ownership

--- a/internal/handler/chat_history_session_test.go
+++ b/internal/handler/chat_history_session_test.go
@@ -474,53 +474,6 @@ func TestServeToolCallDetail_PostRejected(t *testing.T) {
 	assert.Equal(t, http.StatusMethodNotAllowed, w.Code)
 }
 
-func TestServeToolCallDetail_SessionIDFallback(t *testing.T) {
-	env, teardown := setupTestEnv(t)
-	defer teardown()
-
-	sessionID, err := service.CreateSession(env.ProjectDir, "claude", "Test", "claude", "", "default", "chat")
-	require.NoError(t, err)
-
-	// Simulate AutoResumeBackend: two assistant messages in the same session
-	msgID1, err := service.AddChatMessage(env.ProjectDir, "claude", sessionID, "assistant", `{"blocks":[{"type":"tool_use","name":"Read","id":"toolu_split01","status":"success","done":true}]}`, nil, false, "")
-	require.NoError(t, err)
-
-	msgID2, err := service.AddChatMessage(env.ProjectDir, "claude", sessionID, "assistant", `{"blocks":[{"type":"tool_use","name":"Write","id":"toolu_split02","status":"success","done":true}]}`, nil, false, "")
-	require.NoError(t, err)
-
-	// Tool call stored under msgID1 (first assistant message)
-	err = service.UpsertToolCall(msgID1, sessionID, "toolu_split01", "Read", json.RawMessage(`{"file_path":"/tmp/a.go"}`), "contents-a", "success", "", true)
-	require.NoError(t, err)
-
-	// Tool call stored under msgID2 (second assistant message)
-	err = service.UpsertToolCall(msgID2, sessionID, "toolu_split02", "Write", json.RawMessage(`{"file_path":"/tmp/b.go"}`), "contents-b", "success", "", true)
-	require.NoError(t, err)
-
-	// Case 1: Wrong message_id but correct session_id → should find via fallback
-	req := newRequest(t, http.MethodGet, fmt.Sprintf("/api/ai/chat/tool-call?tool_id=toolu_split01&message_id=%d&session_id=%s", msgID2, sessionID), nil)
-	req = withProjectCookie(req, env.ProjectDir)
-	w := callHandler(ServeToolCallDetail, req)
-	assertOK(t, w)
-	var result map[string]any
-	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &result))
-	assert.Equal(t, "Read", result["name"])
-
-	// Case 2: No session_id, wrong message_id → 404
-	req2 := newRequest(t, http.MethodGet, fmt.Sprintf("/api/ai/chat/tool-call?tool_id=toolu_split01&message_id=%d", msgID2), nil)
-	req2 = withProjectCookie(req2, env.ProjectDir)
-	w2 := callHandler(ServeToolCallDetail, req2)
-	assert.Equal(t, http.StatusNotFound, w2.Code)
-
-	// Case 3: Correct message_id, no session_id → should still work (primary lookup)
-	req3 := newRequest(t, http.MethodGet, fmt.Sprintf("/api/ai/chat/tool-call?tool_id=toolu_split01&message_id=%d", msgID1), nil)
-	req3 = withProjectCookie(req3, env.ProjectDir)
-	w3 := callHandler(ServeToolCallDetail, req3)
-	assertOK(t, w3)
-	var result3 map[string]any
-	require.NoError(t, json.Unmarshal(w3.Body.Bytes(), &result3))
-	assert.Equal(t, "Read", result3["name"])
-}
-
 // --- ServeSessions GET with pagination ---
 
 func TestServeSessions_Get_WithLimitParam(t *testing.T) {

--- a/internal/push/dingtalk/push.go
+++ b/internal/push/dingtalk/push.go
@@ -5,26 +5,7 @@ import (
 	"fmt"
 	"log/slog"
 	"time"
-	"unicode/utf8"
 )
-
-// dingtalkPreviewMaxRunes is the maximum number of runes for the response
-// preview in DingTalk Markdown messages. DingTalk sampleMarkdown supports
-// ~20000 bytes; 4000 runes (~12000 bytes for CJK) leaves room for the
-// message template and reply hint.
-const dingtalkPreviewMaxRunes = 4000
-
-// truncateForDingTalk truncates text to dingtalkPreviewMaxRunes with
-// ellipsis if needed. Truncates by rune boundary to avoid corrupted characters.
-func truncateForDingTalk(text string) string {
-	if text == "" {
-		return ""
-	}
-	if utf8.RuneCountInString(text) <= dingtalkPreviewMaxRunes {
-		return text
-	}
-	return string([]rune(text)[:dingtalkPreviewMaxRunes]) + "…"
-}
 
 // PushSessionEvent sends a DingTalk push notification for a session event.
 // Only processes completed/cancelled/permission_pending statuses.
@@ -44,7 +25,7 @@ func PushSessionEvent(sessionID, status, sessionTitle, responsePreview, projectP
 		markdown = fmt.Sprintf("### 会话已完成\n**会话**: %s\n\n**项目**: %s\n\n%s%s",
 			sessionTitle,
 			projectPath,
-			truncateForDingTalk(responsePreview),
+			responsePreview,
 			replyHint)
 	case "cancelled":
 		title = "会话已取消"
@@ -52,7 +33,7 @@ func PushSessionEvent(sessionID, status, sessionTitle, responsePreview, projectP
 		markdown = fmt.Sprintf("### 会话已取消\n**会话**: %s\n\n**项目**: %s\n\n%s%s",
 			sessionTitle,
 			projectPath,
-			truncateForDingTalk(responsePreview),
+			responsePreview,
 			replyHint)
 	case "permission_pending":
 		title = "操作需批准"
@@ -90,19 +71,19 @@ func PushTaskEvent(taskID, status, taskName, responsePreview, projectPath string
 		markdown = fmt.Sprintf("### 定时任务已完成\n**任务**: %s\n\n**项目**: %s\n\n%s",
 			taskName,
 			projectPath,
-			truncateForDingTalk(responsePreview))
+			responsePreview)
 	case "failed":
 		title = "定时任务失败"
 		markdown = fmt.Sprintf("### 定时任务失败\n**任务**: %s\n\n**项目**: %s\n\n%s",
 			taskName,
 			projectPath,
-			truncateForDingTalk(responsePreview))
+			responsePreview)
 	case "cancelled":
 		title = "定时任务已取消"
 		markdown = fmt.Sprintf("### 定时任务已取消\n**任务**: %s\n\n**项目**: %s\n\n%s",
 			taskName,
 			projectPath,
-			truncateForDingTalk(responsePreview))
+			responsePreview)
 	default:
 		return false
 	}

--- a/internal/push/dingtalk/push_test.go
+++ b/internal/push/dingtalk/push_test.go
@@ -1,7 +1,6 @@
 package dingtalk
 
 import (
-	"strings"
 	"testing"
 
 	"clawbench/internal/model"
@@ -367,50 +366,6 @@ func TestSendToAllSubscribers_DisabledMode(t *testing.T) {
 
 	if sendToAllSubscribers("Title", "Markdown") {
 		t.Error("expected false in disabled mode")
-	}
-}
-
-func TestTruncateForDingTalk_Empty(t *testing.T) {
-	if got := truncateForDingTalk(""); got != "" {
-		t.Errorf("expected empty, got %q", got)
-	}
-}
-
-func TestTruncateForDingTalk_Short(t *testing.T) {
-	input := "Hello, world!"
-	if got := truncateForDingTalk(input); got != input {
-		t.Errorf("expected %q, got %q", input, got)
-	}
-}
-
-func TestTruncateForDingTalk_ExactLimit(t *testing.T) {
-	input := strings.Repeat("x", dingtalkPreviewMaxRunes)
-	if got := truncateForDingTalk(input); got != input {
-		t.Errorf("expected no truncation at exact limit")
-	}
-}
-
-func TestTruncateForDingTalk_OverLimit(t *testing.T) {
-	input := strings.Repeat("x", dingtalkPreviewMaxRunes+100)
-	got := truncateForDingTalk(input)
-	if !strings.HasSuffix(got, "…") {
-		t.Error("expected ellipsis suffix")
-	}
-	// Should be exactly dingtalkPreviewMaxRunes + 1 (ellipsis)
-	if len([]rune(got)) != dingtalkPreviewMaxRunes+1 {
-		t.Errorf("expected %d runes, got %d", dingtalkPreviewMaxRunes+1, len([]rune(got)))
-	}
-}
-
-func TestTruncateForDingTalk_CJK(t *testing.T) {
-	// CJK characters are multi-byte in UTF-8 but single runes
-	input := strings.Repeat("中", dingtalkPreviewMaxRunes+50)
-	got := truncateForDingTalk(input)
-	if !strings.HasSuffix(got, "…") {
-		t.Error("expected ellipsis suffix for CJK")
-	}
-	if len([]rune(got)) != dingtalkPreviewMaxRunes+1 {
-		t.Errorf("expected %d runes, got %d", dingtalkPreviewMaxRunes+1, len([]rune(got)))
 	}
 }
 

--- a/internal/service/drain.go
+++ b/internal/service/drain.go
@@ -74,11 +74,11 @@ func RunDrainLoop(cfg DrainConfig, result DrainResult) {
 			return
 		}
 		if result.Err != "" {
-			cfg.MarkDoneAndSendFinal(ai.StreamEvent{Type: eventTypeError, Error: result.Err})
+			cfg.MarkDoneAndSendFinal(ai.StreamEvent{Type: "error", Error: result.Err})
 			return
 		}
 		if result.Empty {
-			cfg.MarkDoneAndSendFinal(ai.StreamEvent{Type: eventTypeError, Error: "AI returned no content", Reason: ai.ReasonEmpty})
+			cfg.MarkDoneAndSendFinal(ai.StreamEvent{Type: "error", Error: "AI returned no content", Reason: ai.ReasonEmpty})
 			return
 		}
 		if result.CancelReason != "" {

--- a/internal/service/scheduler.go
+++ b/internal/service/scheduler.go
@@ -526,16 +526,15 @@ func emitTaskEvent(taskID, status, executionID, sessionID, projectPath, taskName
 		ProjectPath: projectPath,
 	}
 	// For completed/failed/cancelled tasks, include session title (task name) and response preview
-	var responsePreviewRaw string
 	if status == "completed" || status == "cancelled" || status == "failed" {
 		if taskName != "" {
 			data.SessionTitle = taskName
 		}
 		if sessionID != "" {
-			responsePreviewRaw = getSessionResponsePreviewRaw(sessionID)
-			data.ResponsePreview = truncatePreview(responsePreviewRaw)
-			if responsePreviewRaw != "" {
-				data.ResponsePreviewPlain = truncatePreview(summarize.StripMarkdown(responsePreviewRaw))
+			raw := getSessionResponsePreviewRaw(sessionID)
+			data.ResponsePreview = truncatePreview(raw)
+			if raw != "" {
+				data.ResponsePreviewPlain = truncatePreview(summarize.StripMarkdown(raw))
 			}
 		}
 	}
@@ -557,10 +556,9 @@ func emitTaskEvent(taskID, status, executionID, sessionID, projectPath, taskName
 	mgr.BroadcastEvent(msg)
 
 	// DingTalk push notification for task events.
-	// Pass raw (untruncated) preview — DingTalk package applies its own limit.
 	// If push succeeds, remove from pending_events to avoid duplicate
 	// Android notification when the app comes back online.
-	if dingtalk.IsStarted() && dingtalk.PushTaskEvent(taskID, status, data.SessionTitle, responsePreviewRaw, data.ProjectPath) {
+	if dingtalk.IsStarted() && dingtalk.PushTaskEvent(taskID, status, data.SessionTitle, data.ResponsePreview, data.ProjectPath) {
 		_ = DeletePendingEvent(msg.ID)
 	}
 }
@@ -710,8 +708,6 @@ func (s *Scheduler) executeTask(task *model.ScheduledTask, projectPath string, t
 		slog.Error("failed to create backend for task", slog.String("err", err.Error()))
 		cancel() // Release context resources
 		_ = UpdateExecutionStatus(sessionID, "failed")
-		SetSessionRunning(sessionID, false, true)
-		ws.EmitToSession(sessionID, ai.StreamEvent{Type: "error", Error: "task execution failed"})
 		emitTaskEvent(fmt.Sprintf("%d", task.ID), "failed", fmt.Sprintf("%d", executionID), sessionID, projectPath, task.Name)
 		return
 	}
@@ -738,8 +734,6 @@ func (s *Scheduler) executeTask(task *model.ScheduledTask, projectPath string, t
 	if err != nil {
 		slog.Error("failed to execute stream for task", slog.String("err", err.Error()))
 		_ = UpdateExecutionStatus(sessionID, "failed")
-		SetSessionRunning(sessionID, false, true)
-		ws.EmitToSession(sessionID, ai.StreamEvent{Type: "error", Error: "task execution failed"})
 		emitTaskEvent(fmt.Sprintf("%d", task.ID), "failed", fmt.Sprintf("%d", executionID), sessionID, projectPath, task.Name)
 		return
 	}
@@ -747,21 +741,20 @@ func (s *Scheduler) executeTask(task *model.ScheduledTask, projectPath string, t
 	// Create streaming placeholder message in DB (so SessionExecutor.Finalize
 	// can update it via FinalizeStreamingMessage, just like interactive sessions).
 	emptyContent, _ := json.Marshal(map[string]any{"blocks": []any{}})
-	streamingMsgID, _ := AddChatMessage(projectPath, backendName, sessionID, "assistant", string(emptyContent), nil, true, "")
+	_, _ = AddChatMessage(projectPath, backendName, sessionID, "assistant", string(emptyContent), nil, true, "")
 
 	// Delegate event loop to SessionExecutor (scheduled mode — no ask-question
 	// conversion, no cancel-reason tracking)
 	executor := NewSessionExecutor(ctx, RunConfig{
-		Mode:               ModeScheduled,
-		ProjectPath:        projectPath,
-		BackendName:        backendName,
-		SessionID:          sessionID,
-		AgentID:            task.AgentID,
-		ChatRequest:        chatReq,
-		TaskID:             task.ID,
-		ExecutionID:        executionID,
-		TriggerType:        triggerType,
-		StreamingMessageID: streamingMsgID,
+		Mode:        ModeScheduled,
+		ProjectPath: projectPath,
+		BackendName: backendName,
+		SessionID:   sessionID,
+		AgentID:     task.AgentID,
+		ChatRequest: chatReq,
+		TaskID:      task.ID,
+		ExecutionID: executionID,
+		TriggerType: triggerType,
 	})
 	runResult := executor.RunWithChannel(eventCh)
 
@@ -773,8 +766,6 @@ func (s *Scheduler) executeTask(task *model.ScheduledTask, projectPath string, t
 			slog.String("session_id", sessionID),
 		)
 		_ = UpdateExecutionStatus(sessionID, "cancelled")
-		SetSessionRunning(sessionID, false, true)
-		ws.EmitToSession(sessionID, ai.StreamEvent{Type: "cancelled"})
 		emitTaskEvent(fmt.Sprintf("%d", task.ID), "cancelled", fmt.Sprintf("%d", executionID), sessionID, projectPath, task.Name)
 		// Only update stats, not status — don't overwrite user-initiated pauses (ISS-013)
 		UpdateTaskStats(task)
@@ -793,8 +784,6 @@ func (s *Scheduler) executeTask(task *model.ScheduledTask, projectPath string, t
 			slog.String("session_id", sessionID),
 		)
 		_ = UpdateExecutionStatus(sessionID, "failed")
-		SetSessionRunning(sessionID, false, true)
-		ws.EmitToSession(sessionID, ai.StreamEvent{Type: "error", Error: "task execution ended unexpectedly"})
 		emitTaskEvent(fmt.Sprintf("%d", task.ID), "failed", fmt.Sprintf("%d", executionID), sessionID, projectPath, task.Name)
 		// Only update stats, not status — don't overwrite user-initiated pauses (ISS-013)
 		UpdateTaskStats(task)
@@ -808,13 +797,6 @@ func (s *Scheduler) executeTask(task *model.ScheduledTask, projectPath string, t
 
 	// Mark execution as completed
 	_ = UpdateExecutionStatus(sessionID, "completed")
-
-	// Send terminal "done" event to WS chat_stream subscribers so that
-	// useTaskExecStream (live preview) stops streaming. Without this,
-	// the frontend stays in streaming state indefinitely.
-	SetSessionRunning(sessionID, false, true) // skip event — we emit directly
-	ws.EmitToSession(sessionID, ai.StreamEvent{Type: "done"})
-
 	emitTaskEvent(fmt.Sprintf("%d", task.ID), "completed", fmt.Sprintf("%d", executionID), sessionID, projectPath, task.Name)
 
 	// Update task execution stats

--- a/internal/service/session_runtime.go
+++ b/internal/service/session_runtime.go
@@ -48,17 +48,16 @@ func EmitSessionEvent(sessionID, status string, hasNewMessages bool, toolName ..
 	}
 
 	// On completion, include session title for push notification
-	var responsePreviewRaw string
 	if status == "completed" || status == "cancelled" {
 		if title, err := GetSessionTitle(sessionID); err == nil && title != "" {
 			data.SessionTitle = title
 		}
 		// Include response preview for DingTalk (Markdown) and Android/browser (plain text)
 		if status == "completed" {
-			responsePreviewRaw = getSessionResponsePreviewRaw(sessionID)
-			data.ResponsePreview = truncatePreview(responsePreviewRaw)
-			if responsePreviewRaw != "" {
-				data.ResponsePreviewPlain = truncatePreview(summarize.StripMarkdown(responsePreviewRaw))
+			raw := getSessionResponsePreviewRaw(sessionID)
+			data.ResponsePreview = truncatePreview(raw)
+			if raw != "" {
+				data.ResponsePreviewPlain = truncatePreview(summarize.StripMarkdown(raw))
 			}
 		}
 	}
@@ -85,10 +84,9 @@ func EmitSessionEvent(sessionID, status string, hasNewMessages bool, toolName ..
 	mgr.BroadcastEvent(msg)
 
 	// DingTalk push notification for session events.
-	// Pass raw (untruncated) preview — DingTalk package applies its own limit.
 	// If push succeeds, remove from pending_events to avoid duplicate
 	// Android notification when the app comes back online.
-	if dingtalk.IsStarted() && dingtalk.PushSessionEvent(sessionID, status, data.SessionTitle, responsePreviewRaw, data.ProjectPath, data.ToolName) {
+	if dingtalk.IsStarted() && dingtalk.PushSessionEvent(sessionID, status, data.SessionTitle, data.ResponsePreview, data.ProjectPath, data.ToolName) {
 		_ = DeletePendingEvent(msg.ID)
 	}
 }

--- a/internal/service/tool_calls.go
+++ b/internal/service/tool_calls.go
@@ -66,31 +66,3 @@ func GetToolCall(toolID string, messageID int64) (*ToolCallRecord, error) {
 	r.Done = doneInt != 0
 	return &r, nil
 }
-
-// GetToolCallBySession retrieves a tool call record by tool_id and session_id.
-// This is a fallback for task executions where the session has multiple assistant
-// messages (from AutoResumeBackend resume splits) and the tool call may be stored
-// under a different message_id than the one the frontend knows about.
-// Returns nil if not found.
-func GetToolCallBySession(toolID, sessionID string) (*ToolCallRecord, error) {
-	var r ToolCallRecord
-	var doneInt int
-	var inputStr string
-	err := dbRead.QueryRowContext(context.Background(), `
-		SELECT id, message_id, session_id, tool_id, name, input, output, status, done, summary, created_at
-		FROM chat_tool_calls WHERE tool_id = ? AND session_id = ?
-		ORDER BY created_at DESC LIMIT 1
-	`, toolID, sessionID).Scan(
-		&r.ID, &r.MessageID, &r.SessionID, &r.ToolID, &r.Name,
-		&inputStr, &r.Output, &r.Status, &doneInt, &r.Summary, &r.CreatedAt,
-	)
-	if err == sql.ErrNoRows {
-		return nil, nil
-	}
-	if err != nil {
-		return nil, fmt.Errorf("GetToolCallBySession: %w", err)
-	}
-	r.Input = json.RawMessage(inputStr)
-	r.Done = doneInt != 0
-	return &r, nil
-}

--- a/internal/service/tool_calls_test.go
+++ b/internal/service/tool_calls_test.go
@@ -123,42 +123,6 @@ func TestUpsertAndGetToolCall(t *testing.T) {
 			t.Error("expected nil for wrong message_id")
 		}
 	})
-
-	t.Run("GetToolCallBySession finds record by session_id", func(t *testing.T) {
-		record, err := GetToolCallBySession("toolu_01", sessionID)
-		if err != nil {
-			t.Fatalf("GetToolCallBySession: %v", err)
-		}
-		if record == nil {
-			t.Fatal("GetToolCallBySession returned nil")
-		}
-		if record.ToolID != "toolu_01" {
-			t.Errorf("ToolID = %q, want %q", record.ToolID, "toolu_01")
-		}
-		if record.SessionID != sessionID {
-			t.Errorf("SessionID = %q, want %q", record.SessionID, sessionID)
-		}
-	})
-
-	t.Run("GetToolCallBySession returns nil for non-existent session", func(t *testing.T) {
-		record, err := GetToolCallBySession("toolu_01", "nonexistent-session")
-		if err != nil {
-			t.Fatalf("GetToolCallBySession: %v", err)
-		}
-		if record != nil {
-			t.Error("expected nil for non-existent session")
-		}
-	})
-
-	t.Run("GetToolCallBySession returns nil for non-existent tool_id", func(t *testing.T) {
-		record, err := GetToolCallBySession("toolu_99", sessionID)
-		if err != nil {
-			t.Fatalf("GetToolCallBySession: %v", err)
-		}
-		if record != nil {
-			t.Error("expected nil for non-existent tool_id")
-		}
-	})
 }
 
 // initTestDB creates a test database in the given directory

--- a/web/src/components/__tests__/format.test.ts
+++ b/web/src/components/__tests__/format.test.ts
@@ -226,8 +226,8 @@ describe('stripMarkdownPreview', () => {
   it('truncates long text with ellipsis', () => {
     const longText = 'a'.repeat(200)
     const result = stripMarkdownPreview(longText, 100)
-    expect(result.length).toBe(101) // 100 + '…'
-    expect(result.endsWith('…')).toBe(true)
+    expect(result.length).toBe(103) // 100 + '...'
+    expect(result.endsWith('...')).toBe(true)
   })
 
   it('preserves short text without truncation', () => {
@@ -244,8 +244,8 @@ describe('stripMarkdownPreview', () => {
   })
 
   it('respects custom maxLen', () => {
-    // 'Hello world' is 11 chars, maxLen=7 -> 'Hello w' + '…' = 'Hello w…'
-    expect(stripMarkdownPreview('Hello world', 7)).toBe('Hello w…')
+    // 'Hello world' is 11 chars, maxLen=7 -> 'Hello w' + '...' = 'Hello w...'
+    expect(stripMarkdownPreview('Hello world', 7)).toBe('Hello w...')
   })
 })
 

--- a/web/src/components/chat/ChatPanelContent.vue
+++ b/web/src/components/chat/ChatPanelContent.vue
@@ -128,7 +128,7 @@
 
   <!-- Tool Detail Overlay -->
   <ToolDetailDrawer
-    :show="toolDetailDrawer.isOpen.value"
+    :show="toolDetailDrawer.effectiveOpen.value"
     :toolName="toolDetailOverlay.name"
     :toolSubagentType="toolDetailOverlay.subagentType"
     :toolSummary="toolDetailOverlay.summary"
@@ -257,6 +257,7 @@ function findToolBlock({ msgId, blockIdx }) {
 }
 
 const {
+  show: toolDetailShow,
   drawer: toolDetailDrawer,
   toolDetailData,
   toolDetailOverlay,
@@ -518,7 +519,7 @@ watch(
     return { output: block.output, done: block.done, status: block.status, input: block.input, name: block.name, summary: block.summary, display_name: block.display_name }
   },
   (data) => {
-    if (data === null || !toolDetailDrawer.isOpen.value) return
+    if (data === null || !toolDetailShow.value) return
     const { formatToolInput } = render
     const hasInput = data.input && Object.keys(data.input).length > 0
     toolDetailData.value.outputHtml = data.output ? formatToolOutput(data.output, data.name) : toolDetailData.value.outputHtml
@@ -530,7 +531,7 @@ watch(
 )
 
 // Clean up overlay state when overlay closes
-watch(() => toolDetailDrawer.isOpen.value, (show) => {
+watch(() => toolDetailShow.value, (show) => {
   if (!show) {
     activeToolOverlay.value = null
     // Clear tool update debounce timers

--- a/web/src/components/chat/ContentBlocks.vue
+++ b/web/src/components/chat/ContentBlocks.vue
@@ -274,9 +274,7 @@ onMounted(() => {
 })
 async function fetchToolCallInputForAutoExpand(block, msgId) {
   try {
-    let url = `/api/ai/chat/tool-call?tool_id=${encodeURIComponent(block.id)}&message_id=${encodeURIComponent(msgId)}`
-    if (props.sessionId) url += `&session_id=${encodeURIComponent(props.sessionId)}`
-    const resp = await fetch(url)
+    const resp = await fetch(`/api/ai/chat/tool-call?tool_id=${encodeURIComponent(block.id)}&message_id=${encodeURIComponent(msgId)}`)
     if (!resp.ok) return
     const data = await resp.json()
     if (data.input) {

--- a/web/src/components/settings/SettingsPage.vue
+++ b/web/src/components/settings/SettingsPage.vue
@@ -10,7 +10,7 @@
       <template v-else>
         <Settings :size="20" class="settings-page__header-icon" />
         <span class="settings-page__title">{{ t('nav.settings') }}</span>
-        <span v-if="serverVersion" class="settings-page__version">{{ serverVersion }}</span>
+        <span v-if="serverVersion" class="settings-page__version">v{{ serverVersion }}</span>
       </template>
     </header>
     <div class="settings-page__body">

--- a/web/src/components/settings/__tests__/SettingsPage.test.ts
+++ b/web/src/components/settings/__tests__/SettingsPage.test.ts
@@ -196,7 +196,7 @@ describe('SettingsPage', () => {
     expect(wrapper.find('.settings-page__header').exists()).toBe(true)
     expect(wrapper.find('.settings-page__header-icon').exists()).toBe(true)
     expect(wrapper.find('.settings-page__version').exists()).toBe(true)
-    expect(wrapper.find('.settings-page__version').text()).toBe('1.2.3')
+    expect(wrapper.find('.settings-page__version').text()).toBe('v1.2.3')
     expect(wrapper.find('.settings-page__back').exists()).toBe(false)
   })
 
@@ -212,7 +212,7 @@ describe('SettingsPage', () => {
 
   it('hides version badge when serverConfig has no version', () => {
     const wrapper = mountPage()
-    expect(wrapper.find('.settings-page__version').text()).toBe('1.2.3')
+    expect(wrapper.find('.settings-page__version').text()).toBe('v1.2.3')
   })
 
   // ─── Category routing (all via SettingsCategory now) ──

--- a/web/src/components/task/TaskExecDetail.vue
+++ b/web/src/components/task/TaskExecDetail.vue
@@ -44,7 +44,7 @@
 
     <!-- Tool Detail Overlay -->
     <ToolDetailDrawer
-      :show="toolDetailDrawer.isOpen.value"
+      :show="toolDetailOverlay.show"
       :toolName="toolDetailOverlay.name"
       :toolSubagentType="toolDetailOverlay.subagentType"
       :toolSummary="toolDetailOverlay.summary"
@@ -53,7 +53,7 @@
       :toolStatus="toolDetailOverlay.status"
       :toolDone="toolDetailOverlay.done"
       :displayNameOverride="toolDetailOverlay.displayNameOverride"
-      @close="closeOverlay"
+      @close="toolDetailShow = false"
       @file-open="handleFileOpenInOverlay"
       @click="handleOverlayRetryClick"
     />
@@ -103,7 +103,6 @@ import { useSessionIdentity } from '@/composables/useSessionIdentity.ts'
 import { useToolDetailDrawer } from '@/composables/useToolDetailDrawer.ts'
 import { useTableRowExpand } from '@/composables/useTableRowExpand.ts'
 import { useTaskExecStream } from '@/composables/useTaskExecStream.ts'
-import { formatToolOutput } from '@/utils/renderToolDetail.ts'
 import TableRowModal from '@/components/common/TableRowModal.vue'
 
 const props = defineProps({
@@ -204,14 +203,12 @@ function setTab(tab) {
 const msgData = computed(() => {
   if (!props.execDetail?.content && props.execDetail?.status !== 'cancelled') return null
   const { blocks } = chatRender.parseAssistantContent(props.execDetail.content || '{}')
-  // Use messageId (DB chat_history ID) for tool detail fetch; fallback only if unavailable
-  const msgId = props.execDetail.messageId || props.execDetail.id || 'exec'
   if (!blocks || blocks.length === 0) {
     // For running executions with empty content, return a streaming placeholder
     // so the live indicator bar is shown instead of "no text output"
     if (isRunning.value) {
       return {
-        id: msgId,
+        id: props.execDetail.messageId || props.execDetail.id || 'exec',
         role: 'assistant',
         content: '',
         blocks: [],
@@ -224,7 +221,7 @@ const msgData = computed(() => {
     return null
   }
   return {
-    id: msgId,
+    id: props.execDetail.messageId || props.execDetail.id || 'exec',
     role: 'assistant',
     content: props.execDetail.content,
     blocks,
@@ -261,15 +258,6 @@ const activeMsgData = computed(() => {
     // Show streaming message if it has blocks (real-time content)
     if (sm.blocks && sm.blocks.length > 0) return sm
   }
-  // After streaming stops, the streamingMsg still has blocks (streaming flag removed).
-  // Use it as fallback while waiting for refreshExecDetail to complete,
-  // so the user sees content immediately instead of a blank/loading state.
-  if (!execStream.isStreaming.value && execStream.streamingMsg.value) {
-    const sm = execStream.streamingMsg.value
-    if (sm.blocks && sm.blocks.length > 0) {
-      return { ...sm, streaming: false }
-    }
-  }
   // When not streaming, use the DB content (refreshed by refreshExecDetail)
   // we always show whatever partial content is available rather than "connecting..."
   if (activeTab.value === 'summary' && summaryMsgData.value) return summaryMsgData.value
@@ -284,84 +272,18 @@ function toggleTool(key) {
 }
 
 // ── Tool Detail Overlay ──
-
-/** Look up the tool_use block from the streaming message by msgId + blockIdx */
-function findLiveToolBlock({ msgId, blockIdx }) {
-  const sm = execStream.streamingMsg.value
-  if (!sm || !sm.blocks) return null
-  // For streaming messages, msgId comes from the streaming message id
-  if (String(sm.id) !== String(msgId)) return null
-  const block = sm.blocks[blockIdx]
-  return (block && block.type === 'tool_use') ? block : null
-}
-
 const {
-  drawer: toolDetailDrawer,
+  show: toolDetailShow,
   toolDetailOverlay,
-  toolDetailData,
-  activeToolOverlay,
   handleShowToolDetail,
   handleOverlayRetryClick,
   handleFileOpenInOverlay,
-  fetchToolCallDetail,
-  closeOverlay,
 } = useToolDetailDrawer({
   chatRender,
   onFileOpen: (path, lineStart, lineEnd) => {
     openFilePath(path, lineStart, lineEnd)
     emit('open-file', { path, lineStart, lineEnd })
   },
-  findLiveBlock: findLiveToolBlock,
-  sessionId: () => props.execDetail?.sessionId,
-})
-
-// Reactively update tool overlay content as block output/done/status changes during streaming
-watch(
-  () => {
-    if (!activeToolOverlay.value) return null
-    const block = findLiveToolBlock(activeToolOverlay.value)
-    if (!block) return null
-    return { output: block.output, done: block.done, status: block.status, input: block.input, name: block.name, summary: block.summary, display_name: block.display_name }
-  },
-  (data) => {
-    if (data === null || !toolDetailDrawer.isOpen.value) return
-    const { formatToolInput } = chatRender
-    const hasInput = data.input && Object.keys(data.input).length > 0
-    toolDetailData.value.outputHtml = data.output ? formatToolOutput(data.output, data.name) : toolDetailData.value.outputHtml
-    toolDetailData.value.status = data.status || ''
-    toolDetailData.value.done = !!data.done
-    toolDetailData.value.inputHtml = hasInput ? formatToolInput(data.input, data.name, { done: data.done, status: data.status, output: data.output }) : toolDetailData.value.inputHtml
-    toolDetailData.value.summary = data.summary || toolDetailData.value.summary
-  }
-)
-
-// Clean up overlay state when drawer closes
-watch(() => toolDetailDrawer.isOpen.value, (open) => {
-  if (!open) {
-    activeToolOverlay.value = null
-  }
-})
-
-// Re-fetch tool detail when messageId becomes available (e.g. after refreshExecDetail completes)
-// The initial execData from the history list may lack messageId, causing fetchToolCallDetail
-// to fail. When refreshExecDetail updates selectedExecData with a valid messageId,
-// retry the fetch if the overlay is still open and content is empty.
-watch(() => props.execDetail?.messageId, (newMsgId) => {
-  if (!newMsgId || !toolDetailDrawer.isOpen.value) return
-  const ids = toolDetailData.value._fetchIds
-  if (!ids) return
-  // Only retry if input is still empty (fetch hasn't succeeded yet)
-  if (toolDetailData.value.inputHtml && !toolDetailData.value.inputHtml.includes('tool-call-loading') && !toolDetailData.value.inputHtml.includes('tool-call-empty')) return
-  // Retry with the correct messageId
-  const block = findLiveToolBlock(activeToolOverlay.value || { msgId: '', blockIdx: 0 })
-  fetchToolCallDetail(ids.toolId, newMsgId, block || { name: toolDetailData.value.name })
-})
-
-// Clear stale streamingMsg once DB content is available (DB is authoritative)
-watch(() => props.execDetail?.content, (newContent) => {
-  if (newContent && !execStream.isStreaming.value && execStream.streamingMsg.value) {
-    execStream.streamingMsg.value = null
-  }
 })
 
 // ── Metadata Modal ──
@@ -448,18 +370,13 @@ function handleContentClick(event) {
 // ── Reset state when exec detail changes ──
 watch(() => props.execDetail, (newVal, oldVal) => {
   expandedTools.value = {}
-  closeOverlay()
+  toolDetailShow.value = false
   metadataModal.value.show = false
   activeTab.value = hasSummary.value ? 'summary' : 'original'
 
   // Start live preview when execution becomes running
   if (newVal?.status === 'running' && newVal?.sessionId) {
     execStream.startPreview()
-    // Fetch latest content from API for running executions — the initial data
-    // from the history list may lack content, and WS only delivers new events
-    if (!newVal.content) {
-      refreshExecDetail()
-    }
   }
   // Stop preview when execution is no longer running
   if (oldVal?.status === 'running' && newVal?.status !== 'running') {

--- a/web/src/composables/useTaskTab.ts
+++ b/web/src/composables/useTaskTab.ts
@@ -297,9 +297,10 @@ export function useTaskTab() {
         selectedExecId.value = execId
         selectedExecData.value = (execData as TaskExecData | null) ?? null
         execDetailOpen.value = true
-        // Always refresh from API — the list data may lack content/sessionId,
-        // and running executions need the latest content for live preview
-        refreshExecDetail()
+        // If no execData provided, auto-fetch from API (e.g. from push notification deep link)
+        if (!execData) {
+            refreshExecDetail()
+        }
     }
 
     /** Open the latest execution detail for a task directly (skip history list) */
@@ -343,8 +344,6 @@ export function useTaskTab() {
                 const merged = { ...selectedExecData.value, ...safeFields }
                 // Only overwrite content if API returned a non-null value
                 if (exec.content != null) merged.content = exec.content
-                // Only set messageId if it's a valid DB ID (Go int64 zero-value = 0 is invalid)
-                if (!exec.messageId) delete merged.messageId
                 selectedExecData.value = merged
             }
         } catch {

--- a/web/src/composables/useToolDetailDrawer.ts
+++ b/web/src/composables/useToolDetailDrawer.ts
@@ -30,21 +30,13 @@ interface ToolDetailDrawerOptions {
   chatRender: ChatRenderRef
   onFileOpen?: (path: string, lineStart?: number, lineEnd?: number) => void
   findLiveBlock?: (ids: { msgId: string | number; blockIdx: number }) => ToolBlock | null
-  /** Optional session ID for tool-call API fallback. When the session has multiple
-   *  assistant messages (e.g. AutoResumeBackend resume splits), the tool call may
-   *  be stored under a different message_id. Passing session_id enables the backend
-   *  to fall back to tool_id+session_id lookup. */
-  sessionId?: () => string | undefined
 }
 
 /**
  * Shared tool detail drawer logic for ChatPanelContent and TaskExecDetail.
- * Uses a simple ref instead of useTabDrawer because ToolDetailDrawer is a
- * BottomSheet (teleported to <body>) — it's a user-initiated overlay that
- * should persist across tab switches, not auto-hide when switching away.
  */
 export function useToolDetailDrawer(options: ToolDetailDrawerOptions) {
-  const { chatRender, onFileOpen, findLiveBlock, sessionId } = options
+  const { chatRender, onFileOpen, findLiveBlock } = options
   const { t } = useI18n()
 
   const drawer = useTabDrawer('chat')
@@ -135,10 +127,7 @@ export function useToolDetailDrawer(options: ToolDetailDrawerOptions) {
       toolDetailData.value.inputHtml = '<div class="tool-call-loading"></div>'
     }
     try {
-      let url = `/api/ai/chat/tool-call?tool_id=${encodeURIComponent(toolId)}&message_id=${encodeURIComponent(msgId)}`
-      const sid = sessionId?.()
-      if (sid) url += `&session_id=${encodeURIComponent(sid)}`
-      const resp = await fetch(url)
+      const resp = await fetch(`/api/ai/chat/tool-call?tool_id=${encodeURIComponent(toolId)}&message_id=${encodeURIComponent(msgId)}`)
       if (!resp.ok) {
         // Retry on 404 (tool call may not yet be persisted during streaming)
         if (shouldRetryToolFetch(resp.status, _retryCount, show.value)) {
@@ -211,7 +200,8 @@ export function useToolDetailDrawer(options: ToolDetailDrawerOptions) {
     _retryRequested = false
   }
 
-  const toolDetailOverlay = computed(() => ({ show: drawer.isOpen.value, ...toolDetailData.value }))
+  // Backward-compatible computed that merges show + data (consumers that read .show/.name etc still work)
+  const toolDetailOverlay = computed(() => ({ show: show.value, ...toolDetailData.value }))
 
   return {
     show,


### PR DESCRIPTION
Reverts #311 — PR contained unrelated changes from old branch history (42 commits from a stale remote branch) that were incorrectly included via rebase. The squash merge introduced 17 file changes when only 4 were intended. Will re-submit a clean PR with only the lint/test fixes.