### PR TITLE
fix: lint, test, and coverage fixes for CI compliance

### DIFF
--- a/internal/handler/chat_history.go
+++ b/internal/handler/chat_history.go
@@ -208,6 +208,11 @@ func ServeChatMessageUpdate(w http.ResponseWriter, r *http.Request) {
 
 // ServeToolCallDetail handles GET /api/ai/chat/tool-call — returns the full
 // input/output for a single tool call from the chat_tool_calls table.
+// Parameters: tool_id (required), message_id (required), session_id (optional).
+// When the tool_id+message_id lookup fails, falls back to tool_id+session_id
+// lookup if session_id is provided. This handles task executions where
+// AutoResumeBackend resume splits create multiple assistant messages and the
+// tool call may be stored under a different message_id.
 func ServeToolCallDetail(w http.ResponseWriter, r *http.Request) {
 	if r.Method != http.MethodGet {
 		writeLocalizedErrorf(w, r, http.StatusMethodNotAllowed, "MethodNotAllowed")
@@ -219,6 +224,7 @@ func ServeToolCallDetail(w http.ResponseWriter, r *http.Request) {
 	}
 	toolID := r.URL.Query().Get("tool_id")
 	messageIDStr := r.URL.Query().Get("message_id")
+	sessionID := r.URL.Query().Get("session_id")
 	if toolID == "" || messageIDStr == "" {
 		writeLocalizedErrorf(w, r, http.StatusBadRequest, "ToolIdAndMessageIdRequired")
 		return
@@ -231,8 +237,16 @@ func ServeToolCallDetail(w http.ResponseWriter, r *http.Request) {
 
 	record, err := service.GetToolCall(toolID, messageID)
 	if err != nil || record == nil {
-		writeLocalizedError(w, r, model.NotFound(fmt.Errorf("tool call not found"), "ToolCallNotFound"))
-		return
+		// Fallback: look up by tool_id + session_id when message_id lookup fails.
+		// This handles task executions with resume splits where the tool call
+		// is stored under a different assistant message than the last one.
+		if sessionID != "" {
+			record, err = service.GetToolCallBySession(toolID, sessionID)
+		}
+		if err != nil || record == nil {
+			writeLocalizedError(w, r, model.NotFound(fmt.Errorf("tool call not found"), "ToolCallNotFound"))
+			return
+		}
 	}
 
 	// Verify session is not soft-deleted, then check project ownership

--- a/internal/handler/chat_history_session_test.go
+++ b/internal/handler/chat_history_session_test.go
@@ -474,6 +474,53 @@ func TestServeToolCallDetail_PostRejected(t *testing.T) {
 	assert.Equal(t, http.StatusMethodNotAllowed, w.Code)
 }
 
+func TestServeToolCallDetail_SessionIDFallback(t *testing.T) {
+	env, teardown := setupTestEnv(t)
+	defer teardown()
+
+	sessionID, err := service.CreateSession(env.ProjectDir, "claude", "Test", "claude", "", "default", "chat")
+	require.NoError(t, err)
+
+	// Simulate AutoResumeBackend: two assistant messages in the same session
+	msgID1, err := service.AddChatMessage(env.ProjectDir, "claude", sessionID, "assistant", `{"blocks":[{"type":"tool_use","name":"Read","id":"toolu_split01","status":"success","done":true}]}`, nil, false, "")
+	require.NoError(t, err)
+
+	msgID2, err := service.AddChatMessage(env.ProjectDir, "claude", sessionID, "assistant", `{"blocks":[{"type":"tool_use","name":"Write","id":"toolu_split02","status":"success","done":true}]}`, nil, false, "")
+	require.NoError(t, err)
+
+	// Tool call stored under msgID1 (first assistant message)
+	err = service.UpsertToolCall(msgID1, sessionID, "toolu_split01", "Read", json.RawMessage(`{"file_path":"/tmp/a.go"}`), "contents-a", "success", "", true)
+	require.NoError(t, err)
+
+	// Tool call stored under msgID2 (second assistant message)
+	err = service.UpsertToolCall(msgID2, sessionID, "toolu_split02", "Write", json.RawMessage(`{"file_path":"/tmp/b.go"}`), "contents-b", "success", "", true)
+	require.NoError(t, err)
+
+	// Case 1: Wrong message_id but correct session_id → should find via fallback
+	req := newRequest(t, http.MethodGet, fmt.Sprintf("/api/ai/chat/tool-call?tool_id=toolu_split01&message_id=%d&session_id=%s", msgID2, sessionID), nil)
+	req = withProjectCookie(req, env.ProjectDir)
+	w := callHandler(ServeToolCallDetail, req)
+	assertOK(t, w)
+	var result map[string]any
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &result))
+	assert.Equal(t, "Read", result["name"])
+
+	// Case 2: No session_id, wrong message_id → 404
+	req2 := newRequest(t, http.MethodGet, fmt.Sprintf("/api/ai/chat/tool-call?tool_id=toolu_split01&message_id=%d", msgID2), nil)
+	req2 = withProjectCookie(req2, env.ProjectDir)
+	w2 := callHandler(ServeToolCallDetail, req2)
+	assert.Equal(t, http.StatusNotFound, w2.Code)
+
+	// Case 3: Correct message_id, no session_id → should still work (primary lookup)
+	req3 := newRequest(t, http.MethodGet, fmt.Sprintf("/api/ai/chat/tool-call?tool_id=toolu_split01&message_id=%d", msgID1), nil)
+	req3 = withProjectCookie(req3, env.ProjectDir)
+	w3 := callHandler(ServeToolCallDetail, req3)
+	assertOK(t, w3)
+	var result3 map[string]any
+	require.NoError(t, json.Unmarshal(w3.Body.Bytes(), &result3))
+	assert.Equal(t, "Read", result3["name"])
+}
+
 // --- ServeSessions GET with pagination ---
 
 func TestServeSessions_Get_WithLimitParam(t *testing.T) {

--- a/internal/push/dingtalk/push.go
+++ b/internal/push/dingtalk/push.go
@@ -5,7 +5,26 @@ import (
 	"fmt"
 	"log/slog"
 	"time"
+	"unicode/utf8"
 )
+
+// dingtalkPreviewMaxRunes is the maximum number of runes for the response
+// preview in DingTalk Markdown messages. DingTalk sampleMarkdown supports
+// ~20000 bytes; 4000 runes (~12000 bytes for CJK) leaves room for the
+// message template and reply hint.
+const dingtalkPreviewMaxRunes = 4000
+
+// truncateForDingTalk truncates text to dingtalkPreviewMaxRunes with
+// ellipsis if needed. Truncates by rune boundary to avoid corrupted characters.
+func truncateForDingTalk(text string) string {
+	if text == "" {
+		return ""
+	}
+	if utf8.RuneCountInString(text) <= dingtalkPreviewMaxRunes {
+		return text
+	}
+	return string([]rune(text)[:dingtalkPreviewMaxRunes]) + "…"
+}
 
 // PushSessionEvent sends a DingTalk push notification for a session event.
 // Only processes completed/cancelled/permission_pending statuses.
@@ -25,7 +44,7 @@ func PushSessionEvent(sessionID, status, sessionTitle, responsePreview, projectP
 		markdown = fmt.Sprintf("### 会话已完成\n**会话**: %s\n\n**项目**: %s\n\n%s%s",
 			sessionTitle,
 			projectPath,
-			responsePreview,
+			truncateForDingTalk(responsePreview),
 			replyHint)
 	case "cancelled":
 		title = "会话已取消"
@@ -33,7 +52,7 @@ func PushSessionEvent(sessionID, status, sessionTitle, responsePreview, projectP
 		markdown = fmt.Sprintf("### 会话已取消\n**会话**: %s\n\n**项目**: %s\n\n%s%s",
 			sessionTitle,
 			projectPath,
-			responsePreview,
+			truncateForDingTalk(responsePreview),
 			replyHint)
 	case "permission_pending":
 		title = "操作需批准"
@@ -71,19 +90,19 @@ func PushTaskEvent(taskID, status, taskName, responsePreview, projectPath string
 		markdown = fmt.Sprintf("### 定时任务已完成\n**任务**: %s\n\n**项目**: %s\n\n%s",
 			taskName,
 			projectPath,
-			responsePreview)
+			truncateForDingTalk(responsePreview))
 	case "failed":
 		title = "定时任务失败"
 		markdown = fmt.Sprintf("### 定时任务失败\n**任务**: %s\n\n**项目**: %s\n\n%s",
 			taskName,
 			projectPath,
-			responsePreview)
+			truncateForDingTalk(responsePreview))
 	case "cancelled":
 		title = "定时任务已取消"
 		markdown = fmt.Sprintf("### 定时任务已取消\n**任务**: %s\n\n**项目**: %s\n\n%s",
 			taskName,
 			projectPath,
-			responsePreview)
+			truncateForDingTalk(responsePreview))
 	default:
 		return false
 	}

--- a/internal/push/dingtalk/push_test.go
+++ b/internal/push/dingtalk/push_test.go
@@ -1,6 +1,7 @@
 package dingtalk
 
 import (
+	"strings"
 	"testing"
 
 	"clawbench/internal/model"
@@ -366,6 +367,50 @@ func TestSendToAllSubscribers_DisabledMode(t *testing.T) {
 
 	if sendToAllSubscribers("Title", "Markdown") {
 		t.Error("expected false in disabled mode")
+	}
+}
+
+func TestTruncateForDingTalk_Empty(t *testing.T) {
+	if got := truncateForDingTalk(""); got != "" {
+		t.Errorf("expected empty, got %q", got)
+	}
+}
+
+func TestTruncateForDingTalk_Short(t *testing.T) {
+	input := "Hello, world!"
+	if got := truncateForDingTalk(input); got != input {
+		t.Errorf("expected %q, got %q", input, got)
+	}
+}
+
+func TestTruncateForDingTalk_ExactLimit(t *testing.T) {
+	input := strings.Repeat("x", dingtalkPreviewMaxRunes)
+	if got := truncateForDingTalk(input); got != input {
+		t.Errorf("expected no truncation at exact limit")
+	}
+}
+
+func TestTruncateForDingTalk_OverLimit(t *testing.T) {
+	input := strings.Repeat("x", dingtalkPreviewMaxRunes+100)
+	got := truncateForDingTalk(input)
+	if !strings.HasSuffix(got, "…") {
+		t.Error("expected ellipsis suffix")
+	}
+	// Should be exactly dingtalkPreviewMaxRunes + 1 (ellipsis)
+	if len([]rune(got)) != dingtalkPreviewMaxRunes+1 {
+		t.Errorf("expected %d runes, got %d", dingtalkPreviewMaxRunes+1, len([]rune(got)))
+	}
+}
+
+func TestTruncateForDingTalk_CJK(t *testing.T) {
+	// CJK characters are multi-byte in UTF-8 but single runes
+	input := strings.Repeat("中", dingtalkPreviewMaxRunes+50)
+	got := truncateForDingTalk(input)
+	if !strings.HasSuffix(got, "…") {
+		t.Error("expected ellipsis suffix for CJK")
+	}
+	if len([]rune(got)) != dingtalkPreviewMaxRunes+1 {
+		t.Errorf("expected %d runes, got %d", dingtalkPreviewMaxRunes+1, len([]rune(got)))
 	}
 }
 

--- a/internal/service/drain.go
+++ b/internal/service/drain.go
@@ -74,11 +74,11 @@ func RunDrainLoop(cfg DrainConfig, result DrainResult) {
 			return
 		}
 		if result.Err != "" {
-			cfg.MarkDoneAndSendFinal(ai.StreamEvent{Type: "error", Error: result.Err})
+			cfg.MarkDoneAndSendFinal(ai.StreamEvent{Type: eventTypeError, Error: result.Err})
 			return
 		}
 		if result.Empty {
-			cfg.MarkDoneAndSendFinal(ai.StreamEvent{Type: "error", Error: "AI returned no content", Reason: ai.ReasonEmpty})
+			cfg.MarkDoneAndSendFinal(ai.StreamEvent{Type: eventTypeError, Error: "AI returned no content", Reason: ai.ReasonEmpty})
 			return
 		}
 		if result.CancelReason != "" {

--- a/internal/service/scheduler.go
+++ b/internal/service/scheduler.go
@@ -526,15 +526,16 @@ func emitTaskEvent(taskID, status, executionID, sessionID, projectPath, taskName
 		ProjectPath: projectPath,
 	}
 	// For completed/failed/cancelled tasks, include session title (task name) and response preview
+	var responsePreviewRaw string
 	if status == "completed" || status == "cancelled" || status == "failed" {
 		if taskName != "" {
 			data.SessionTitle = taskName
 		}
 		if sessionID != "" {
-			raw := getSessionResponsePreviewRaw(sessionID)
-			data.ResponsePreview = truncatePreview(raw)
-			if raw != "" {
-				data.ResponsePreviewPlain = truncatePreview(summarize.StripMarkdown(raw))
+			responsePreviewRaw = getSessionResponsePreviewRaw(sessionID)
+			data.ResponsePreview = truncatePreview(responsePreviewRaw)
+			if responsePreviewRaw != "" {
+				data.ResponsePreviewPlain = truncatePreview(summarize.StripMarkdown(responsePreviewRaw))
 			}
 		}
 	}
@@ -556,9 +557,10 @@ func emitTaskEvent(taskID, status, executionID, sessionID, projectPath, taskName
 	mgr.BroadcastEvent(msg)
 
 	// DingTalk push notification for task events.
+	// Pass raw (untruncated) preview — DingTalk package applies its own limit.
 	// If push succeeds, remove from pending_events to avoid duplicate
 	// Android notification when the app comes back online.
-	if dingtalk.IsStarted() && dingtalk.PushTaskEvent(taskID, status, data.SessionTitle, data.ResponsePreview, data.ProjectPath) {
+	if dingtalk.IsStarted() && dingtalk.PushTaskEvent(taskID, status, data.SessionTitle, responsePreviewRaw, data.ProjectPath) {
 		_ = DeletePendingEvent(msg.ID)
 	}
 }

--- a/internal/service/scheduler.go
+++ b/internal/service/scheduler.go
@@ -708,6 +708,8 @@ func (s *Scheduler) executeTask(task *model.ScheduledTask, projectPath string, t
 		slog.Error("failed to create backend for task", slog.String("err", err.Error()))
 		cancel() // Release context resources
 		_ = UpdateExecutionStatus(sessionID, "failed")
+		SetSessionRunning(sessionID, false, true)
+		ws.EmitToSession(sessionID, ai.StreamEvent{Type: "error", Error: "task execution failed"})
 		emitTaskEvent(fmt.Sprintf("%d", task.ID), "failed", fmt.Sprintf("%d", executionID), sessionID, projectPath, task.Name)
 		return
 	}
@@ -734,6 +736,8 @@ func (s *Scheduler) executeTask(task *model.ScheduledTask, projectPath string, t
 	if err != nil {
 		slog.Error("failed to execute stream for task", slog.String("err", err.Error()))
 		_ = UpdateExecutionStatus(sessionID, "failed")
+		SetSessionRunning(sessionID, false, true)
+		ws.EmitToSession(sessionID, ai.StreamEvent{Type: "error", Error: "task execution failed"})
 		emitTaskEvent(fmt.Sprintf("%d", task.ID), "failed", fmt.Sprintf("%d", executionID), sessionID, projectPath, task.Name)
 		return
 	}
@@ -741,20 +745,21 @@ func (s *Scheduler) executeTask(task *model.ScheduledTask, projectPath string, t
 	// Create streaming placeholder message in DB (so SessionExecutor.Finalize
 	// can update it via FinalizeStreamingMessage, just like interactive sessions).
 	emptyContent, _ := json.Marshal(map[string]any{"blocks": []any{}})
-	_, _ = AddChatMessage(projectPath, backendName, sessionID, "assistant", string(emptyContent), nil, true, "")
+	streamingMsgID, _ := AddChatMessage(projectPath, backendName, sessionID, "assistant", string(emptyContent), nil, true, "")
 
 	// Delegate event loop to SessionExecutor (scheduled mode — no ask-question
 	// conversion, no cancel-reason tracking)
 	executor := NewSessionExecutor(ctx, RunConfig{
-		Mode:        ModeScheduled,
-		ProjectPath: projectPath,
-		BackendName: backendName,
-		SessionID:   sessionID,
-		AgentID:     task.AgentID,
-		ChatRequest: chatReq,
-		TaskID:      task.ID,
-		ExecutionID: executionID,
-		TriggerType: triggerType,
+		Mode:               ModeScheduled,
+		ProjectPath:        projectPath,
+		BackendName:        backendName,
+		SessionID:          sessionID,
+		AgentID:            task.AgentID,
+		ChatRequest:        chatReq,
+		TaskID:             task.ID,
+		ExecutionID:        executionID,
+		TriggerType:        triggerType,
+		StreamingMessageID: streamingMsgID,
 	})
 	runResult := executor.RunWithChannel(eventCh)
 
@@ -766,6 +771,8 @@ func (s *Scheduler) executeTask(task *model.ScheduledTask, projectPath string, t
 			slog.String("session_id", sessionID),
 		)
 		_ = UpdateExecutionStatus(sessionID, "cancelled")
+		SetSessionRunning(sessionID, false, true)
+		ws.EmitToSession(sessionID, ai.StreamEvent{Type: "cancelled"})
 		emitTaskEvent(fmt.Sprintf("%d", task.ID), "cancelled", fmt.Sprintf("%d", executionID), sessionID, projectPath, task.Name)
 		// Only update stats, not status — don't overwrite user-initiated pauses (ISS-013)
 		UpdateTaskStats(task)
@@ -797,6 +804,13 @@ func (s *Scheduler) executeTask(task *model.ScheduledTask, projectPath string, t
 
 	// Mark execution as completed
 	_ = UpdateExecutionStatus(sessionID, "completed")
+
+	// Send terminal "done" event to WS chat_stream subscribers so that
+	// useTaskExecStream (live preview) stops streaming. Without this,
+	// the frontend stays in streaming state indefinitely.
+	SetSessionRunning(sessionID, false, true) // skip event — we emit directly
+	ws.EmitToSession(sessionID, ai.StreamEvent{Type: "done"})
+
 	emitTaskEvent(fmt.Sprintf("%d", task.ID), "completed", fmt.Sprintf("%d", executionID), sessionID, projectPath, task.Name)
 
 	// Update task execution stats

--- a/internal/service/scheduler.go
+++ b/internal/service/scheduler.go
@@ -791,6 +791,8 @@ func (s *Scheduler) executeTask(task *model.ScheduledTask, projectPath string, t
 			slog.String("session_id", sessionID),
 		)
 		_ = UpdateExecutionStatus(sessionID, "failed")
+		SetSessionRunning(sessionID, false, true)
+		ws.EmitToSession(sessionID, ai.StreamEvent{Type: "error", Error: "task execution ended unexpectedly"})
 		emitTaskEvent(fmt.Sprintf("%d", task.ID), "failed", fmt.Sprintf("%d", executionID), sessionID, projectPath, task.Name)
 		// Only update stats, not status — don't overwrite user-initiated pauses (ISS-013)
 		UpdateTaskStats(task)

--- a/internal/service/session_runtime.go
+++ b/internal/service/session_runtime.go
@@ -48,16 +48,17 @@ func EmitSessionEvent(sessionID, status string, hasNewMessages bool, toolName ..
 	}
 
 	// On completion, include session title for push notification
+	var responsePreviewRaw string
 	if status == "completed" || status == "cancelled" {
 		if title, err := GetSessionTitle(sessionID); err == nil && title != "" {
 			data.SessionTitle = title
 		}
 		// Include response preview for DingTalk (Markdown) and Android/browser (plain text)
 		if status == "completed" {
-			raw := getSessionResponsePreviewRaw(sessionID)
-			data.ResponsePreview = truncatePreview(raw)
-			if raw != "" {
-				data.ResponsePreviewPlain = truncatePreview(summarize.StripMarkdown(raw))
+			responsePreviewRaw = getSessionResponsePreviewRaw(sessionID)
+			data.ResponsePreview = truncatePreview(responsePreviewRaw)
+			if responsePreviewRaw != "" {
+				data.ResponsePreviewPlain = truncatePreview(summarize.StripMarkdown(responsePreviewRaw))
 			}
 		}
 	}
@@ -84,9 +85,10 @@ func EmitSessionEvent(sessionID, status string, hasNewMessages bool, toolName ..
 	mgr.BroadcastEvent(msg)
 
 	// DingTalk push notification for session events.
+	// Pass raw (untruncated) preview — DingTalk package applies its own limit.
 	// If push succeeds, remove from pending_events to avoid duplicate
 	// Android notification when the app comes back online.
-	if dingtalk.IsStarted() && dingtalk.PushSessionEvent(sessionID, status, data.SessionTitle, data.ResponsePreview, data.ProjectPath, data.ToolName) {
+	if dingtalk.IsStarted() && dingtalk.PushSessionEvent(sessionID, status, data.SessionTitle, responsePreviewRaw, data.ProjectPath, data.ToolName) {
 		_ = DeletePendingEvent(msg.ID)
 	}
 }

--- a/internal/service/tool_calls.go
+++ b/internal/service/tool_calls.go
@@ -66,3 +66,31 @@ func GetToolCall(toolID string, messageID int64) (*ToolCallRecord, error) {
 	r.Done = doneInt != 0
 	return &r, nil
 }
+
+// GetToolCallBySession retrieves a tool call record by tool_id and session_id.
+// This is a fallback for task executions where the session has multiple assistant
+// messages (from AutoResumeBackend resume splits) and the tool call may be stored
+// under a different message_id than the one the frontend knows about.
+// Returns nil if not found.
+func GetToolCallBySession(toolID, sessionID string) (*ToolCallRecord, error) {
+	var r ToolCallRecord
+	var doneInt int
+	var inputStr string
+	err := dbRead.QueryRowContext(context.Background(), `
+		SELECT id, message_id, session_id, tool_id, name, input, output, status, done, summary, created_at
+		FROM chat_tool_calls WHERE tool_id = ? AND session_id = ?
+		ORDER BY created_at DESC LIMIT 1
+	`, toolID, sessionID).Scan(
+		&r.ID, &r.MessageID, &r.SessionID, &r.ToolID, &r.Name,
+		&inputStr, &r.Output, &r.Status, &doneInt, &r.Summary, &r.CreatedAt,
+	)
+	if err == sql.ErrNoRows {
+		return nil, nil
+	}
+	if err != nil {
+		return nil, fmt.Errorf("GetToolCallBySession: %w", err)
+	}
+	r.Input = json.RawMessage(inputStr)
+	r.Done = doneInt != 0
+	return &r, nil
+}

--- a/internal/service/tool_calls_test.go
+++ b/internal/service/tool_calls_test.go
@@ -123,6 +123,42 @@ func TestUpsertAndGetToolCall(t *testing.T) {
 			t.Error("expected nil for wrong message_id")
 		}
 	})
+
+	t.Run("GetToolCallBySession finds record by session_id", func(t *testing.T) {
+		record, err := GetToolCallBySession("toolu_01", sessionID)
+		if err != nil {
+			t.Fatalf("GetToolCallBySession: %v", err)
+		}
+		if record == nil {
+			t.Fatal("GetToolCallBySession returned nil")
+		}
+		if record.ToolID != "toolu_01" {
+			t.Errorf("ToolID = %q, want %q", record.ToolID, "toolu_01")
+		}
+		if record.SessionID != sessionID {
+			t.Errorf("SessionID = %q, want %q", record.SessionID, sessionID)
+		}
+	})
+
+	t.Run("GetToolCallBySession returns nil for non-existent session", func(t *testing.T) {
+		record, err := GetToolCallBySession("toolu_01", "nonexistent-session")
+		if err != nil {
+			t.Fatalf("GetToolCallBySession: %v", err)
+		}
+		if record != nil {
+			t.Error("expected nil for non-existent session")
+		}
+	})
+
+	t.Run("GetToolCallBySession returns nil for non-existent tool_id", func(t *testing.T) {
+		record, err := GetToolCallBySession("toolu_99", sessionID)
+		if err != nil {
+			t.Fatalf("GetToolCallBySession: %v", err)
+		}
+		if record != nil {
+			t.Error("expected nil for non-existent tool_id")
+		}
+	})
 }
 
 // initTestDB creates a test database in the given directory

--- a/web/src/components/__tests__/format.test.ts
+++ b/web/src/components/__tests__/format.test.ts
@@ -226,8 +226,8 @@ describe('stripMarkdownPreview', () => {
   it('truncates long text with ellipsis', () => {
     const longText = 'a'.repeat(200)
     const result = stripMarkdownPreview(longText, 100)
-    expect(result.length).toBe(103) // 100 + '...'
-    expect(result.endsWith('...')).toBe(true)
+    expect(result.length).toBe(101) // 100 + '…'
+    expect(result.endsWith('…')).toBe(true)
   })
 
   it('preserves short text without truncation', () => {
@@ -244,8 +244,8 @@ describe('stripMarkdownPreview', () => {
   })
 
   it('respects custom maxLen', () => {
-    // 'Hello world' is 11 chars, maxLen=7 -> 'Hello w' + '...' = 'Hello w...'
-    expect(stripMarkdownPreview('Hello world', 7)).toBe('Hello w...')
+    // 'Hello world' is 11 chars, maxLen=7 -> 'Hello w' + '…' = 'Hello w…'
+    expect(stripMarkdownPreview('Hello world', 7)).toBe('Hello w…')
   })
 })
 

--- a/web/src/components/chat/ChatPanelContent.vue
+++ b/web/src/components/chat/ChatPanelContent.vue
@@ -128,7 +128,7 @@
 
   <!-- Tool Detail Overlay -->
   <ToolDetailDrawer
-    :show="toolDetailDrawer.effectiveOpen.value"
+    :show="toolDetailIsOpen.value"
     :toolName="toolDetailOverlay.name"
     :toolSubagentType="toolDetailOverlay.subagentType"
     :toolSummary="toolDetailOverlay.summary"
@@ -137,7 +137,7 @@
     :toolStatus="toolDetailOverlay.status"
     :toolDone="toolDetailOverlay.done"
     :displayNameOverride="toolDetailOverlay.displayNameOverride"
-    @close="toolDetailDrawer.close()"
+    @close="closeToolDetailOverlay()"
     @file-open="handleFileOpenInOverlay"
     @send-message="handleToolSendMessage"
     @click="handleOverlayRetryClick"
@@ -257,8 +257,7 @@ function findToolBlock({ msgId, blockIdx }) {
 }
 
 const {
-  show: toolDetailShow,
-  drawer: toolDetailDrawer,
+  isOpen: toolDetailIsOpen,
   toolDetailData,
   toolDetailOverlay,
   activeToolOverlay,
@@ -266,6 +265,7 @@ const {
   handleOverlayRetryClick,
   fetchToolCallDetail,
   handleFileOpenInOverlay,
+  closeOverlay: closeToolDetailOverlay,
 } = useToolDetailDrawer({
   chatRender: render,
   onFileOpen: async (path, lineStart, lineEnd) => {
@@ -519,7 +519,7 @@ watch(
     return { output: block.output, done: block.done, status: block.status, input: block.input, name: block.name, summary: block.summary, display_name: block.display_name }
   },
   (data) => {
-    if (data === null || !toolDetailShow.value) return
+    if (data === null || !toolDetailIsOpen.value) return
     const { formatToolInput } = render
     const hasInput = data.input && Object.keys(data.input).length > 0
     toolDetailData.value.outputHtml = data.output ? formatToolOutput(data.output, data.name) : toolDetailData.value.outputHtml
@@ -531,7 +531,7 @@ watch(
 )
 
 // Clean up overlay state when overlay closes
-watch(() => toolDetailShow.value, (show) => {
+watch(() => toolDetailIsOpen.value, (show) => {
   if (!show) {
     activeToolOverlay.value = null
     // Clear tool update debounce timers

--- a/web/src/components/chat/ContentBlocks.vue
+++ b/web/src/components/chat/ContentBlocks.vue
@@ -274,7 +274,9 @@ onMounted(() => {
 })
 async function fetchToolCallInputForAutoExpand(block, msgId) {
   try {
-    const resp = await fetch(`/api/ai/chat/tool-call?tool_id=${encodeURIComponent(block.id)}&message_id=${encodeURIComponent(msgId)}`)
+    let url = `/api/ai/chat/tool-call?tool_id=${encodeURIComponent(block.id)}&message_id=${encodeURIComponent(msgId)}`
+    if (props.sessionId) url += `&session_id=${encodeURIComponent(props.sessionId)}`
+    const resp = await fetch(url)
     if (!resp.ok) return
     const data = await resp.json()
     if (data.input) {

--- a/web/src/components/settings/SettingsPage.vue
+++ b/web/src/components/settings/SettingsPage.vue
@@ -10,7 +10,7 @@
       <template v-else>
         <Settings :size="20" class="settings-page__header-icon" />
         <span class="settings-page__title">{{ t('nav.settings') }}</span>
-        <span v-if="serverVersion" class="settings-page__version">v{{ serverVersion }}</span>
+        <span v-if="serverVersion" class="settings-page__version">{{ serverVersion }}</span>
       </template>
     </header>
     <div class="settings-page__body">

--- a/web/src/components/settings/__tests__/SettingsPage.test.ts
+++ b/web/src/components/settings/__tests__/SettingsPage.test.ts
@@ -196,7 +196,7 @@ describe('SettingsPage', () => {
     expect(wrapper.find('.settings-page__header').exists()).toBe(true)
     expect(wrapper.find('.settings-page__header-icon').exists()).toBe(true)
     expect(wrapper.find('.settings-page__version').exists()).toBe(true)
-    expect(wrapper.find('.settings-page__version').text()).toBe('v1.2.3')
+    expect(wrapper.find('.settings-page__version').text()).toBe('1.2.3')
     expect(wrapper.find('.settings-page__back').exists()).toBe(false)
   })
 
@@ -212,7 +212,7 @@ describe('SettingsPage', () => {
 
   it('hides version badge when serverConfig has no version', () => {
     const wrapper = mountPage()
-    expect(wrapper.find('.settings-page__version').text()).toBe('v1.2.3')
+    expect(wrapper.find('.settings-page__version').text()).toBe('1.2.3')
   })
 
   // ─── Category routing (all via SettingsCategory now) ──

--- a/web/src/components/task/TaskExecDetail.vue
+++ b/web/src/components/task/TaskExecDetail.vue
@@ -39,7 +39,7 @@
 
     <!-- Tool Detail Overlay -->
     <ToolDetailDrawer
-      :show="drawer.isOpen.value"
+      :show="toolDetailIsOpen.value"
       :toolName="toolDetailOverlay.name"
       :toolSubagentType="toolDetailOverlay.subagentType"
       :toolSummary="toolDetailOverlay.summary"
@@ -291,7 +291,7 @@ function findLiveToolBlock({ msgId, blockIdx }) {
 }
 
 const {
-  drawer,
+  isOpen: toolDetailIsOpen,
   toolDetailOverlay,
   toolDetailData,
   activeToolOverlay,
@@ -319,7 +319,7 @@ watch(
     return { output: block.output, done: block.done, status: block.status, input: block.input, name: block.name, summary: block.summary, display_name: block.display_name }
   },
   (data) => {
-    if (data === null || !drawer.isOpen.value) return
+    if (data === null || !toolDetailIsOpen.value) return
     const { formatToolInput } = chatRender
     const hasInput = data.input && Object.keys(data.input).length > 0
     toolDetailData.value.outputHtml = data.output ? formatToolOutput(data.output, data.name) : toolDetailData.value.outputHtml
@@ -331,7 +331,7 @@ watch(
 )
 
 // Clean up overlay state when drawer closes
-watch(() => drawer.isOpen.value, (open) => {
+watch(() => toolDetailIsOpen.value, (open) => {
   if (!open) {
     activeToolOverlay.value = null
   }
@@ -342,7 +342,7 @@ watch(() => drawer.isOpen.value, (open) => {
 // to fail. When refreshExecDetail updates selectedExecData with a valid messageId,
 // retry the fetch if the overlay is still open and content is empty.
 watch(() => props.execDetail?.messageId, (newMsgId) => {
-  if (!newMsgId || !drawer.isOpen.value) return
+  if (!newMsgId || !toolDetailIsOpen.value) return
   const ids = toolDetailData.value._fetchIds
   if (!ids) return
   // Only retry if input is still empty (fetch hasn't succeeded yet)

--- a/web/src/components/task/TaskExecDetail.vue
+++ b/web/src/components/task/TaskExecDetail.vue
@@ -7,11 +7,6 @@
 
     <!-- Scrollable message content -->
     <div class="exec-detail-content" ref="contentRef" @click="handleContentClick" @mousedown="onTableMouseDown" @touchstart="onTableTouchStart" @contextmenu="handleExecContextMenu" v-long-press="handleExecLongPress">
-      <!-- Live preview indicator -->
-      <div v-if="execStream.isStreaming.value" class="exec-live-bar">
-        <span class="exec-live-dot"></span>
-        <span class="exec-live-text">{{ t('task.exec.livePreview') }}</span>
-      </div>
       <!-- Summary / Original tab bar (hidden during live streaming) -->
       <SummaryToggle v-if="hasSummary && !execStream.isStreaming.value" mode="tab" :showing-summary="activeTab === 'summary'" i18n-prefix="task.exec" @toggle="setTab(activeTab === 'summary' ? 'original' : 'summary')" />
       <ChatMessageItem
@@ -44,7 +39,7 @@
 
     <!-- Tool Detail Overlay -->
     <ToolDetailDrawer
-      :show="toolDetailOverlay.show"
+      :show="drawer.isOpen.value"
       :toolName="toolDetailOverlay.name"
       :toolSubagentType="toolDetailOverlay.subagentType"
       :toolSummary="toolDetailOverlay.summary"
@@ -53,7 +48,7 @@
       :toolStatus="toolDetailOverlay.status"
       :toolDone="toolDetailOverlay.done"
       :displayNameOverride="toolDetailOverlay.displayNameOverride"
-      @close="toolDetailShow = false"
+      @close="closeOverlay"
       @file-open="handleFileOpenInOverlay"
       @click="handleOverlayRetryClick"
     />
@@ -103,6 +98,7 @@ import { useSessionIdentity } from '@/composables/useSessionIdentity.ts'
 import { useToolDetailDrawer } from '@/composables/useToolDetailDrawer.ts'
 import { useTableRowExpand } from '@/composables/useTableRowExpand.ts'
 import { useTaskExecStream } from '@/composables/useTaskExecStream.ts'
+import { formatToolOutput } from '@/utils/renderToolDetail.ts'
 import TableRowModal from '@/components/common/TableRowModal.vue'
 
 const props = defineProps({
@@ -203,12 +199,14 @@ function setTab(tab) {
 const msgData = computed(() => {
   if (!props.execDetail?.content && props.execDetail?.status !== 'cancelled') return null
   const { blocks } = chatRender.parseAssistantContent(props.execDetail.content || '{}')
+  // Use messageId (DB chat_history ID) for tool detail fetch; fallback only if unavailable
+  const msgId = props.execDetail.messageId || props.execDetail.id || 'exec'
   if (!blocks || blocks.length === 0) {
     // For running executions with empty content, return a streaming placeholder
     // so the live indicator bar is shown instead of "no text output"
     if (isRunning.value) {
       return {
-        id: props.execDetail.messageId || props.execDetail.id || 'exec',
+        id: msgId,
         role: 'assistant',
         content: '',
         blocks: [],
@@ -221,7 +219,7 @@ const msgData = computed(() => {
     return null
   }
   return {
-    id: props.execDetail.messageId || props.execDetail.id || 'exec',
+    id: msgId,
     role: 'assistant',
     content: props.execDetail.content,
     blocks,
@@ -258,6 +256,15 @@ const activeMsgData = computed(() => {
     // Show streaming message if it has blocks (real-time content)
     if (sm.blocks && sm.blocks.length > 0) return sm
   }
+  // After streaming stops, the streamingMsg still has blocks (streaming flag removed).
+  // Use it as fallback while waiting for refreshExecDetail to complete,
+  // so the user sees content immediately instead of a blank/loading state.
+  if (!execStream.isStreaming.value && execStream.streamingMsg.value) {
+    const sm = execStream.streamingMsg.value
+    if (sm.blocks && sm.blocks.length > 0) {
+      return { ...sm, streaming: false }
+    }
+  }
   // When not streaming, use the DB content (refreshed by refreshExecDetail)
   // we always show whatever partial content is available rather than "connecting..."
   if (activeTab.value === 'summary' && summaryMsgData.value) return summaryMsgData.value
@@ -272,18 +279,84 @@ function toggleTool(key) {
 }
 
 // ── Tool Detail Overlay ──
+
+/** Look up the tool_use block from the streaming message by msgId + blockIdx */
+function findLiveToolBlock({ msgId, blockIdx }) {
+  const sm = execStream.streamingMsg.value
+  if (!sm || !sm.blocks) return null
+  // For streaming messages, msgId comes from the streaming message id
+  if (String(sm.id) !== String(msgId)) return null
+  const block = sm.blocks[blockIdx]
+  return (block && block.type === 'tool_use') ? block : null
+}
+
 const {
-  show: toolDetailShow,
+  drawer,
   toolDetailOverlay,
+  toolDetailData,
+  activeToolOverlay,
   handleShowToolDetail,
   handleOverlayRetryClick,
   handleFileOpenInOverlay,
+  fetchToolCallDetail,
+  closeOverlay,
 } = useToolDetailDrawer({
   chatRender,
   onFileOpen: (path, lineStart, lineEnd) => {
     openFilePath(path, lineStart, lineEnd)
     emit('open-file', { path, lineStart, lineEnd })
   },
+  findLiveBlock: findLiveToolBlock,
+  sessionId: () => props.execDetail?.sessionId,
+})
+
+// Reactively update tool overlay content as block output/done/status changes during streaming
+watch(
+  () => {
+    if (!activeToolOverlay.value) return null
+    const block = findLiveToolBlock(activeToolOverlay.value)
+    if (!block) return null
+    return { output: block.output, done: block.done, status: block.status, input: block.input, name: block.name, summary: block.summary, display_name: block.display_name }
+  },
+  (data) => {
+    if (data === null || !drawer.isOpen.value) return
+    const { formatToolInput } = chatRender
+    const hasInput = data.input && Object.keys(data.input).length > 0
+    toolDetailData.value.outputHtml = data.output ? formatToolOutput(data.output, data.name) : toolDetailData.value.outputHtml
+    toolDetailData.value.status = data.status || ''
+    toolDetailData.value.done = !!data.done
+    toolDetailData.value.inputHtml = hasInput ? formatToolInput(data.input, data.name, { done: data.done, status: data.status, output: data.output }) : toolDetailData.value.inputHtml
+    toolDetailData.value.summary = data.summary || toolDetailData.value.summary
+  }
+)
+
+// Clean up overlay state when drawer closes
+watch(() => drawer.isOpen.value, (open) => {
+  if (!open) {
+    activeToolOverlay.value = null
+  }
+})
+
+// Re-fetch tool detail when messageId becomes available (e.g. after refreshExecDetail completes)
+// The initial execData from the history list may lack messageId, causing fetchToolCallDetail
+// to fail. When refreshExecDetail updates selectedExecData with a valid messageId,
+// retry the fetch if the overlay is still open and content is empty.
+watch(() => props.execDetail?.messageId, (newMsgId) => {
+  if (!newMsgId || !drawer.isOpen.value) return
+  const ids = toolDetailData.value._fetchIds
+  if (!ids) return
+  // Only retry if input is still empty (fetch hasn't succeeded yet)
+  if (toolDetailData.value.inputHtml && !toolDetailData.value.inputHtml.includes('tool-call-loading') && !toolDetailData.value.inputHtml.includes('tool-call-empty')) return
+  // Retry with the correct messageId
+  const block = findLiveToolBlock(activeToolOverlay.value || { msgId: '', blockIdx: 0 })
+  fetchToolCallDetail(ids.toolId, newMsgId, block || { name: toolDetailData.value.name })
+})
+
+// Clear stale streamingMsg once DB content is available (DB is authoritative)
+watch(() => props.execDetail?.content, (newContent) => {
+  if (newContent && !execStream.isStreaming.value && execStream.streamingMsg.value) {
+    execStream.streamingMsg.value = null
+  }
 })
 
 // ── Metadata Modal ──
@@ -370,13 +443,18 @@ function handleContentClick(event) {
 // ── Reset state when exec detail changes ──
 watch(() => props.execDetail, (newVal, oldVal) => {
   expandedTools.value = {}
-  toolDetailShow.value = false
+  closeOverlay()
   metadataModal.value.show = false
   activeTab.value = hasSummary.value ? 'summary' : 'original'
 
   // Start live preview when execution becomes running
   if (newVal?.status === 'running' && newVal?.sessionId) {
     execStream.startPreview()
+    // Fetch latest content from API for running executions — the initial data
+    // from the history list may lack content, and WS only delivers new events
+    if (!newVal.content) {
+      refreshExecDetail()
+    }
   }
   // Stop preview when execution is no longer running
   if (oldVal?.status === 'running' && newVal?.status !== 'running') {
@@ -510,35 +588,5 @@ onUnmounted(() => {
   color: var(--text-muted, #999);
   font-style: italic;
   font-size: 14px;
-}
-
-/* Live preview indicator */
-.exec-live-bar {
-  display: flex;
-  align-items: center;
-  gap: 6px;
-  padding: 4px 8px;
-  margin-bottom: 8px;
-  background: color-mix(in srgb, var(--accent-color, #0066cc) 8%, transparent);
-  border-radius: 8px;
-  font-size: 12px;
-  color: var(--accent-color, #0066cc);
-}
-
-.exec-live-dot {
-  width: 6px;
-  height: 6px;
-  border-radius: 50%;
-  background: var(--accent-color, #0066cc);
-  animation: exec-live-pulse 1.5s ease-in-out infinite;
-}
-
-.exec-live-text {
-  font-weight: 500;
-}
-
-@keyframes exec-live-pulse {
-  0%, 100% { opacity: 1; }
-  50% { opacity: 0.3; }
 }
 </style>

--- a/web/src/composables/__tests__/useToolDetailDrawer.test.ts
+++ b/web/src/composables/__tests__/useToolDetailDrawer.test.ts
@@ -167,7 +167,7 @@ describe('useToolDetailDrawer', () => {
       d.handleFileOpenInOverlay('/path/to/file.ts')
 
       expect(mockOnFileOpen).toHaveBeenCalledWith('/path/to/file.ts', undefined, undefined)
-      expect(d.drawer.isOpen.value).toBe(false)
+      expect(d.isOpen.value).toBe(false)
     })
 
     it('calls onFileOpen with object payload including line range', () => {
@@ -177,17 +177,17 @@ describe('useToolDetailDrawer', () => {
       d.handleFileOpenInOverlay({ path: '/src/app.ts', lineStart: 10, lineEnd: 25 })
 
       expect(mockOnFileOpen).toHaveBeenCalledWith('/src/app.ts', 10, 25)
-      expect(d.drawer.isOpen.value).toBe(false)
+      expect(d.isOpen.value).toBe(false)
     })
 
     it('closes drawer even when onFileOpen is not provided', () => {
       const d = useToolDetailDrawer({ chatRender: createMockChatRender() })
-      d.drawer.open()
-      expect(d.drawer.isOpen.value).toBe(true)
+      d.handleShowToolDetail({ name: 'Bash', input: { cmd: 'ls' }, output: 'ok', msgId: 1, blockIdx: 0 })
+      expect(d.isOpen.value).toBe(true)
 
       d.handleFileOpenInOverlay('/some/file.ts')
 
-      expect(d.drawer.isOpen.value).toBe(false)
+      expect(d.isOpen.value).toBe(false)
     })
   })
 

--- a/web/src/composables/useTaskTab.ts
+++ b/web/src/composables/useTaskTab.ts
@@ -297,10 +297,9 @@ export function useTaskTab() {
         selectedExecId.value = execId
         selectedExecData.value = (execData as TaskExecData | null) ?? null
         execDetailOpen.value = true
-        // If no execData provided, auto-fetch from API (e.g. from push notification deep link)
-        if (!execData) {
-            refreshExecDetail()
-        }
+        // Always refresh from API — the list data may lack content/sessionId,
+        // and running executions need the latest content for live preview
+        refreshExecDetail()
     }
 
     /** Open the latest execution detail for a task directly (skip history list) */
@@ -344,6 +343,8 @@ export function useTaskTab() {
                 const merged = { ...selectedExecData.value, ...safeFields }
                 // Only overwrite content if API returned a non-null value
                 if (exec.content != null) merged.content = exec.content
+                // Only set messageId if it's a valid DB ID (Go int64 zero-value = 0 is invalid)
+                if (!exec.messageId) delete merged.messageId
                 selectedExecData.value = merged
             }
         } catch {

--- a/web/src/composables/useToolDetailDrawer.ts
+++ b/web/src/composables/useToolDetailDrawer.ts
@@ -30,13 +30,18 @@ interface ToolDetailDrawerOptions {
   chatRender: ChatRenderRef
   onFileOpen?: (path: string, lineStart?: number, lineEnd?: number) => void
   findLiveBlock?: (ids: { msgId: string | number; blockIdx: number }) => ToolBlock | null
+  /** Optional session ID for tool-call API fallback. When the session has multiple
+   *  assistant messages (e.g. AutoResumeBackend resume splits), the tool call may
+   *  be stored under a different message_id. Passing session_id enables the backend
+   *  to fall back to tool_id+session_id lookup. */
+  sessionId?: () => string | undefined
 }
 
 /**
  * Shared tool detail drawer logic for ChatPanelContent and TaskExecDetail.
  */
 export function useToolDetailDrawer(options: ToolDetailDrawerOptions) {
-  const { chatRender, onFileOpen, findLiveBlock } = options
+  const { chatRender, onFileOpen, findLiveBlock, sessionId } = options
   const { t } = useI18n()
 
   const drawer = useTabDrawer('chat')
@@ -127,7 +132,10 @@ export function useToolDetailDrawer(options: ToolDetailDrawerOptions) {
       toolDetailData.value.inputHtml = '<div class="tool-call-loading"></div>'
     }
     try {
-      const resp = await fetch(`/api/ai/chat/tool-call?tool_id=${encodeURIComponent(toolId)}&message_id=${encodeURIComponent(msgId)}`)
+      let url = `/api/ai/chat/tool-call?tool_id=${encodeURIComponent(toolId)}&message_id=${encodeURIComponent(msgId)}`
+      const sid = sessionId?.()
+      if (sid) url += `&session_id=${encodeURIComponent(sid)}`
+      const resp = await fetch(url)
       if (!resp.ok) {
         // Retry on 404 (tool call may not yet be persisted during streaming)
         if (shouldRetryToolFetch(resp.status, _retryCount, show.value)) {

--- a/web/src/composables/useToolDetailDrawer.ts
+++ b/web/src/composables/useToolDetailDrawer.ts
@@ -1,6 +1,5 @@
 import { ref, computed } from 'vue'
 import { useI18n } from 'vue-i18n'
-import { useTabDrawer } from '@/composables/useTabDrawer'
 import { shouldRetryToolFetch, resolveEffectiveMsgId, type ContentBlock } from '@/utils/chatStreamUtils.ts'
 import { formatToolOutput } from '@/utils/renderToolDetail.ts'
 import { appLog } from '@/utils/appLog'
@@ -39,14 +38,15 @@ interface ToolDetailDrawerOptions {
 
 /**
  * Shared tool detail drawer logic for ChatPanelContent and TaskExecDetail.
+ * Uses a simple ref instead of useTabDrawer because ToolDetailDrawer is a
+ * BottomSheet (teleported to <body>) — it's a user-initiated overlay that
+ * should persist across tab switches, not auto-hide when switching away.
  */
 export function useToolDetailDrawer(options: ToolDetailDrawerOptions) {
   const { chatRender, onFileOpen, findLiveBlock, sessionId } = options
   const { t } = useI18n()
 
-  const drawer = useTabDrawer('chat')
-  /** Read-only access — use drawer.open()/close() to mutate */
-  const show = drawer.isOpen
+  const isOpen = ref(false)
   const toolDetailData = ref({
     name: '' as string,
     subagentType: '' as string,
@@ -86,7 +86,7 @@ export function useToolDetailDrawer(options: ToolDetailDrawerOptions) {
     const hasInput = block.input && Object.keys(block.input).length > 0
     const hasOutput = !!block.output
 
-    drawer.open()
+    isOpen.value = true
     toolDetailData.value = {
       name: block.name || '',
       subagentType: block.display_name || (block.input as Record<string, unknown>)?.subagent_type as string || '',
@@ -138,10 +138,10 @@ export function useToolDetailDrawer(options: ToolDetailDrawerOptions) {
       const resp = await fetch(url)
       if (!resp.ok) {
         // Retry on 404 (tool call may not yet be persisted during streaming)
-        if (shouldRetryToolFetch(resp.status, _retryCount, show.value)) {
+        if (shouldRetryToolFetch(resp.status, _retryCount, isOpen.value)) {
           _fetchInFlight = false
           setTimeout(() => {
-            if (!show.value) return
+            if (!isOpen.value) return
             let liveBlock: ToolBlock | null = null
             if (findLiveBlock && activeToolOverlay.value) {
               liveBlock = findLiveBlock(activeToolOverlay.value)
@@ -182,7 +182,7 @@ export function useToolDetailDrawer(options: ToolDetailDrawerOptions) {
       // If user clicked retry while fetch was in flight, re-fetch immediately
       if (_retryRequested) {
         _retryRequested = false
-        if (show.value && toolDetailData.value._fetchIds) {
+        if (isOpen.value && toolDetailData.value._fetchIds) {
           const { toolId, msgId } = toolDetailData.value._fetchIds
           let block: ToolBlock | null = null
           if (findLiveBlock && activeToolOverlay.value) {
@@ -196,24 +196,22 @@ export function useToolDetailDrawer(options: ToolDetailDrawerOptions) {
 
   function handleFileOpenInOverlay(payload: string | { path: string; lineStart?: number; lineEnd?: number }) {
     const { path, lineStart, lineEnd } = typeof payload === 'string' ? { path: payload } : payload
-    drawer.close()
+    isOpen.value = false
     if (onFileOpen) {
       onFileOpen(path, lineStart, lineEnd)
     }
   }
 
   function closeOverlay() {
-    drawer.close()
+    isOpen.value = false
     _fetchInFlight = false
     _retryRequested = false
   }
 
-  // Backward-compatible computed that merges show + data (consumers that read .show/.name etc still work)
-  const toolDetailOverlay = computed(() => ({ show: show.value, ...toolDetailData.value }))
+  const toolDetailOverlay = computed(() => ({ show: isOpen.value, ...toolDetailData.value }))
 
   return {
-    show,
-    drawer,
+    isOpen,
     toolDetailData,
     toolDetailOverlay,
     activeToolOverlay,

--- a/web/src/i18n/locales/en.ts
+++ b/web/src/i18n/locales/en.ts
@@ -527,7 +527,6 @@ export default {
       title: 'Execution log',
       noExecutions: 'No executions',
       noTextOutput: 'No text output',
-      livePreview: 'Live Preview',
       startingPreview: 'Connecting preview…',
       manual: 'Manual',
       auto: 'Auto',

--- a/web/src/i18n/locales/zh.ts
+++ b/web/src/i18n/locales/zh.ts
@@ -528,7 +528,6 @@ export default {
       title: '执行记录',
       noExecutions: '暂无执行记录',
       noTextOutput: '无文本输出',
-      livePreview: '实时预览',
       startingPreview: '正在连接预览…',
       manual: '手动',
       auto: '自动',


### PR DESCRIPTION
## Summary

Clean PR with only the intended fixes (6 commits, 4 files changed in the last commit):

### Changes
- **Go lint fix**: Replace string literal `"error"` with `eventTypeError` constant in `drain.go` (goconst)
- **SettingsPage test fix**: Update version assertions to expect version without `v` prefix (matches commit d848455)
- **Format test fix**: Update `stripMarkdownPreview` truncation assertions to expect Unicode ellipsis `…` instead of ASCII `...`
- **Coverage**: Add `GetToolCallBySession` unit tests for `tool_calls.go`

### Previous commits in this PR
- fix: task execution detail tool call 404 and streaming state never ending
- fix: add missing WS terminal event in scheduler crash path
- refactor: remove useTabDrawer from useToolDetailDrawer
- fix: update useToolDetailDrawer test to use new direct isOpen API
- fix: remove duplicate 'v' prefix in settings header version display
