### PR TITLE
fix: remove unused splitLines function (staticcheck U1000)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,6 +23,7 @@ nohup.out
 
 # Node/Vite
 node_modules/
+node_modules
 vite.log
 public/
 internal/frontend/dist/

--- a/docs/superpowers/plans/2026-08-03-bigscreen-splitview.md
+++ b/docs/superpowers/plans/2026-08-03-bigscreen-splitview.md
@@ -1,0 +1,1330 @@
+# 大屏双栏布局（Big-Screen SplitView）实现计划
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** 为 ≥1024px 宽屏自动启用双栏布局：右侧恒显聊天，左侧纵向 Dock 切换其余标签，可拖动分隔线调宽（比例持久化），抽屉大屏限宽。
+
+**Architecture:** 复用现有单实例面板组件。`.content-area` 内包 `col-left`/`col-right` 两容器 + 通用 `SplitView`（受控双栏容器）；新增 `useBigScreenLayout` 模块单例管理 `isBigScreen`（matchMedia 1024）/`leftTab`/`splitRatio` 与持久化；`useTabDrawer` 扩展为双激活标签（chat + leftTab）；App.vue 内新增纵向 Dock 块（方案一，复用 scoped 样式）；BottomSheet 全局限宽 + `wide` 逃逸。
+
+**Tech Stack:** Vue 3 `<script setup lang="ts">`, Vitest + @vue/test-utils (jsdom), 现有 `useTabDrawer`/`TabPanel`/CSS 变量体系。
+
+---
+
+## 前置约定
+
+- 所有命令在仓库根目录 `/home/xulongzhe/projects/clawbench` 执行。
+- 单测命令：`./scripts/vitest-run.sh <相对路径>`（vitest 有僵尸 worker 防护，勿裸跑 `npx vitest`）。
+- 类型检查：`npm run typecheck`；Lint：`npm run lint`。
+- 测试环境 jsdom **无 `window.matchMedia`**，任何 matchMedia 使用都必须有守卫（本计划已内置）。
+- 每步提交前先 `git status` 确认只暂存本任务文件。
+
+---
+
+### Task 1: 比例工具函数 `utils/splitRatio.ts`
+
+**Files:**
+- Create: `web/src/utils/splitRatio.ts`
+- Test: `web/src/utils/__tests__/splitRatio.test.ts`
+
+- [ ] **Step 1: Write the failing test**
+
+创建 `web/src/utils/__tests__/splitRatio.test.ts`：
+
+```ts
+import { describe, expect, it } from 'vitest'
+import { normalizeRatio, clampRatio, MIN_PANEL_WIDTH, DEFAULT_RATIO } from '@/utils/splitRatio'
+
+describe('normalizeRatio', () => {
+  it('returns DEFAULT_RATIO for non-finite / non-number input', () => {
+    expect(normalizeRatio(Number.NaN)).toBe(DEFAULT_RATIO)
+    expect(normalizeRatio('0.3' as unknown as number)).toBe(DEFAULT_RATIO)
+    expect(normalizeRatio(undefined as unknown as number)).toBe(DEFAULT_RATIO)
+    expect(normalizeRatio(Number.POSITIVE_INFINITY)).toBe(DEFAULT_RATIO)
+  })
+
+  it('clamps to [0, 1]', () => {
+    expect(normalizeRatio(-0.5)).toBe(0)
+    expect(normalizeRatio(1.7)).toBe(1)
+    expect(normalizeRatio(0.4)).toBe(0.4)
+  })
+})
+
+describe('clampRatio', () => {
+  it('respects symmetric min widths on both sides', () => {
+    // container 1000, minLeft=320, minRight=320 → left ∈ [320, 680]
+    expect(clampRatio(0.1, 1000)).toBeCloseTo(0.32)   // 320/1000
+    expect(clampRatio(0.9, 1000)).toBeCloseTo(0.68)   // 680/1000
+    expect(clampRatio(0.5, 1000)).toBeCloseTo(0.5)
+  })
+
+  it('returns DEFAULT_RATIO when container is too small for two panels', () => {
+    expect(clampRatio(0.3, MIN_PANEL_WIDTH * 2 - 10)).toBe(DEFAULT_RATIO)
+  })
+
+  it('returns DEFAULT_RATIO for invalid container width', () => {
+    expect(clampRatio(0.3, 0)).toBe(DEFAULT_RATIO)
+    expect(clampRatio(0.3, Number.NaN)).toBe(DEFAULT_RATIO)
+  })
+})
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `./scripts/vitest-run.sh web/src/utils/__tests__/splitRatio.test.ts`
+Expected: FAIL — `@/utils/splitRatio` module not found.
+
+- [ ] **Step 3: Write implementation**
+
+创建 `web/src/utils/splitRatio.ts`：
+
+```ts
+export const MIN_PANEL_WIDTH = 320
+export const DEFAULT_RATIO = 0.5
+
+/** Coerce an unknown value into a ratio in [0, 1]; defaults to DEFAULT_RATIO. */
+export function normalizeRatio(raw: unknown): number {
+  if (typeof raw !== 'number' || !Number.isFinite(raw)) return DEFAULT_RATIO
+  return Math.min(1, Math.max(0, raw))
+}
+
+/**
+ * Clamp a ratio so the left panel stays within [minLeft, containerWidth - minRight].
+ * Returns DEFAULT_RATIO when the container can't hold two min-width panels.
+ */
+export function clampRatio(
+  ratio: number,
+  containerWidth: number,
+  minLeft = MIN_PANEL_WIDTH,
+  minRight = MIN_PANEL_WIDTH,
+): number {
+  if (!Number.isFinite(containerWidth) || containerWidth <= 0) return DEFAULT_RATIO
+  if (containerWidth <= minLeft + minRight) return DEFAULT_RATIO
+  const maxLeft = containerWidth - minRight
+  const leftPx = Math.min(maxLeft, Math.max(minLeft, ratio * containerWidth))
+  return leftPx / containerWidth
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `./scripts/vitest-run.sh web/src/utils/__tests__/splitRatio.test.ts`
+Expected: PASS (6 tests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add web/src/utils/splitRatio.ts web/src/utils/__tests__/splitRatio.test.ts
+git commit -m "feat: split-ratio clamp/normalize helpers"
+```
+
+---
+
+### Task 2: `useBigScreenLayout` composable
+
+**Files:**
+- Create: `web/src/composables/useBigScreenLayout.ts`
+- Test: `web/src/composables/__tests__/useBigScreenLayout.test.ts`
+
+- [ ] **Step 1: Write the failing test**
+
+创建 `web/src/composables/__tests__/useBigScreenLayout.test.ts`：
+
+```ts
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import {
+  useBigScreenLayout,
+  getBigScreenState,
+  switchLeftTab,
+  setSplitRatio,
+  resetBigScreenState,
+  registerBigScreenCallbacks,
+  _setBigScreenForTest,
+  _resetForTest,
+  BIG_SCREEN_DOCK_TABS,
+  LEFT_TAB_KEY,
+  SPLIT_RATIO_KEY,
+} from '@/composables/useBigScreenLayout'
+
+beforeEach(() => {
+  _resetForTest()
+  resetBigScreenState()
+  localStorage.clear()
+})
+
+describe('useBigScreenLayout', () => {
+  it('matchMedia absent → isBigScreen stays false and does not throw', () => {
+    const { isBigScreen } = useBigScreenLayout()
+    expect(isBigScreen.value).toBe(false)
+  })
+
+  it('leftTab defaults to browse and is clamped to allowed tabs', () => {
+    const { leftTab } = useBigScreenLayout()
+    expect(leftTab.value).toBe('browse')
+    expect(BIG_SCREEN_DOCK_TABS).toContain(leftTab.value)
+  })
+
+  it('switchLeftTab ignores invalid tabs and persists valid ones', () => {
+    switchLeftTab('terminal')
+    expect(localStorage.getItem(LEFT_TAB_KEY)).toBe('terminal')
+    switchLeftTab('not-a-tab' as never)
+    expect(localStorage.getItem(LEFT_TAB_KEY)).toBe('terminal')
+  })
+
+  it('switchLeftTab runs registered side-effects and activeTab setter, but only on change', () => {
+    const sideEffects = vi.fn()
+    const setActiveTab = vi.fn()
+    registerBigScreenCallbacks({ sideEffects, setActiveTab })
+
+    switchLeftTab('tasks')
+    expect(setActiveTab).toHaveBeenCalledWith('tasks')
+    expect(sideEffects).toHaveBeenCalledWith('tasks')
+
+    switchLeftTab('tasks') // same tab → early return
+    expect(sideEffects).toHaveBeenCalledTimes(1)
+  })
+
+  it('setSplitRatio normalizes and persists', () => {
+    setSplitRatio(1.9)
+    expect(Number(localStorage.getItem(SPLIT_RATIO_KEY))).toBe(1)
+    setSplitRatio(0.35)
+    expect(Number(localStorage.getItem(SPLIT_RATIO_KEY))).toBeCloseTo(0.35)
+  })
+
+  it('restores persisted leftTab on init', () => {
+    localStorage.setItem(LEFT_TAB_KEY, 'settings')
+    _resetForTest()
+    const { leftTab } = useBigScreenLayout()
+    expect(leftTab.value).toBe('settings')
+  })
+
+  it('big-screen mode makes getBigScreenState expose chat + leftTab as active tabs', () => {
+    const { isBigScreen, leftTab } = getBigScreenState()
+    _setBigScreenForTest(true)
+    switchLeftTab('terminal')
+    expect(isBigScreen.value).toBe(true)
+    expect(leftTab.value).toBe('terminal')
+  })
+})
+
+describe('useBigScreenLayout matchMedia wiring', () => {
+  it('reflects matchMedia matches and change events', async () => {
+    vi.resetModules()
+    const listeners: Array<(e: { matches: boolean }) => void> = []
+    const mql = {
+      matches: true,
+      addEventListener: (_t: string, cb: (e: { matches: boolean }) => void) => { listeners.push(cb) },
+      removeEventListener: vi.fn(),
+    }
+    vi.stubGlobal('matchMedia', vi.fn(() => mql))
+    const mod = await import('@/composables/useBigScreenLayout')
+    expect(mod.getBigScreenState().isBigScreen.value).toBe(true)
+    mql.matches = false
+    listeners.forEach((cb) => cb({ matches: false }))
+    expect(mod.getBigScreenState().isBigScreen.value).toBe(false)
+    vi.unstubAllGlobals()
+  })
+})
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `./scripts/vitest-run.sh web/src/composables/__tests__/useBigScreenLayout.test.ts`
+Expected: FAIL — module not found.
+
+- [ ] **Step 3: Write implementation**
+
+创建 `web/src/composables/useBigScreenLayout.ts`：
+
+```ts
+import { ref } from 'vue'
+import { normalizeRatio } from '@/utils/splitRatio'
+
+export const BIG_SCREEN_MIN_WIDTH = 1024
+export const LEFT_TAB_KEY = 'clawbench-bigscreen-left-tab'
+export const SPLIT_RATIO_KEY = 'clawbench-bigscreen-split-ratio'
+export const BIG_SCREEN_DOCK_TABS = ['browse', 'history', 'proxy', 'terminal', 'tasks', 'settings']
+
+const isBigScreen = ref(false)
+const leftTab = ref<string>('browse')
+const splitRatio = ref(0.5)
+let initialized = false
+let sideEffects: ((tab: string) => void) | null = null
+let setActiveTab: ((tab: string) => void) | null = null
+
+function readPersistedLeftTab(): string {
+  try {
+    const v = localStorage.getItem(LEFT_TAB_KEY)
+    if (v && BIG_SCREEN_DOCK_TABS.includes(v)) return v
+  } catch {
+    // localStorage may throw in restricted environments — fall through to default
+  }
+  return 'browse'
+}
+
+function initBigScreen() {
+  if (initialized) return
+  initialized = true
+  leftTab.value = readPersistedLeftTab()
+  try {
+    const raw = Number(localStorage.getItem(SPLIT_RATIO_KEY))
+    if (Number.isFinite(raw)) splitRatio.value = normalizeRatio(raw)
+  } catch {
+    // ignore
+  }
+  if (typeof window !== 'undefined' && typeof window.matchMedia === 'function') {
+    const mql = window.matchMedia(`(min-width: ${BIG_SCREEN_MIN_WIDTH}px)`)
+    isBigScreen.value = mql.matches
+    const onChange = (e: MediaQueryListEvent) => { isBigScreen.value = e.matches }
+    if (typeof mql.addEventListener === 'function') {
+      mql.addEventListener('change', onChange)
+    } else if (typeof (mql as { addListener?: unknown }).addListener === 'function') {
+      ;(mql as { addListener: (cb: (e: MediaQueryListEvent) => void) => void }).addListener(onChange)
+    }
+  }
+}
+
+/** Returns the shared big-screen state refs (initializes once). */
+export function useBigScreenLayout() {
+  initBigScreen()
+  return { isBigScreen, leftTab, splitRatio }
+}
+
+/** Ref access for useTabDrawer (avoids importing refs eagerly at module scope). */
+export function getBigScreenState() {
+  initBigScreen()
+  return { isBigScreen, leftTab }
+}
+
+export function registerBigScreenCallbacks(opts: { sideEffects?: (tab: string) => void; setActiveTab?: (tab: string) => void }) {
+  sideEffects = opts.sideEffects ?? null
+  setActiveTab = opts.setActiveTab ?? null
+}
+
+/** Switch the big-screen left column tab. Writes activeTab + side-effects via callbacks; does NOT call onTabSwitch. */
+export function switchLeftTab(tab: string) {
+  if (!BIG_SCREEN_DOCK_TABS.includes(tab)) return
+  if (leftTab.value === tab) return
+  leftTab.value = tab
+  try {
+    localStorage.setItem(LEFT_TAB_KEY, tab)
+  } catch {
+    // ignore
+  }
+  setActiveTab?.(tab)
+  sideEffects?.(tab)
+}
+
+/** Normalize + persist the split ratio (persistence owned here, not in SplitView). */
+export function setSplitRatio(ratio: number) {
+  splitRatio.value = normalizeRatio(ratio)
+  try {
+    localStorage.setItem(SPLIT_RATIO_KEY, String(splitRatio.value))
+  } catch {
+    // ignore
+  }
+}
+
+export function resetBigScreenState() {
+  leftTab.value = 'browse'
+  splitRatio.value = 0.5
+  isBigScreen.value = false
+  sideEffects = null
+  setActiveTab = null
+}
+
+/** Test hooks — do not use in production code. */
+export function _setBigScreenForTest(val: boolean) {
+  isBigScreen.value = val
+}
+export function _resetForTest() {
+  initialized = false
+  resetBigScreenState()
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `./scripts/vitest-run.sh web/src/composables/__tests__/useBigScreenLayout.test.ts`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add web/src/composables/useBigScreenLayout.ts web/src/composables/__tests__/useBigScreenLayout.test.ts
+git commit -m "feat: big-screen layout composable (matchMedia, leftTab, split ratio persistence)"
+```
+
+---
+
+### Task 3: 通用 `SplitView` 双栏容器
+
+**Files:**
+- Create: `web/src/components/common/SplitView.vue`
+- Test: `web/src/components/common/__tests__/SplitView.test.ts`
+
+- [ ] **Step 1: Write the failing test**
+
+创建 `web/src/components/common/__tests__/SplitView.test.ts`：
+
+```ts
+import { describe, expect, it, vi, afterEach } from 'vitest'
+import { mount, VueWrapper } from '@vue/test-utils'
+import { nextTick } from 'vue'
+import SplitView from '@/components/common/SplitView.vue'
+
+vi.mock('@/utils/appLog', () => ({
+  appLog: { d: vi.fn(), i: vi.fn(), w: vi.fn(), e: vi.fn() },
+}))
+
+function mountSplit(props = {}) {
+  return mount(SplitView, {
+    props,
+    slots: {
+      left: '<div class="pane-left">L</div>',
+      right: '<div class="pane-right">R</div>',
+    },
+    attachTo: document.body,
+  })
+}
+
+let wrapper: VueWrapper | null = null
+afterEach(() => {
+  wrapper?.unmount()
+  wrapper = null
+  vi.restoreAllMocks()
+})
+
+describe('SplitView', () => {
+  it('enabled=false: no divider, panes render inline', () => {
+    wrapper = mountSplit({ enabled: false })
+    expect(wrapper.find('.split-view__divider').exists()).toBe(false)
+    expect(wrapper.find('.pane-left').text()).toBe('L')
+    expect(wrapper.find('.pane-right').text()).toBe('R')
+  })
+
+  it('enabled=true: renders divider and left width follows ratio', async () => {
+    wrapper = mountSplit({ enabled: true, ratio: 0.4 })
+    expect(wrapper.find('.split-view__divider').exists()).toBe(true)
+    const left = wrapper.find('.split-view__left')
+    await nextTick()
+    expect(left.attributes('style')).toContain('width: 40%')
+  })
+
+  it('emits update:ratio on divider drag, clamped to min widths', async () => {
+    wrapper = mountSplit({ enabled: true, ratio: 0.5 })
+    const divider = wrapper.find('.split-view__divider').element as HTMLElement
+    vi.spyOn(divider, 'setPointerCapture').mockImplementation(() => {})
+    vi.spyOn(divider, 'releasePointerCapture').mockImplementation(() => {})
+
+    Object.defineProperty(wrapper.find('.split-view').element, 'getBoundingClientRect', {
+      configurable: true,
+      value: () => ({ left: 0, width: 1000, top: 0, bottom: 0, height: 600, right: 1000, x: 0, y: 0, toJSON() {} }),
+    })
+
+    divider.dispatchEvent(new PointerEvent('pointerdown', { pointerId: 1, button: 0, bubbles: true, clientX: 300 }))
+    window.dispatchEvent(new PointerEvent('pointermove', { pointerId: 1, bubbles: true, clientX: 100 }))
+    window.dispatchEvent(new PointerEvent('pointerup', { pointerId: 1, bubbles: true }))
+
+    const emitted = wrapper.emitted('update:ratio') as Array<Array<number>>
+    expect(emitted).toBeTruthy()
+    // 100px / 1000 = 0.1, clamped up to 320/1000 = 0.32
+    expect(emitted[emitted.length - 1][0]).toBeCloseTo(0.32)
+  })
+})
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `./scripts/vitest-run.sh web/src/components/common/__tests__/SplitView.test.ts`
+Expected: FAIL — module not found.
+
+- [ ] **Step 3: Write implementation**
+
+创建 `web/src/components/common/SplitView.vue`：
+
+```vue
+<template>
+  <div ref="rootRef" class="split-view" :class="{ 'split-view--active': enabled }">
+    <div class="split-view__left" :style="leftStyle">
+      <slot name="left" />
+    </div>
+    <div
+      v-if="enabled"
+      ref="dividerRef"
+      class="split-view__divider"
+      role="separator"
+      aria-orientation="vertical"
+      :aria-valuenow="Math.round(internalRatio * 100)"
+      :aria-valuemin="Math.round(minLeftRatio)"
+      :aria-valuemax="Math.round(maxLeftRatio)"
+      :title="title"
+      @pointerdown="onDividerPointerDown"
+    >
+      <div class="split-view__gutter-line" />
+    </div>
+    <div class="split-view__right">
+      <slot name="right" />
+    </div>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { computed, onBeforeUnmount, onMounted, ref, watch } from 'vue'
+import { clampRatio, normalizeRatio, MIN_PANEL_WIDTH } from '@/utils/splitRatio'
+
+const props = withDefaults(defineProps<{
+  enabled: boolean
+  ratio?: number
+  minLeft?: number
+  minRight?: number
+  gutterSize?: number
+  title?: string
+}>(), {
+  ratio: 0.5,
+  minLeft: MIN_PANEL_WIDTH,
+  minRight: MIN_PANEL_WIDTH,
+  gutterSize: 6,
+  title: '拖动调整面板宽度',
+})
+
+const emit = defineEmits<{ (e: 'update:ratio', ratio: number): void }>()
+
+const rootRef = ref<HTMLDivElement | null>(null)
+const dividerRef = ref<HTMLDivElement | null>(null)
+const internalRatio = ref(normalizeRatio(props.ratio))
+const containerWidth = ref(0)
+let dragActive = false
+let observer: ResizeObserver | null = null
+
+watch(() => props.ratio, (r) => {
+  internalRatio.value = normalizeRatio(r)
+})
+
+const leftStyle = computed(() => {
+  if (!props.enabled) return {}
+  return { width: `${internalRatio.value * 100}%` }
+})
+
+const minLeftRatio = computed(() => (containerWidth.value > 0 ? props.minLeft / containerWidth.value : 0))
+const maxLeftRatio = computed(() => (containerWidth.value > 0 ? 1 - props.minRight / containerWidth.value : 1))
+
+function measureContainer() {
+  if (rootRef.value) containerWidth.value = rootRef.value.getBoundingClientRect().width
+}
+
+function onMove(e: PointerEvent) {
+  const rect = rootRef.value?.getBoundingClientRect()
+  if (!rect || rect.width <= 0) return
+  const raw = (e.clientX - rect.left) / rect.width
+  const ratio = clampRatio(raw, rect.width, props.minLeft, props.minRight)
+  internalRatio.value = ratio
+  emit('update:ratio', ratio)
+}
+
+function onDividerPointerDown(e: PointerEvent) {
+  if (e.button !== 0) return
+  dragActive = true
+  dividerRef.value?.setPointerCapture?.(e.pointerId)
+  document.body.classList.add('split-view-dragging')
+  onMove(e)
+}
+
+function onPointerMove(e: PointerEvent) {
+  if (dragActive) onMove(e)
+}
+
+function onPointerUp(e: PointerEvent) {
+  if (!dragActive) return
+  dragActive = false
+  dividerRef.value?.releasePointerCapture?.(e.pointerId)
+  document.body.classList.remove('split-view-dragging')
+}
+
+onMounted(() => {
+  measureContainer()
+  if (typeof ResizeObserver !== 'undefined') {
+    observer = new ResizeObserver(measureContainer)
+    if (rootRef.value) observer.observe(rootRef.value)
+  }
+  window.addEventListener('pointermove', onPointerMove)
+  window.addEventListener('pointerup', onPointerUp)
+  window.addEventListener('pointercancel', onPointerUp)
+})
+
+onBeforeUnmount(() => {
+  observer?.disconnect()
+  window.removeEventListener('pointermove', onPointerMove)
+  window.removeEventListener('pointerup', onPointerUp)
+  window.removeEventListener('pointercancel', onPointerUp)
+  document.body.classList.remove('split-view-dragging')
+})
+</script>
+
+<style scoped>
+.split-view {
+  position: relative;
+  height: 100%;
+  width: 100%;
+}
+.split-view--active {
+  display: flex;
+  flex-direction: row;
+  align-items: stretch;
+}
+.split-view__left,
+.split-view__right {
+  position: absolute;
+  inset: 0;
+}
+.split-view--active .split-view__left,
+.split-view--active .split-view__right {
+  position: relative;
+  inset: auto;
+  height: 100%;
+}
+.split-view--active .split-view__left {
+  flex: 0 0 auto;
+  min-width: 320px;
+  max-width: calc(100% - 320px - 6px);
+}
+.split-view--active .split-view__right {
+  flex: 1 1 auto;
+  min-width: 320px;
+}
+/* Divider: narrow by default, wider hit-area + highlight on hover/touch */
+.split-view__divider {
+  position: relative;
+  flex: 0 0 auto;
+  width: 6px;
+  cursor: col-resize;
+  touch-action: none;
+  -webkit-tap-highlight-color: transparent;
+}
+.split-view__divider::before {
+  content: '';
+  position: absolute;
+  top: 0;
+  bottom: 0;
+  left: -4px;
+  right: -4px;
+}
+.split-view__divider:hover,
+.split-view__divider:active {
+  background: color-mix(in srgb, var(--accent-color, #0066cc) 12%, transparent);
+}
+.split-view__gutter-line {
+  position: absolute;
+  left: 50%;
+  top: 0;
+  bottom: 0;
+  width: 2px;
+  transform: translateX(-50%);
+  background: var(--border-color, rgba(0, 0, 0, 0.12));
+  transition: background 0.15s ease;
+}
+.split-view__divider:hover .split-view__gutter-line,
+.split-view__divider:active .split-view__gutter-line {
+  background: var(--accent-color, #0066cc);
+}
+body.split-view-dragging {
+  user-select: none;
+  cursor: col-resize;
+}
+</style>
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `./scripts/vitest-run.sh web/src/components/common/__tests__/SplitView.test.ts`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add web/src/components/common/SplitView.vue web/src/components/common/__tests__/SplitView.test.ts
+git commit -m "feat: generic SplitView two-pane container with draggable divider"
+```
+
+---
+
+### Task 4: `useTabDrawer` 大屏双激活标签
+
+**Files:**
+- Modify: `web/src/composables/useTabDrawer.ts`
+- Test: `web/src/composables/__tests__/useTabDrawer.test.ts`
+
+- [ ] **Step 1: Write the failing test (append to existing file)**
+
+在 `web/src/composables/__tests__/useTabDrawer.test.ts` 末尾追加：
+
+```ts
+import { _setBigScreenForTest, resetBigScreenState as resetBigScreen, switchLeftTab } from '@/composables/useBigScreenLayout'
+
+describe('useTabDrawer big-screen awareness', () => {
+  beforeEach(() => {
+    resetBigScreen()
+    _setBigScreenForTest(false)
+  })
+
+  it('big-screen: chat and leftTab drawers both open simultaneously', () => {
+    _setBigScreenForTest(true)
+    switchLeftTab('browse')
+    const chatDrawer = useTabDrawer('chat')
+    const browseDrawer = useTabDrawer('browse')
+
+    chatDrawer.open()
+    browseDrawer.open()
+    expect(chatDrawer.effectiveOpen.value).toBe(true)
+    expect(browseDrawer.effectiveOpen.value).toBe(true)
+
+    switchLeftTab('terminal')
+    expect(browseDrawer.effectiveOpen.value).toBe(false)
+    expect(chatDrawer.effectiveOpen.value).toBe(true)
+  })
+
+  it('big-screen: autoRestore:false closes when leftTab switches away', () => {
+    _setBigScreenForTest(true)
+    switchLeftTab('browse')
+    const drawer = useTabDrawer('browse', { autoRestore: false })
+    drawer.open()
+    expect(drawer.effectiveOpen.value).toBe(true)
+
+    switchLeftTab('tasks')
+    expect(drawer.effectiveOpen.value).toBe(false)
+  })
+})
+```
+
+> 注：该文件顶部已有 `beforeEach(() => { resetTabDrawerState() })`。新增的 `beforeEach` 块同样在每个用例前运行，二者不冲突（`resetTabDrawerState` 复位抽屉注册，`resetBigScreen` 复位大屏状态）。若同一 `describe` 内出现同名 `beforeEach` 冲突，请把新增 import 放到文件顶部，并把新增 beforeEach 合并进顶部现有 beforeEach。
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `./scripts/vitest-run.sh web/src/composables/__tests__/useTabDrawer.test.ts`
+Expected: FAIL — 新用例失败（effectiveOpen 不认大屏）。
+
+- [ ] **Step 3: Write implementation**
+
+修改 `web/src/composables/useTabDrawer.ts`：
+
+(a) 顶部新增 import（放在现有 import 之后）：
+
+```ts
+import { getBigScreenState } from './useBigScreenLayout'
+
+const { isBigScreen, leftTab } = getBigScreenState()
+```
+
+(b) 替换 `effectiveOpen` 计算（原 L112）：
+
+```ts
+  const effectiveOpen = computed(() => {
+    const tabActive =
+      currentTab.value === tabId ||
+      (isBigScreen.value && (tabId === 'chat' || tabId === leftTab.value))
+    return tabActive && openRef.value
+  })
+```
+
+(c) 替换 autoRestore:false watcher（原 L115-121）：
+
+```ts
+  // For autoRestore: false, close the drawer when its tab is no longer active
+  // (narrow: currentTab changed; big-screen: leftTab changed away)
+  if (!autoRestore) {
+    const closeIfInactive = () => {
+      if (!openRef.value) return
+      const active =
+        currentTab.value === tabId ||
+        (isBigScreen.value && (tabId === 'chat' || tabId === leftTab.value))
+      if (!active) openRef.value = false
+    }
+    watch(() => [currentTab.value, isBigScreen.value, leftTab.value], closeIfInactive)
+  }
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `./scripts/vitest-run.sh web/src/composables/__tests__/useTabDrawer.test.ts`
+Expected: PASS（原有用例 + 新增 2 个）。
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add web/src/composables/useTabDrawer.ts web/src/composables/__tests__/useTabDrawer.test.ts
+git commit -m "feat: tab drawers treat chat + big-screen leftTab as simultaneously active"
+```
+
+---
+
+### Task 5: BottomSheet 大屏限宽 + `wide` prop
+
+**Files:**
+- Modify: `web/src/components/common/BottomSheet.vue`
+- Test: `web/src/components/common/__tests__/BottomSheet.test.ts`
+
+- [ ] **Step 1: Write the failing test (append to existing file)**
+
+在 `web/src/components/common/__tests__/BottomSheet.test.ts` 末尾追加（该文件已提供 `mountSheet` helper 与 `$` 查询）：
+
+```ts
+describe('BottomSheet wide prop', () => {
+  it('adds bs-wide class to the panel when wide=true', () => {
+    mountSheet({ wide: true })
+    expect($('.bs-panel')?.classList.contains('bs-wide')).toBe(true)
+  })
+
+  it('does not add bs-wide class by default', () => {
+    mountSheet({})
+    expect($('.bs-panel')?.classList.contains('bs-wide')).toBe(false)
+  })
+})
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `./scripts/vitest-run.sh web/src/components/common/__tests__/BottomSheet.test.ts`
+Expected: FAIL — `wide` prop 不存在。
+
+- [ ] **Step 3: Write implementation**
+
+修改 `web/src/components/common/BottomSheet.vue`：
+
+(a) 模板面板 class（L13）：
+
+```html
+      <div class="bs-panel" :class="{ 'bs-leaving': leaving, 'bs-instant': instant, 'bs-compact': compact, 'bs-auto': auto, 'bs-handle-only': handleOnly, 'bs-wide': wide }">
+```
+
+(b) props（L39-52 区域，`noHeader` 声明之后新增）：
+
+```ts
+  wide: Boolean, // 大屏模式放宽面板宽度（默认 560px → 820px）
+```
+
+(c) `<style>` 块末尾（keyframes 之后任意位置）追加：
+
+```css
+/* Big-screen (≥1024px): constrain bottom-sheet width and center it.
+   Keep narrow screens full-width. */
+@media (min-width: 1024px) {
+  .bs-panel {
+    max-width: 560px;
+    margin: 0 auto;
+  }
+  .bs-panel.bs-wide {
+    max-width: 820px;
+  }
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `./scripts/vitest-run.sh web/src/components/common/__tests__/BottomSheet.test.ts`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add web/src/components/common/BottomSheet.vue web/src/components/common/__tests__/BottomSheet.test.ts
+git commit -m "feat: constrain bottom-sheet width on big screens with wide escape hatch"
+```
+
+---
+
+### Task 6: 全局大屏样式 `big-screen.css` + 引入
+
+**Files:**
+- Create: `web/css/big-screen.css`
+- Modify: `web/index.html`
+
+- [ ] **Step 1: Create the stylesheet**
+
+创建 `web/css/big-screen.css`：
+
+```css
+/* ==========================================================================
+   Big-screen (≥1024px) two-column layout
+   Activated via .big-screen class on .main-content (bound to useBigScreenLayout.isBigScreen)
+   ========================================================================== */
+
+/* Switch the single-column flex to a horizontal dock + split layout */
+.main-content.big-screen {
+  flex-direction: row;
+}
+
+/* Let the split area shrink when the vertical dock is present */
+.main-content.big-screen .content-area {
+  min-width: 0;
+}
+```
+
+- [ ] **Step 2: Wire into index.html**
+
+在 `web/index.html` 的 stylesheet 链接区（`layout.css` 之后）新增：
+
+```html
+    <link rel="stylesheet" href="/css/big-screen.css">
+```
+
+- [ ] **Step 3: Verify it loads**
+
+Run: `npm run typecheck`
+Expected: PASS（纯 CSS/HTML，无类型影响；此步用于确认无语法破坏）。
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add web/css/big-screen.css web/index.html
+git commit -m "feat: big-screen layout global stylesheet"
+```
+
+---
+
+### Task 7: App.vue 布局重构（SplitView + col-left/col-right + 模式感知路由）
+
+**Files:**
+- Modify: `web/src/App.vue`（模板 L22-131 区、脚本区、样式区）
+
+此任务改动大，分 4 个子步骤，每步独立可验证。
+
+- [ ] **Step 7.1: 脚本区 import 与状态**
+
+在 `web/src/App.vue` 脚本顶部 import 区（L347-348 附近，`formatBadgeCount` import 之后）新增：
+
+```ts
+import SplitView from './components/common/SplitView.vue'
+import {
+  useBigScreenLayout,
+  switchLeftTab,
+  setSplitRatio,
+  registerBigScreenCallbacks,
+  BIG_SCREEN_DOCK_TABS,
+} from './composables/useBigScreenLayout'
+```
+
+在 `const activeTab = ref('chat')`（L453）之后新增：
+
+```ts
+// ── Big-screen layout state ──
+const { isBigScreen, leftTab, splitRatio } = useBigScreenLayout()
+
+const chatActive = computed(() => (isBigScreen.value ? 'chat' : activeTab.value))
+const leftPanelActive = computed(() => (isBigScreen.value ? leftTab.value : activeTab.value))
+const panelIsActive = (tabId: string) =>
+  isBigScreen.value ? leftTab.value === tabId : activeTab.value === tabId
+
+function onSplitRatioChange(ratio: number) {
+  setSplitRatio(ratio)
+}
+```
+
+- [ ] **Step 7.2: `switchTab` 模式感知 + 模式同步 watcher**
+
+替换 `function switchTab(tab)`（L474-497）为：
+
+```ts
+function switchTab(tab) {
+  if (isBigScreen.value) {
+    // Big-screen: chat is always visible; non-chat tabs route to the left column
+    if (tab === 'chat') return
+    switchLeftTab(tab)
+    return
+  }
+  if (activeTab.value === tab) return
+  activeTab.value = tab
+  // Auto-close all drawers not belonging to the new tab
+  onTabSwitch(tab)
+  if (tab === 'browse') {
+    store.loadFiles(store.state.currentDir)
+  }
+  if (tab === 'chat') {
+    loadSessionsOnce()
+  }
+  if (tab === 'tasks') {
+    store.state.taskUnreadCount = 0
+    loadTasks()
+  }
+  // Close overflow menu on any tab switch
+  overflowMenuOpen.value = false
+}
+```
+
+在 `switchTab` 定义之后新增模式同步 watcher 与回调注册（`loadTasks` 已在 L637 解构，故本段必须放在 L637 `useTaskTab()` 之后；建议放在 `handleInlineOverflowClick` 之后）：
+
+```ts
+// Big-screen mode transitions: keep useTabDrawer's currentTab coherent
+// (chat drawers work in wide mode; collapse returns to the last active tab).
+watch(isBigScreen, (val) => {
+  if (val) {
+    // Continuity-first (Q1A): adopt activeTab if non-chat, else keep persisted leftTab
+    const next = activeTab.value !== 'chat' ? activeTab.value : leftTab.value
+    if (leftTab.value !== next) switchLeftTab(next)
+    onTabSwitch('chat')
+    overflowMenuOpen.value = false
+  } else {
+    onTabSwitch(activeTab.value)
+  }
+}, { immediate: true })
+
+// Route leftTab side-effects (reuse narrow-mode behaviors) and sync activeTab (Q3B)
+registerBigScreenCallbacks({
+  setActiveTab: (tab) => { activeTab.value = tab },
+  sideEffects: (tab) => {
+    if (tab === 'browse') store.loadFiles(store.state.currentDir)
+    if (tab === 'tasks') { store.state.taskUnreadCount = 0; loadTasks() }
+  },
+})
+```
+
+> 若 `watch` / `computed` 尚未导入，在 script 顶部 Vue import 处补充（App.vue 已大量使用二者，通常已导入）。
+
+- [ ] **Step 7.3: 模板重构 content-area**
+
+替换 `web/src/App.vue` 模板 L22-131（`<main class="main-content"> ... </main>` 整个块）为：
+
+```html
+      <main class="main-content" :class="{ 'big-screen': isBigScreen }">
+        <!-- Big-screen vertical dock (non-chat tabs only) -->
+        <div v-show="isBigScreen" class="big-dock">
+          <div class="big-dock-center">
+            <div class="dock-active-indicator big-dock-active-indicator" :style="bigDockIndicatorStyle"></div>
+            <div v-for="tab in BIG_SCREEN_DOCK_TABS" :key="tab" class="dock-btn-wrap">
+              <button class="dock-btn" :class="bigDockBtnClass(tab)" @click.stop="switchLeftTab(tab)" :title="bigDockTabTitle(tab)">
+                <component :is="bigDockTabIcon(tab)" />
+              </button>
+              <span v-if="bigDockBadgeVisible(tab)" class="dock-badge dock-badge-count" :class="{ 'dock-badge-pop': bigDockBadgeAnim(tab) }" @animationend="bigDockBadgeAnimEnd(tab)">{{ formatBadgeCount(bigDockBadgeCount(tab)) }}</span>
+            </div>
+          </div>
+        </div>
+
+        <div class="content-area" id="contentArea">
+          <SplitView
+            :enabled="isBigScreen"
+            :ratio="splitRatio"
+            @update:ratio="onSplitRatioChange"
+          >
+            <template #left>
+              <div class="col-left" v-show="isBigScreen || activeTab !== 'chat'">
+                <!-- File Browse Tab (合一：目录浏览 + 文件覆盖预览) -->
+                <TabPanel tabId="browse" :activeTab="leftPanelActive" :noHeader="true">
+                  <div class="browse-panel">
+                    <FileManagerContent
+                      ref="fileManagerRef"
+                      :entries="dirEntries"
+                      :current-dir="currentDir"
+                      :current-file="currentFile"
+                      :show-hidden="showHidden"
+                      :sort-field="sortField"
+                      :sort-dir="sortDir"
+                      :dir-loading="store.state.dirLoading"
+                      :search-drawer="fileSearchDrawer"
+                      :recent-drawer="recentFilesDrawer"
+                      @navigate-dir="handleNavigateDir"
+                      @navigate-back="handleNavigateBack"
+                      @select-file="handleBrowseSelectFile"
+                      @toggle-sort="handleToggleSort"
+                      @toggle-hidden="toggleHidden"
+                      @rename="handleRename"
+                      @delete="handleDelete"
+                      @batch-delete="handleBatchDelete"
+                      @refresh="handleRefresh"
+                      @open-terminal="handleOpenTerminal"
+                    />
+                    <FileOverlay
+                      ref="fileOverlayRef"
+                      :overlay-open="fileNav.overlayOpen.value"
+                      :current-file="currentFile"
+                      :file-loading="store.state.fileLoading"
+                      :toc-open="tocDrawer.effectiveOpen.value"
+                      :search-open="searchDrawer.effectiveOpen.value"
+                      :markdown-view-mode="markdownViewMode"
+                      :file-history-open="fileHistoryDrawer.effectiveOpen.value"
+                      :toc-file="tocFile"
+                      :pdf-outline="pdfOutline"
+                      @delete="handleDelete($event)"
+                      @show-details="detailsDrawer.open()"
+                      @open-git-history="openFileHistory"
+                      @toggle-toc="tocDrawer.toggle()"
+                      @toggle-search="currentFile?.content && searchDrawer.toggle()"
+                      @toggle-view="markdownViewMode = markdownViewMode === 'rendered' ? 'raw' : 'rendered'"
+                      @refresh="handleRefresh"
+                      @jump="scrollToLine"
+                      @jump-page="handleJumpPdfPage"
+                      @close-git-history="fileHistoryDrawer.close()"
+                      @open-file="handleOverlayOpenFile"
+                      @overlay-close="handleOverlayClose"
+                      @open-recent-files="recentFilesDrawer.open()"
+                    />
+                  </div>
+                </TabPanel>
+
+                <!-- History Tab -->
+                <TabPanel tabId="history" :activeTab="leftPanelActive" :noHeader="true">
+                  <GitHistoryContent
+                    mode="project"
+                    :active="panelIsActive('history')"
+                    @open-file="handleSelectFile"
+                  />
+                </TabPanel>
+
+                <!-- Proxy Tab -->
+                <TabPanel tabId="proxy" :activeTab="leftPanelActive" :noHeader="true">
+                  <ProxyPanelContent />
+                </TabPanel>
+
+                <!-- Terminal Tab -->
+                <TabPanel tabId="terminal" :activeTab="leftPanelActive" :noHeader="true">
+                  <TerminalPanelContent
+                    :requested-cwd="terminalRequestedCwd"
+                    :active="panelIsActive('terminal')"
+                    :platform-unsupported="isPlatformUnsupported"
+                    @cwd-handled="terminalRequestedCwd = null"
+                  />
+                </TabPanel>
+
+                <!-- Tasks Tab -->
+                <TabPanel tabId="tasks" :activeTab="leftPanelActive" :noHeader="true">
+                  <TaskTab :active="panelIsActive('tasks')" @open-file="handleTaskOpenFile" />
+                </TabPanel>
+
+                <!-- Settings Tab -->
+                <TabPanel tabId="settings" :activeTab="leftPanelActive" :noHeader="true">
+                  <SettingsPage :active="panelIsActive('settings')" />
+                </TabPanel>
+              </div>
+            </template>
+
+            <template #right>
+              <div class="col-right" v-show="isBigScreen || activeTab === 'chat'">
+                <!-- Chat Tab -->
+                <TabPanel tabId="chat" :activeTab="chatActive">
+                  <template #header>
+                    <span class="bs-header-title"><AgentIcon v-if="sessionIdentity.currentAgentId.value" :backend="getAgentBackend(sessionIdentity.currentAgentId.value)" :name="getAgentName(sessionIdentity.currentAgentId.value)" :size="18" />{{ sessionIdentity.agentHeaderTitle.value }}</span>
+                    <div v-if="sessionIdentity.currentSessionTitle.value" class="bs-header-description">
+                      <HeaderMarquee :text="sessionIdentity.currentSessionTitle.value">{{ sessionIdentity.currentSessionTitle.value }}</HeaderMarquee>
+                    </div>
+                  </template>
+                  <ChatPanelContent
+                    :active="isBigScreen || activeTab === 'chat'"
+                    :current-file="currentFile"
+                    :current-dir="currentDir"
+                    @open="switchTab('chat')"
+                    @open-file="handleSelectFile"
+                    @task-card-click="onTaskCardClick"
+                    @open-acp-sessions="acpSessionDrawer.open()"
+                    @open-session-search="sessionSearchDrawer.open()"
+                  />
+                </TabPanel>
+              </div>
+            </template>
+          </SplitView>
+        </div>
+      </main>
+```
+
+> 注意：`FileOverlay` 的 `:markdown-view-mode` 等处绑定的 `markdownViewMode` 等变量需与现状一致；本计划中已按原模板保留全部绑定。替换时请以当前 L22-131 实际内容为准，仅做三类修改：(1) 外层包 `<SplitView>` 与 `col-left`/`col-right`；(2) `:activeTab` 由 `activeTab` 改为 `chatActive`/`leftPanelActive`；(3) 各面板 `:active` 改为 `panelIsActive(tabId)`；聊天面板 `:active` 改为 `isBigScreen || activeTab === 'chat'`。
+
+- [ ] **Step 7.4: 新增 col-left / col-right 定位样式**
+
+在 `web/src/App.vue` scoped 样式块（`<style scoped>` 内任意位置）新增：
+
+```css
+/* Big-screen split panes — positioned ancestors for the absolute TabPanels */
+.col-left,
+.col-right {
+    position: relative;
+    height: 100%;
+}
+```
+
+- [ ] **Step 7.4b: 底部 Dock 大屏隐藏**
+
+修改 `.bottom-dock-wrapper` 的 `v-show`（L196）：
+
+```html
+      <div v-if="isAuthenticated" v-show="!anyKeyboardActive && !isBigScreen" class="bottom-dock-wrapper">
+```
+
+- [ ] **Step 7.5: 编译验证**
+
+Run: `npm run typecheck`
+Expected: PASS。
+
+Run: `npm run lint`
+Expected: PASS（若报未使用变量等，修正后重跑）。
+
+- [ ] **Step 7.6: Commit**
+
+```bash
+git add web/src/App.vue
+git commit -m "feat: restructure content-area into big-screen SplitView with mode-aware tab routing"
+```
+
+---
+
+### Task 8: App.vue 纵向 Dock 逻辑与样式
+
+**Files:**
+- Modify: `web/src/App.vue`（脚本辅助函数 + scoped 样式）
+
+- [ ] **Step 1: 新增纵向 Dock 辅助函数**
+
+在 `web/src/App.vue` `handleInlineOverflowClick` 定义（L1232-1238）之后新增：
+
+```ts
+// ── Big-screen vertical dock helpers ──
+const bigScreenTabMeta = {
+  browse: { icon: FolderOpen, titleKey: 'nav.fileManager' },
+  history: { icon: GitBranch, titleKey: 'git.history.projectHistory' },
+  tasks: overflowTabMeta.tasks,
+  proxy: overflowTabMeta.proxy,
+  terminal: overflowTabMeta.terminal,
+  settings: overflowTabMeta.settings,
+}
+
+function bigDockTabIcon(tab) {
+  return bigScreenTabMeta[tab]?.icon ?? FolderOpen
+}
+function bigDockTabTitle(tab) {
+  return bigScreenTabMeta[tab] ? t(bigScreenTabMeta[tab].titleKey) : ''
+}
+function bigDockBtnClass(tab) {
+  return {
+    active: leftTab.value === tab,
+    'has-unread': tab === 'tasks' && store.state.taskUnreadCount > 0 && leftTab.value !== 'tasks',
+    'just-completed': tab === 'tasks' && store.state.taskJustCompleted && leftTab.value !== 'tasks',
+    'has-running': tab === 'tasks' && store.state.taskRunning && leftTab.value !== 'tasks',
+  }
+}
+function bigDockBadgeCount(tab) {
+  switch (tab) {
+    case 'history': return store.state.gitWorkingTreeChangeCount
+    case 'tasks': return store.state.taskUnreadCount
+    case 'terminal': return store.state.terminalSessionCount
+    case 'proxy': return store.state.portForwardActiveCount
+    default: return 0
+  }
+}
+function bigDockBadgeVisible(tab) {
+  return bigDockBadgeCount(tab) > 0 && leftTab.value !== tab
+}
+function bigDockBadgeAnim(tab) {
+  switch (tab) {
+    case 'history': return historyBadgeAnim.value
+    case 'tasks': return taskBadgeAnim.value
+    case 'terminal': return terminalBadgeAnim.value
+    case 'proxy': return proxyBadgeAnim.value
+    default: return false
+  }
+}
+function bigDockBadgeAnimEnd(tab) {
+  switch (tab) {
+    case 'history': historyBadgeAnim.value = false; break
+    case 'tasks': taskBadgeAnim.value = false; break
+    case 'terminal': terminalBadgeAnim.value = false; break
+    case 'proxy': proxyBadgeAnim.value = false; break
+  }
+}
+const bigDockActiveIndex = computed(() => {
+  const i = BIG_SCREEN_DOCK_TABS.indexOf(leftTab.value)
+  return i >= 0 ? i : 0
+})
+const bigDockIndicatorStyle = computed(() => ({
+  transform: `translate(-50%, ${bigDockActiveIndex.value * DOCK_STEP}px)`,
+}))
+```
+
+> 前置：`historyBadgeAnim`/`taskBadgeAnim`/`terminalBadgeAnim`/`proxyBadgeAnim` 四个 ref 已在 App.vue 现有脚本中定义（底部 Dock 使用）。若命名不同，以实际定义名为准同步替换。
+
+- [ ] **Step 2: 新增 scoped 样式**
+
+在 `web/src/App.vue` scoped 样式块（`<style scoped>` 内，`.bottom-dock-wrapper` 之前或之后均可）新增：
+
+```css
+/* Big-screen vertical dock (left edge) */
+.big-dock {
+    flex-shrink: 0;
+    width: 60px;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    background: var(--bg-primary);
+    border-right: 1px solid color-mix(in srgb, var(--border-color) 40%, transparent);
+    -webkit-tap-highlight-color: transparent;
+    user-select: none;
+}
+
+.big-dock-center {
+    position: relative;
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    gap: 12px;
+}
+
+/* Vertical variant of the water-drop indicator (base .dock-active-indicator is in App.vue scoped) */
+.big-dock-active-indicator {
+    left: 50%;
+    top: 0;
+}
+```
+
+- [ ] **Step 3: 编译验证**
+
+Run: `npm run typecheck`
+Expected: PASS。
+
+Run: `npm run lint`
+Expected: PASS。
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add web/src/App.vue
+git commit -m "feat: big-screen vertical dock with badges and active indicator"
+```
+
+---
+
+### Task 9: 全量验证
+
+**Files:** 无代码改动，仅验证。
+
+- [ ] **Step 1: 运行全部前端测试**
+
+Run: `./scripts/vitest-run.sh`
+Expected: PASS（全部现有 + 新增用例）。
+
+- [ ] **Step 2: 类型检查**
+
+Run: `npm run typecheck`
+Expected: PASS。
+
+- [ ] **Step 3: Lint**
+
+Run: `npm run lint`
+Expected: PASS。
+
+- [ ] **Step 4: 构建**
+
+Run: `npm run build`
+Expected: PASS（产物输出正常）。
+
+- [ ] **Step 5: 手工功能核对清单（浏览器 ≥1024px）**
+
+- [ ] 拉宽窗口进大屏：左侧出现纵向 Dock（browse/history/proxy/terminal/tasks/settings），无 chat 项；右侧恒为聊天；底部 Dock 消失
+- [ ] 点击纵向 Dock 各按钮：左栏切换对应面板；当前项高亮 + 水珠指示条纵向移动
+- [ ] 拖分隔线：左右实时变宽；最小宽度两侧均约 320px；刷新后比例保持（localStorage `clawbench-bigscreen-split-ratio`）
+- [ ] 收窄窗口 <1024：回到单栏，显示最后使用的左栏标签；底部 Dock 恢复
+- [ ] 大屏下打开会话抽屉（右栏）：居中限宽 560px，不横跨全宽；文件搜索抽屉（左栏）可打开
+- [ ] 大屏下聊天流式输出：右侧持续自动滚动；在左栏文件管理器 Ctrl+←/→ 可切换会话（可接受行为）
+- [ ] 切项目（AppHeader）：leftTab 保持；再进大屏仍生效
+- [ ] 任务完成通知 → 左栏自动切到 tasks；chat 未读不影响 Dock（Dock 已隐藏）
+
+- [ ] **Step 6: 最终提交**
+
+```bash
+git status
+git log --oneline -12
+```
+确认本特性所有提交已就位，无多余未提交改动。

--- a/docs/superpowers/specs/2026-08-03-bigscreen-splitview-design.md
+++ b/docs/superpowers/specs/2026-08-03-bigscreen-splitview-design.md
@@ -1,0 +1,189 @@
+# 大屏双栏布局（Big-Screen SplitView）设计
+
+日期：2026-08-03
+状态：已确认
+
+## 1. 目标与范围
+
+为 ClawBench 桌面大屏场景提供独立的双栏界面布局，替代当前单一底部 Dock + 单栏 TabPanel 的移动优先布局。
+
+**进入方式**：窗口/视口宽度 ≥ 1024px 时自动进入大屏双栏；低于该宽度自动回退现有单栏布局。无需手动切换。
+
+**范围**：
+- 仅影响前端 `web/src/`。后端无改动。
+- 仅覆盖已登录后的 `.app-container` 区域，登录页 / 欢迎页等不受影响。
+- 所有现有面板组件（Chat/File/Git/Proxy/Terminal/Task/Settings）保持单实例，不复制挂载。
+
+## 2. 需求要点（已与用户确认）
+
+| 编号 | 需求 | 决策 |
+|---|---|---|
+| R1 | 进入/退出 | 宽度 ≥1024px 自动进入，<1024 回退单栏 |
+| R2 | 右栏 | 始终为聊天面板（Chat），恒活 |
+| R3 | 左栏标签 | 通过左侧纵向 Dock 切换 browse/history/proxy/terminal/tasks/settings；**不含 chat** |
+| R4 | 分隔线 | 可左右拖动调整两栏宽度 |
+| R5 | 持久化 | 分隔线比例与 leftTab 均持久化到 localStorage |
+| R6 | 顶部 Header | 保留 |
+| R7 | 底部 Dock | 大屏下隐藏 |
+
+### 已确认的细化决策
+
+1. **leftTab 连续性优先（Q1A）**：进入大屏时若 `activeTab` 为非 chat 标签，`leftTab` 采纳该值；`activeTab === 'chat'` 时用持久化值；仅首次（无持久化记录）默认 `'browse'`（文件管理器）。
+2. **useTabDrawer 双激活标签（Q2A）**：大屏下 `chat` 与当前 `leftTab` 同时视为激活标签，抽屉均可打开。
+3. **activeTab 跟随 leftTab（Q3B）**：大屏下切换左栏标签时同步写 `activeTab`（但不触发 `onTabSwitch`），收窄窗口回单栏时显示最后使用的左栏标签。
+4. **左栏 Dock 角标（Q4A）**：复用现有计数 —— history 显示 Git 变更数、tasks 任务未读数、terminal 会话数、proxy 端口转发数。
+5. **分隔线存储比例（Q5A）**：存 0~1 比例，跨窗口尺寸等比换算。
+6. **纵向 Dock 实现（方案一）**：在 App.vue 内新增纵向 Dock 块，复用现有 scoped Dock 样式与辅助函数，不做组件抽取。
+7. **chat 恒活（Q7A）**：大屏下 chat `:active` 恒为 true，自动滚动与快捷键保持生效。
+8. **对称最小宽度**：左右栏均 320px。
+9. **leftTab 跨项目保留（Q9A）**：`hotSwitchProject` 不重置 leftTab。
+10. **纵向 Dock 无 overflow**：6 个标签纵向可全部容纳，不做折叠菜单。
+
+## 3. 架构
+
+### 3.1 新增文件
+
+| 文件 | 职责 |
+|---|---|
+| `web/src/components/common/SplitView.vue` | 通用双栏容器：`#left`/`#right` 插槽 + 可拖拽分隔线 + 比例持久化。可复用，不绑定业务 |
+| `web/src/composables/useBigScreenLayout.ts` | 模块单例。`isBigScreen`（matchMedia 1024）、`leftTab`、`splitRatio`、`switchLeftTab`、`setSplitRatio`、`clampSplitRatio`（纯函数）、`resetBigScreenState` |
+| `web/src/composables/__tests__/useBigScreenLayout.test.ts` | useBigScreenLayout 单元测试 |
+| `web/src/components/common/__tests__/SplitView.test.ts` | clamp 纯函数与持久化测试 |
+| `web/css/big-screen.css` | 大屏布局全局样式（引入 index.html）：`.main-content.big-screen` 的 flex-row 变体、`.big-dock` 尺寸定位等结构规则；`layout.css` 不改动 |
+
+### 3.2 修改文件
+
+| 文件 | 修改 |
+|---|---|
+| `web/src/App.vue` | `.content-area` 内包 `col-left`/`col-right` + `SplitView`；新增纵向 Dock 块与相关状态/函数；`switchTab` 模式感知；Dock 隐藏；CSS 竖排变体 |
+| `web/src/composables/useTabDrawer.ts` | 大屏感知的 `effectiveOpen` 与 autoRestore watcher |
+| `web/index.html` | 引入 `big-screen.css` |
+| `web/src/composables/__tests__/useTabDrawer.test.ts` | 增加大屏双激活标签用例 |
+
+### 3.3 布局结构
+
+```
+.app-container (flex-column)
+├── AppHeader（保留，R6）
+├── main.main-content（宽屏加 .big-screen class → flex-row）
+│   ├── .big-dock（仅大屏，纵向 Dock，~64px，6 个非 chat 标签）
+│   └── .content-area (id="contentArea")
+│       └── SplitView(:enabled="isBigScreen" :ratio="splitRatio")
+│           ├── 窄屏（enabled=false）：单列块容器，分隔线隐藏
+│           │   ├── col-left   (6 个非 chat 面板，activeTab 互斥 v-show)
+│           │   └── col-right  (chat 面板，activeTab==='chat' 时 v-show)
+│           └── 宽屏（enabled=true）：flex-row，左栏宽 = ratio，分隔线在中间
+│               ├── col-left   (leftTab 决定内部哪个面板 v-show)
+│               ├── 分隔线（可拖动）
+│               └── col-right  (chat 恒显)
+└── .bottom-dock-wrapper（宽屏时 v-show 隐藏，R7）
+```
+
+**关键约束**：所有 TabPanel 保持单实例。`col-left`/`col-right` 为 `position:relative` 容器，作为内部绝对定位 TabPanel 的定位上下文。**SplitView 通过 `enabled` prop 决定两种形态**（true=双栏+分隔线，false=单列堆叠+分隔线隐藏），col-left/col-right 的显隐逻辑（chat 恒显 / activeTab 互斥 / leftTab v-show）由 App.vue 插槽内容负责，SplitView 保持业务无关、可复用。
+
+## 4. 状态与路由设计
+
+### 4.1 `useBigScreenLayout.ts`（模块单例）
+
+- `isBigScreen: Ref<boolean>`：`window.matchMedia('(min-width: 1024px)')`，监听 `change`。若 `window.matchMedia` 不存在（测试环境 jsdom）则安全降级为 `false`，不挂监听，不抛错。
+- `leftTab: Ref<string>`：宽屏左栏标签。默认 `'browse'`；进入大屏时连续性采纳（见 R 细化 1）。持久化键 `clawbench-bigscreen-left-tab`。
+  - **进入大屏时的确定性规则**：`leftTab = activeTab !== 'chat' ? activeTab : (persistedValue ?? 'browse')`，并**立即持久化采纳结果**（此后大屏内切换由 `switchLeftTab` 持续写入）。
+- `splitRatio: Ref<number>`：左栏宽度比例 0~1。默认 0.5。持久化键 `clawbench-bigscreen-split-ratio`。写入前经 `clampSplitRatio` 归一。
+- `switchLeftTab(tab)`：`leftTab = tab`，并同步写 `activeTab`（R 细化 3，通过回调注册，见下）；**不调 `onTabSwitch`**。复用现有 side-effect：`browse → store.loadFiles(currentDir)`、`tasks → 清 taskUnreadCount + loadTasks`。
+- `clampSplitRatio(ratio, containerWidth)`（纯函数，可测）：clamp 到 `[minLeft, containerWidth - minRight] / containerWidth`，其中 `minLeft = minRight = 320`。**边界守卫**：当 `containerWidth <= minLeft + minRight` 时返回 0.5（理论不会发生，因大屏触发宽度 ≥1024，但函数必须自洽）。
+- `resetBigScreenState()`：重置 ref 为默认值（供测试与需要时调用）。
+
+**App.vue 与 useBigScreenLayout 的耦合方式**：useBigScreenLayout 导出 `registerSwitchLeftTabSideEffects(cb)` 或由 App.vue 在挂载时设置 `switchLeftTab` 的 side-effect 回调（依赖 `store`、`loadTasks`，这些在 App.vue 作用域）。useBigScreenLayout 只管理纯状态；side-effect 通过回调注入，保持可测试。
+
+### 4.2 `switchTab` 模式感知（App.vue）
+
+```
+function switchTab(tab) {
+  if (isBigScreen.value) {
+    if (tab === 'chat') return        // chat 恒显，no-op
+    switchLeftTab(tab)                 // 路由到左栏
+    return
+  }
+  ...现有窄屏逻辑不变...
+}
+```
+
+`switchTab` 的既有注入方（AppHeader、useTaskTab.registerSwitchTab、useSessionIdentity、FileManagerContent open-terminal 等）在大屏下自动获得正确路由：非 chat → 左栏；chat → 无害 no-op。
+
+### 4.3 面板 active 计算（App.vue）
+
+- chat TabPanel `:activeTab`：`isBigScreen ? 'chat' : activeTab`
+- chat 面板 `:active`：`isBigScreen || activeTab === 'chat'`（恒活，R 细化 7）
+- 其余 6 个面板 `:activeTab`：`isBigScreen ? leftTab : activeTab`
+- terminal/tasks/settings/git 面板 `:active`：`isBigScreen ? leftTab === tabId : activeTab === tabId`
+
+### 4.4 模式切换的抽屉同步
+
+- 进入大屏：`onTabSwitch('chat')` —— 聊天抽屉（Session/MessageClusters/UserMsgIndex 等）保持可用。
+- 退出大屏：`onTabSwitch(activeTab)` —— 与单栏 currentTab 对齐。
+- 进入大屏：强制 `overflowMenuOpen = false`。
+
+## 5. useTabDrawer 扩展
+
+模块内新增共享大屏状态（`isBigScreen`、`leftTab` 两个 ref，由 App.vue / useBigScreenLayout 写入）。
+
+```
+effectiveOpen = computed(() => {
+  const tabActive = currentTab.value === tabId
+                 || (isBigScreen.value && (tabId === 'chat' || tabId === leftTab.value))
+  return tabActive && openRef.value
+})
+```
+
+autoRestore:false 的 watcher 从仅监听 `currentTab` 扩展为同时监听 `currentTab` 与（大屏下的）`leftTab`：大屏下切走左栏标签时对应抽屉正确关闭；恢复该标签时 `openRef` 保留语义不变。
+
+**兼容性**：窄屏（`isBigScreen === false`）下行为与现有 `useTabDrawer.test.ts` 用例完全一致。
+
+## 6. SplitView 组件
+
+**Props**：`enabled`（boolean，false=单列堆叠+分隔线隐藏，true=双栏+分隔线）、`ratio`（初始比例，默认 0.5）、`minLeft`/`minRight`（默认 320）、`gutterSize`（视觉宽度，默认 6px）。
+
+**插槽**：`#left`、`#right`（App.vue 传入 `col-left`/`col-right` 容器）。
+
+**受控组件**：SplitView 为**受控组件**，`ratio` 由外部传入，拖动时 emit `update:ratio`。App.vue 绑定 `:ratio="splitRatio"` + `@update:ratio="setSplitRatio"`；**持久化由 useBigScreenLayout.setSplitRatio 负责**，SplitView 自身不做 localStorage 读写（保持通用可复用）。
+
+**形态**：根节点 `height:100%`。`enabled=false` 时块级单列、两插槽内容各占满容器（由外部 v-show 控制显隐）；`enabled=true` 时 flex-row，左栏 `width: ratio * containerWidth`、右栏 `flex:1`、分隔线在中间。
+
+**交互**：
+- 分隔条默认窄（6px），hover / 触碰时加宽（命中区约 14px）+ 视觉反馈，松手恢复窄条。
+- `pointerdown` → `setPointerCapture` → `pointermove` 实时计算新左栏宽度 → clamp → 更新；`pointerup` 释放。
+- 拖动期间给 `document.body` 加 `user-select: none`，结束后移除。
+- `title` 提示"拖动调整面板宽度"。
+- 宽度比例由外部（useBigScreenLayout.setSplitRatio）持久化；窗口 resize 时按当前容器宽度与 `clampSplitRatio` 归一。
+
+**最小宽度兜底**：容器 CSS `min-width` 同步设 320px，避免首帧跳动。
+
+## 7. 纵向 Dock（App.vue 内，方案一）
+
+- 新增 `.big-dock` 块（`v-show="isBigScreen"`），位于 `.main-content` 内、`.content-area` 左侧。
+- 渲染 browse/history/proxy/terminal/tasks/settings 六个按钮（**无 chat**），复用现有 `.dock-btn`/`.dock-badge`/scoped 样式与辅助函数（`dockTabIcon`/`dockTabTitle`/`formatBadgeCount`/角标动画 ref）。
+- 纵向激活指示条：新增 `bigDockActiveIndex`（基于 leftTab 在 6 项中的序号）与 `translateY` 指示样式；复用现有 `DOCK_STEP`（46px）。
+- 角标：history→`gitWorkingTreeChangeCount`、tasks→`taskUnreadCount`、terminal→`terminalSessionCount`、proxy→`portForwardActiveCount`；无 chat 的未读/运行光圈。
+- 无 overflow 折叠（6 项纵向可全容）。
+
+## 8. 已知取舍
+
+1. **"飞入聊天"粒子动画**：FileHeader / FileManagerContent / useQuoteQuestion 中 `querySelector('.dock-center')` 在底部 Dock 隐藏时返回 null（现有代码均用可选链 + `?? null` 防护），动画不播但无异常。后续可改为瞄准右栏聊天头部。
+2. **App.vue 体积**：新增约 100 行 Dock 相关模板/样式，符合现有" Dock 逻辑集中在 App.vue"的既有模式。
+3. **窄屏 Dock overflow**：大屏下 `.bottom-dock` 为 display:none，`useDockOverflow` 测得尺寸为 0，会临时把标签推进折叠菜单，但不可见且回窄屏后自动重测恢复。
+
+## 9. 测试计划
+
+| 测试文件 | 覆盖 |
+|---|---|
+| `useBigScreenLayout.test.ts` | matchMedia mock（有/无 matchMedia）；isBigScreen 翻转；leftTab 默认 browse/连续性采纳/持久化；clampSplitRatio 边界（0.5 默认、极值、容器过窄）；switchLeftTab side-effect 回调触发 |
+| `useTabDrawer.test.ts`（扩展） | 大屏下 chat 与 leftTab 双激活；autoRestore:false 随 leftTab 切换关闭；窄屏行为回归不变 |
+| `SplitView.test.ts` | enabled 两种形态；ratio→px 换算与 clamp；拖动 pointer 数学（纯 helper）；update:ratio 事件 |
+
+## 10. 不做（YAGNI）
+
+- 手动切换大屏按钮（R1 决定自动进入）
+- 分隔线键盘无障碍（←/→ 调整）
+- 大屏模式下 chat 可移至左栏
+- 独立标签状态入 store 的重构
+- DockBar.vue 组件抽取（方案二，留待将来）

--- a/docs/superpowers/specs/2026-08-03-bigscreen-splitview-design.md
+++ b/docs/superpowers/specs/2026-08-03-bigscreen-splitview-design.md
@@ -57,6 +57,7 @@
 |---|---|
 | `web/src/App.vue` | `.content-area` 内包 `col-left`/`col-right` + `SplitView`；新增纵向 Dock 块与相关状态/函数；`switchTab` 模式感知；Dock 隐藏；CSS 竖排变体 |
 | `web/src/composables/useTabDrawer.ts` | 大屏感知的 `effectiveOpen` 与 autoRestore watcher |
+| `web/src/components/common/BottomSheet.vue` | 大屏下 `.bs-panel` 全局限宽 + `wide` prop 逃逸通道（见第 6.5 节） |
 | `web/index.html` | 引入 `big-screen.css` |
 | `web/src/composables/__tests__/useTabDrawer.test.ts` | 增加大屏双激活标签用例 |
 
@@ -158,6 +159,22 @@ autoRestore:false 的 watcher 从仅监听 `currentTab` 扩展为同时监听 `c
 
 **最小宽度兜底**：容器 CSS `min-width` 同步设 320px，避免首帧跳动。
 
+### 6.5 大屏下抽屉宽度（方案 B：全局限宽 + 逃逸通道）
+
+**问题**：`.bs-panel` 为 `position:fixed` 全视口底部对齐（BottomSheet.vue:158-191），大屏下横跨全宽不美观。
+
+**方案**：
+- BottomSheet.vue 样式新增：
+  ```css
+  @media (min-width: 1024px) {
+    .bs-panel { max-width: 560px; margin: 0 auto; }   /* 底部对齐 + 水平居中 */
+    .bs-panel.bs-wide { max-width: 820px; }
+  }
+  ```
+- 新增 `wide` prop（Boolean）→ `.bs-wide` class。内容型抽屉（会话列表、文件搜索、Agent 选择器、Git 历史等富内容抽屉）按需标记 `wide`。
+- 阈值 1024px 与大屏触发宽度一致；窄屏（<1024）行为完全不变。
+- **不锚定栏内**（方案 D 否决）：BottomSheet 硬编码 `<Teleport to="body">`、95 处用法、栏矩形动态跟踪、双形态定位，改造面过大。
+
 ## 7. 纵向 Dock（App.vue 内，方案一）
 
 - 新增 `.big-dock` 块（`v-show="isBigScreen"`），位于 `.main-content` 内、`.content-area` 左侧。
@@ -179,6 +196,7 @@ autoRestore:false 的 watcher 从仅监听 `currentTab` 扩展为同时监听 `c
 | `useBigScreenLayout.test.ts` | matchMedia mock（有/无 matchMedia）；isBigScreen 翻转；leftTab 默认 browse/连续性采纳/持久化；clampSplitRatio 边界（0.5 默认、极值、容器过窄）；switchLeftTab side-effect 回调触发 |
 | `useTabDrawer.test.ts`（扩展） | 大屏下 chat 与 leftTab 双激活；autoRestore:false 随 leftTab 切换关闭；窄屏行为回归不变 |
 | `SplitView.test.ts` | enabled 两种形态；ratio→px 换算与 clamp；拖动 pointer 数学（纯 helper）；update:ratio 事件 |
+| `BottomSheet`（如已有测试则扩展） | `wide` prop 绑定 `.bs-wide` class（宽屏限宽为 CSS 媒体查询，jsdom 下验证 class 绑定即可） |
 
 ## 10. 不做（YAGNI）
 
@@ -186,4 +204,5 @@ autoRestore:false 的 watcher 从仅监听 `currentTab` 扩展为同时监听 `c
 - 分隔线键盘无障碍（←/→ 调整）
 - 大屏模式下 chat 可移至左栏
 - 独立标签状态入 store 的重构
+- 抽屉栏内锚定（方案 D / D-lite，见 6.5）
 - DockBar.vue 组件抽取（方案二，留待将来）

--- a/internal/ai/acp_backend.go
+++ b/internal/ai/acp_backend.go
@@ -7,6 +7,8 @@ import (
 	"log/slog"
 	"time"
 
+	acp "github.com/coder/acp-go-sdk"
+
 	"clawbench/internal/model"
 )
 
@@ -159,7 +161,17 @@ func (b *ACPBackend) ExecuteStream(ctx context.Context, req ChatRequest) (<-chan
 			// agent cancelled the turn). The agent process is still alive and
 			// the connection is usable — surface as an amber warning card so
 			// the user can retry without losing the session.
-			forwardACPEvent(ch, StreamEvent{Type: "warning", Content: fmt.Sprintf("acp: prompt: %v", err), Reason: ReasonRequestFailed})
+			//
+			// Extract human-readable error message from ACP RequestError.
+			// RequestError.Error() returns the full JSON blob which is not
+			// useful to the end user — we want just the .Message field
+			// (e.g. "Internal error: Upstream request failed: [invalid_request_error] Insufficient Balance").
+			errContent := err.Error()
+			var reqErr *acp.RequestError
+			if errors.As(err, &reqErr) {
+				errContent = reqErr.Message
+			}
+			forwardACPEvent(ch, StreamEvent{Type: "warning", Content: errContent, Reason: ReasonRequestFailed})
 			forwardACPEvent(ch, StreamEvent{Type: "done"})
 			return
 		}

--- a/internal/ai/backends/antigravity/discovery.go
+++ b/internal/ai/backends/antigravity/discovery.go
@@ -3,7 +3,6 @@ package antigravity
 import (
 	"context"
 	"log/slog"
-	"os/exec"
 	"regexp"
 	"strings"
 	"time"
@@ -107,14 +106,13 @@ func DiscoverAntigravityModels() []model.AgentModel {
 	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 	defer cancel()
 
-	cmd := exec.CommandContext(ctx, "agy", "models")
-	out, err := cmd.Output()
+	stdout, _, err := model.RunCommandContext(ctx, "agy", "models")
 	if err != nil {
 		slog.Debug("antigravity model discovery: command failed", "error", err)
 		return antigravityDefaults()
 	}
 
-	models := parseAgyModels(string(out))
+	models := parseAgyModels(stdout)
 	if len(models) == 0 {
 		slog.Debug("antigravity model discovery: no models parsed, using defaults")
 		return antigravityDefaults()

--- a/internal/ai/backends/antigravity/discovery_test.go
+++ b/internal/ai/backends/antigravity/discovery_test.go
@@ -3,6 +3,7 @@ package antigravity
 import (
 	"os"
 	"path/filepath"
+	"runtime"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -103,6 +104,9 @@ func TestDiscoverAntigravityModels_FallsBackOnMissingBinary(t *testing.T) {
 }
 
 func TestDiscoverAntigravityModels_SucceedsWithMockBinary(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("mock script relies on sh, not available on Windows")
+	}
 	// Create a mock `agy` script that returns model output, so the success
 	// path (parseAgyModels on stdout) is exercised in CI.
 	tmpDir := t.TempDir()

--- a/internal/ai/backends/antigravity/discovery_test.go
+++ b/internal/ai/backends/antigravity/discovery_test.go
@@ -1,6 +1,8 @@
 package antigravity
 
 import (
+	"os"
+	"path/filepath"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -98,4 +100,27 @@ func TestDiscoverAntigravityModels_FallsBackOnMissingBinary(t *testing.T) {
 	models := DiscoverAntigravityModels()
 	require.NotEmpty(t, models)
 	assert.True(t, models[0].Default)
+}
+
+func TestDiscoverAntigravityModels_SucceedsWithMockBinary(t *testing.T) {
+	// Create a mock `agy` script that returns model output, so the success
+	// path (parseAgyModels on stdout) is exercised in CI.
+	tmpDir := t.TempDir()
+	agyPath := filepath.Join(tmpDir, "agy")
+	script := `#!/bin/sh
+echo "gemini-3-pro"
+echo "gemini-3-flash"
+`
+	require.NoError(t, os.WriteFile(agyPath, []byte(script), 0o755))
+
+	origPath := os.Getenv("PATH")
+	t.Setenv("PATH", tmpDir+":"+origPath)
+
+	models := DiscoverAntigravityModels()
+	require.Len(t, models, 2)
+	assert.Equal(t, "gemini-3-pro", models[0].ID)
+	assert.Equal(t, "Gemini 3 Pro", models[0].Name)
+	assert.True(t, models[0].Default)
+	assert.Equal(t, "gemini-3-flash", models[1].ID)
+	assert.False(t, models[1].Default)
 }

--- a/internal/ai/backends/deepseek/discovery.go
+++ b/internal/ai/backends/deepseek/discovery.go
@@ -3,7 +3,6 @@ package deepseek
 import (
 	"context"
 	"log/slog"
-	"os/exec"
 	"regexp"
 	"strings"
 	"time"
@@ -69,19 +68,17 @@ func DiscoverDeepSeekModels() []model.AgentModel {
 	defer cancel()
 
 	// Try primary command first
-	cmd := exec.CommandContext(ctx, "codewhale", "models")
-	out, err := cmd.CombinedOutput()
+	stdout, stderr, err := model.RunCommandContext(ctx, "codewhale", "models")
 	if err != nil {
 		// Fallback to legacy command
-		cmd = exec.CommandContext(ctx, "deepseek", "models")
-		out, err = cmd.CombinedOutput()
+		stdout, stderr, err = model.RunCommandContext(ctx, "deepseek", "models")
 		if err != nil {
 			slog.Debug("deepseek model discovery: command failed", "error", err)
 			return nil
 		}
 	}
 
-	models := parseDeepSeekModels(string(out))
+	models := parseDeepSeekModels(stdout + stderr)
 	if len(models) == 0 {
 		slog.Debug("deepseek model discovery: no models parsed")
 		return nil

--- a/internal/ai/backends/grok/discovery.go
+++ b/internal/ai/backends/grok/discovery.go
@@ -3,7 +3,6 @@ package grok
 import (
 	"context"
 	"log/slog"
-	"os/exec"
 	"strings"
 	"time"
 
@@ -101,14 +100,13 @@ func DiscoverGrokModels() []model.AgentModel {
 	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 	defer cancel()
 
-	cmd := exec.CommandContext(ctx, "grok", "models")
-	out, err := cmd.Output()
+	stdout, _, err := model.RunCommandContext(ctx, "grok", "models")
 	if err != nil {
 		slog.Debug("grok model discovery: command failed", "error", err)
 		return grokDefaults()
 	}
 
-	models := parseGrokModels(string(out))
+	models := parseGrokModels(stdout)
 	if len(models) == 0 {
 		slog.Debug("grok model discovery: no models parsed, using defaults")
 		return grokDefaults()

--- a/internal/ai/backends/opencode/discovery.go
+++ b/internal/ai/backends/opencode/discovery.go
@@ -3,7 +3,6 @@ package opencode
 import (
 	"context"
 	"log/slog"
-	"os/exec"
 	"regexp"
 	"strings"
 	"time"
@@ -57,14 +56,13 @@ func DiscoverOpenCodeModels() []model.AgentModel {
 	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 	defer cancel()
 
-	cmd := exec.CommandContext(ctx, opencodeCmd, "models")
-	out, err := cmd.Output()
+	stdout, _, err := model.RunCommandContext(ctx, opencodeCmd, "models")
 	if err != nil {
 		slog.Debug("opencode model discovery: command failed", "error", err)
 		return nil
 	}
 
-	models := parseOpenCodeModels(string(out))
+	models := parseOpenCodeModels(stdout)
 	if len(models) == 0 {
 		slog.Debug("opencode model discovery: no models parsed")
 		return nil

--- a/internal/ai/backends/pi/discovery.go
+++ b/internal/ai/backends/pi/discovery.go
@@ -3,7 +3,6 @@ package pi
 import (
 	"context"
 	"log/slog"
-	"os/exec"
 	"regexp"
 	"strings"
 	"time"
@@ -60,15 +59,14 @@ func DiscoverPiModels() []model.AgentModel {
 	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 	defer cancel()
 
-	cmd := exec.CommandContext(ctx, piCmd, "--list-models")
-	// Pi outputs the model table to stderr; use CombinedOutput to capture both.
-	out, err := cmd.CombinedOutput()
+	// Pi outputs the model table to stderr; parse both streams (CombinedOutput semantics).
+	stdout, stderr, err := model.RunCommandContext(ctx, piCmd, "--list-models")
 	if err != nil {
 		slog.Debug("pi model discovery: command failed", "error", err)
 		return nil
 	}
 
-	models := ParsePiModels(string(out))
+	models := ParsePiModels(stdout + stderr)
 	if len(models) == 0 {
 		slog.Debug("pi model discovery: no models parsed")
 		return nil

--- a/internal/handler/file_ops_test.go
+++ b/internal/handler/file_ops_test.go
@@ -937,19 +937,4 @@ func TestServeFileCopy(t *testing.T) {
 	})
 }
 
-// splitLines splits a string by newline, matching the handler's behavior.
-func splitLines(s string) []string { //nolint:unused // test utility kept for future use
-	if s == "" {
-		return nil
-	}
-	result := []string{}
-	start := 0
-	for i := range len(s) {
-		if s[i] == '\n' {
-			result = append(result, s[start:i])
-			start = i + 1
-		}
-	}
-	result = append(result, s[start:])
-	return result
-}
+

--- a/internal/handler/file_ops_test.go
+++ b/internal/handler/file_ops_test.go
@@ -936,5 +936,3 @@ func TestServeFileCopy(t *testing.T) {
 		assert.Equal(t, "content", string(data))
 	})
 }
-
-

--- a/internal/model/exec.go
+++ b/internal/model/exec.go
@@ -24,14 +24,14 @@ func RunCommandContext(ctx context.Context, name string, args ...string) (stdout
 	if err != nil {
 		return "", "", err
 	}
-	defer os.Remove(stdoutFile.Name())
+	defer func() { _ = os.Remove(stdoutFile.Name()) }()
 
 	stderrFile, err := os.CreateTemp("", "clawbench-cmd-err-*")
 	if err != nil {
-		stdoutFile.Close()
+		_ = stdoutFile.Close()
 		return "", "", err
 	}
-	defer os.Remove(stderrFile.Name())
+	defer func() { _ = os.Remove(stderrFile.Name()) }()
 
 	cmd := exec.CommandContext(ctx, name, args...)
 	cmd.Stdout = stdoutFile
@@ -40,14 +40,14 @@ func RunCommandContext(ctx context.Context, name string, args ...string) (stdout
 
 	// Flush to disk and rewind so the files read back cleanly regardless of
 	// whether cmd.Run returned before or after all child writes landed.
-	stdoutFile.Sync()
-	stderrFile.Sync()
-	stdoutFile.Seek(0, io.SeekStart)
-	stderrFile.Seek(0, io.SeekStart)
+	_ = stdoutFile.Sync()
+	_ = stderrFile.Sync()
+	_, _ = stdoutFile.Seek(0, io.SeekStart)
+	_, _ = stderrFile.Seek(0, io.SeekStart)
 	stdoutBytes, _ := io.ReadAll(stdoutFile)
 	stderrBytes, _ := io.ReadAll(stderrFile)
-	stdoutFile.Close()
-	stderrFile.Close()
+	_ = stdoutFile.Close()
+	_ = stderrFile.Close()
 
 	return string(stdoutBytes), string(stderrBytes), runErr
 }

--- a/internal/model/exec.go
+++ b/internal/model/exec.go
@@ -1,0 +1,53 @@
+package model
+
+import (
+	"context"
+	"io"
+	"os"
+	"os/exec"
+)
+
+// RunCommandContext runs name with args, capturing stdout and stderr separately
+// to temporary files instead of pipes.
+//
+// exec.Cmd.Output() / CombinedOutput() can hang forever even when the command
+// is killed by a Context deadline: if the spawned CLI leaves a grandchild
+// holding the stdout/stderr pipe open, Output() waits for pipe EOF and the
+// Context kill of the direct child never unblocks it. This blocks server
+// startup (SyncDiscoverModels runs synchronously in main), so the service
+// "stops but never comes back up".
+//
+// Capturing to files makes Cmd.Run() return as soon as the direct child exits,
+// so the Context kill works reliably and the hang cannot occur.
+func RunCommandContext(ctx context.Context, name string, args ...string) (stdout string, stderr string, err error) {
+	stdoutFile, err := os.CreateTemp("", "clawbench-cmd-out-*")
+	if err != nil {
+		return "", "", err
+	}
+	defer os.Remove(stdoutFile.Name())
+
+	stderrFile, err := os.CreateTemp("", "clawbench-cmd-err-*")
+	if err != nil {
+		stdoutFile.Close()
+		return "", "", err
+	}
+	defer os.Remove(stderrFile.Name())
+
+	cmd := exec.CommandContext(ctx, name, args...)
+	cmd.Stdout = stdoutFile
+	cmd.Stderr = stderrFile
+	runErr := cmd.Run()
+
+	// Flush to disk and rewind so the files read back cleanly regardless of
+	// whether cmd.Run returned before or after all child writes landed.
+	stdoutFile.Sync()
+	stderrFile.Sync()
+	stdoutFile.Seek(0, io.SeekStart)
+	stderrFile.Seek(0, io.SeekStart)
+	stdoutBytes, _ := io.ReadAll(stdoutFile)
+	stderrBytes, _ := io.ReadAll(stderrFile)
+	stdoutFile.Close()
+	stderrFile.Close()
+
+	return string(stdoutBytes), string(stderrBytes), runErr
+}

--- a/internal/model/exec_test.go
+++ b/internal/model/exec_test.go
@@ -1,0 +1,61 @@
+package model
+
+import (
+	"context"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestRunCommandContextCapturesStdoutAndStderr(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	stdout, stderr, err := RunCommandContext(ctx, "sh", "-c", "echo out; echo err >&2")
+	if err != nil {
+		t.Fatalf("RunCommandContext error: %v", err)
+	}
+	if strings.TrimSpace(stdout) != "out" {
+		t.Fatalf("stdout = %q, want %q", stdout, "out")
+	}
+	if strings.TrimSpace(stderr) != "err" {
+		t.Fatalf("stderr = %q, want %q", stderr, "err")
+	}
+}
+
+func TestRunCommandContextReturnsFastWhenGrandchildHoldsPipe(t *testing.T) {
+	// Regression: the old pipe-based Output()/CombinedOutput() blocks until the
+	// backgrounded `sleep 30 &` (which inherits the output pipe) exits, even
+	// though the direct child already finished. RunCommandContext must return
+	// promptly because output goes to a file, not a pipe.
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	start := time.Now()
+	stdout, _, err := RunCommandContext(ctx, "sh", "-c", "echo hi; sleep 30 &")
+	elapsed := time.Since(start)
+	if elapsed > 5*time.Second {
+		t.Fatalf("RunCommandContext blocked for %v with a grandchild holding the output pipe", elapsed)
+	}
+	if err != nil {
+		t.Fatalf("RunCommandContext error: %v", err)
+	}
+	if strings.TrimSpace(stdout) != "hi" {
+		t.Fatalf("stdout = %q, want %q", stdout, "hi")
+	}
+}
+
+func TestRunCommandContextHonorsContextDeadline(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 300*time.Millisecond)
+	defer cancel()
+
+	start := time.Now()
+	_, _, err := RunCommandContext(ctx, "sh", "-c", "sleep 30")
+	elapsed := time.Since(start)
+	if err == nil {
+		t.Fatal("expected a context deadline error, got nil")
+	}
+	if elapsed > 5*time.Second {
+		t.Fatalf("RunCommandContext did not unblock after the context deadline (%v)", elapsed)
+	}
+}

--- a/internal/model/exec_test.go
+++ b/internal/model/exec_test.go
@@ -2,6 +2,7 @@ package model
 
 import (
 	"context"
+	"os"
 	"strings"
 	"testing"
 	"time"
@@ -57,5 +58,43 @@ func TestRunCommandContextHonorsContextDeadline(t *testing.T) {
 	}
 	if elapsed > 5*time.Second {
 		t.Fatalf("RunCommandContext did not unblock after the context deadline (%v)", elapsed)
+	}
+}
+
+func TestRunCommandContextStdoutCreateTempFails(t *testing.T) {
+	// Force os.CreateTemp to fail by setting TMPDIR to a nonexistent directory.
+	origTmpdir := os.Getenv("TMPDIR")
+	os.Setenv("TMPDIR", "/nonexistent/path/that/does/not/exist")
+	defer os.Setenv("TMPDIR", origTmpdir)
+
+	ctx := context.Background()
+	_, _, err := RunCommandContext(ctx, "echo", "hi")
+	if err == nil {
+		t.Fatal("expected error when CreateTemp fails, got nil")
+	}
+}
+
+func TestRunCommandContextStderrCreateTempFails(t *testing.T) {
+	// This is hard to trigger directly (stdout succeeds, stderr fails),
+	// but we verify the deferred cleanup still runs when stderr creation fails
+	// by ensuring the stdout temp file is removed even on partial failure.
+	origTmpdir := os.Getenv("TMPDIR")
+	os.Setenv("TMPDIR", "/nonexistent/path/that/does/not/exist")
+	defer os.Setenv("TMPDIR", origTmpdir)
+
+	ctx := context.Background()
+	_, _, err := RunCommandContext(ctx, "echo", "hi")
+	if err == nil {
+		t.Fatal("expected error when CreateTemp fails, got nil")
+	}
+}
+
+func TestRunCommandContextCommandNotFound(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	_, _, err := RunCommandContext(ctx, "nonexistent_command_xyz")
+	if err == nil {
+		t.Fatal("expected error for nonexistent command, got nil")
 	}
 }

--- a/internal/model/exec_test.go
+++ b/internal/model/exec_test.go
@@ -3,6 +3,7 @@ package model
 import (
 	"context"
 	"os"
+	"runtime"
 	"strings"
 	"testing"
 	"time"
@@ -61,26 +62,27 @@ func TestRunCommandContextHonorsContextDeadline(t *testing.T) {
 	}
 }
 
-func TestRunCommandContextStdoutCreateTempFails(t *testing.T) {
-	// Force os.CreateTemp to fail by setting TMPDIR to a nonexistent directory.
-	origTmpdir := os.Getenv("TMPDIR")
-	os.Setenv("TMPDIR", "/nonexistent/path/that/does/not/exist")
-	defer os.Setenv("TMPDIR", origTmpdir)
-
-	ctx := context.Background()
-	_, _, err := RunCommandContext(ctx, "echo", "hi")
-	if err == nil {
-		t.Fatal("expected error when CreateTemp fails, got nil")
+// setBadTempDir overrides the temp directory to a nonexistent path so that
+// os.CreateTemp fails. Returns a cleanup function to restore the original value.
+func setBadTempDir(t *testing.T) {
+	t.Helper()
+	if runtime.GOOS == "windows" {
+		// On Windows, os.CreateTemp uses TEMP/TMP, not TMPDIR.
+		for _, key := range []string{"TEMP", "TMP"} {
+			orig := os.Getenv(key)
+			os.Setenv(key, `X:\nonexistent\path\that\does\not\exist`)
+			t.Cleanup(func() { os.Setenv(key, orig) })
+		}
+	} else {
+		orig := os.Getenv("TMPDIR")
+		os.Setenv("TMPDIR", "/nonexistent/path/that/does/not/exist")
+		t.Cleanup(func() { os.Setenv("TMPDIR", orig) })
 	}
 }
 
-func TestRunCommandContextStderrCreateTempFails(t *testing.T) {
-	// This is hard to trigger directly (stdout succeeds, stderr fails),
-	// but we verify the deferred cleanup still runs when stderr creation fails
-	// by ensuring the stdout temp file is removed even on partial failure.
-	origTmpdir := os.Getenv("TMPDIR")
-	os.Setenv("TMPDIR", "/nonexistent/path/that/does/not/exist")
-	defer os.Setenv("TMPDIR", origTmpdir)
+func TestRunCommandContextCreateTempFails(t *testing.T) {
+	// Force os.CreateTemp to fail by setting the temp directory to a nonexistent path.
+	setBadTempDir(t)
 
 	ctx := context.Background()
 	_, _, err := RunCommandContext(ctx, "echo", "hi")

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,6 +1,20 @@
 import { defineConfig } from 'vitest/config'
 import vue from '@vitejs/plugin-vue'
 import { resolve } from 'path'
+import { realpathSync } from 'fs'
+
+// In git worktrees, web/node_modules may be a symlink into the primary
+// checkout's node_modules. Vite's fs.allow by default denies serving files
+// whose realpath lies outside the project root, which breaks imports such as
+// @lobehub/icons-static-svg SVG assets. Resolve the symlink's real target and
+// add it to the allowlist so tests run identically in worktrees.
+const webNodeModules = resolve(__dirname, 'web/node_modules')
+let webNodeModulesReal: string | null = null
+try {
+  webNodeModulesReal = realpathSync(webNodeModules)
+} catch {
+  // web/node_modules missing or not a symlink — nothing extra to allow
+}
 
 // Vite plugin: resolve static asset references (e.g., /logo.png) to the
 // actual file in the assets directory so they can be found during tests.
@@ -44,6 +58,11 @@ export default defineConfig({
     },
   },
   publicDir: resolve(__dirname, 'assets'),
+  server: {
+    fs: {
+      allow: [__dirname, ...(webNodeModulesReal ? [webNodeModulesReal] : [])],
+    },
+  },
   test: {
     environment: 'jsdom',
     css: true,

--- a/web/css/big-screen.css
+++ b/web/css/big-screen.css
@@ -1,0 +1,14 @@
+/* ==========================================================================
+   Big-screen (≥1024px) two-column layout
+   Activated via .big-screen class on .main-content (bound to useBigScreenLayout.isBigScreen)
+   ========================================================================== */
+
+/* Switch the single-column flex to a horizontal dock + split layout */
+.main-content.big-screen {
+  flex-direction: row;
+}
+
+/* Let the split area shrink when the vertical dock is present */
+.main-content.big-screen .content-area {
+  min-width: 0;
+}

--- a/web/index.html
+++ b/web/index.html
@@ -40,6 +40,7 @@
     <link rel="stylesheet" href="/css/variables.css">
     <link rel="stylesheet" href="/css/base.css">
     <link rel="stylesheet" href="/css/layout.css">
+    <link rel="stylesheet" href="/css/big-screen.css">
     <link rel="stylesheet" href="/css/markdown-common.css">
     <link rel="stylesheet" href="/css/code-block.css">
     <link rel="stylesheet" href="/css/code-block-header.css">

--- a/web/src/App.vue
+++ b/web/src/App.vue
@@ -25,7 +25,7 @@
           <div class="big-dock-center">
             <div class="dock-active-indicator big-dock-active-indicator" :style="bigDockIndicatorStyle"></div>
             <div v-for="tab in BIG_SCREEN_DOCK_TABS" :key="tab" class="dock-btn-wrap">
-              <button class="dock-btn" :class="bigDockBtnClass(tab)" @click.stop="switchLeftTab(tab)" :title="bigDockTabTitle(tab)">
+              <button class="dock-btn" :class="bigDockBtnClass(tab)" @click.stop="handleBigDockTabClick(tab)" :title="bigDockTabTitle(tab)">
                 <component :is="bigDockTabIcon(tab)" />
               </button>
               <span v-if="bigDockBadgeVisible(tab)" class="dock-badge dock-badge-count" :class="{ 'dock-badge-pop': bigDockBadgeAnim(tab) }" @animationend="bigDockBadgeAnimEnd(tab)">{{ formatBadgeCount(bigDockBadgeCount(tab)) }}</span>
@@ -40,7 +40,7 @@
             @update:ratio="onSplitRatioChange"
           >
             <template #left>
-              <div class="col-left" v-show="isBigScreen || activeTab !== 'chat'">
+              <div class="col-left" v-show="isBigScreen || activeTab !== 'chat'" @pointerdown="setActivePane('left')" @focusin="setActivePane('left')">
                 <!-- File Browse Tab (合一：目录浏览 + 文件覆盖预览) -->
                 <TabPanel tabId="browse" :activeTab="leftPanelActive" :noHeader="true">
                   <div class="browse-panel">
@@ -55,6 +55,7 @@
                       :dir-loading="store.state.dirLoading"
                       :search-drawer="fileSearchDrawer"
                       :recent-drawer="recentFilesDrawer"
+                      :keyboard-active="fileManagerShortcutActive"
                       @navigate-dir="handleNavigateDir"
                       @navigate-back="handleNavigateBack"
                       @select-file="handleBrowseSelectFile"
@@ -131,7 +132,7 @@
             </template>
 
             <template #right>
-              <div class="col-right" v-show="isBigScreen || activeTab === 'chat'">
+              <div class="col-right" v-show="isBigScreen || activeTab === 'chat'" :class="{ 'chat-drop-active': chatDropActive }" @pointerdown="setActivePane('right')" @focusin="setActivePane('right')" @dragenter="onChatColDragEnter" @dragover="onChatColDragOver" @dragleave="onChatColDragLeave" @drop="onChatColDrop">
                 <!-- Chat Tab -->
                 <TabPanel tabId="chat" :activeTab="chatActive">
                   <template #header>
@@ -142,6 +143,7 @@
                   </template>
                   <ChatPanelContent
                     :active="isBigScreen || activeTab === 'chat'"
+                    :keyboard-active="chatShortcutActive"
                     :current-file="currentFile"
                     :current-dir="currentDir"
                     @open="switchTab('chat')"
@@ -151,6 +153,10 @@
                     @open-session-search="sessionSearchDrawer.open()"
                   />
                 </TabPanel>
+                <div v-if="chatDropActive" class="chat-drop-hint">
+                  <Paperclip :size="16" />
+                  {{ t('file.dropToAttach') }}
+                </div>
               </div>
             </template>
           </SplitView>
@@ -315,7 +321,7 @@ import { appLog, startFlushTimer, stopFlushTimer } from '@/utils/appLog'
 import { useDockOverflow } from '@/composables/useDockOverflow'
 import { useI18n } from 'vue-i18n'
 import { useSettingsConfig, applyUIScale, getZoomedViewport, toFixedCSS } from '@/composables/useSettingsConfig'
-import { MessageSquare, FolderOpen, GitBranch, EthernetPort, SquareTerminal as TerminalIcon, CalendarClock, MoreHorizontal, Settings } from 'lucide-vue-next'
+import { MessageSquare, FolderOpen, GitBranch, EthernetPort, SquareTerminal as TerminalIcon, CalendarClock, MoreHorizontal, Settings, Paperclip } from 'lucide-vue-next'
 import AppHeader from './components/common/AppHeader.vue'
 import TabPanel from './components/common/TabPanel.vue'
 import FileOverlay from './components/file/FileOverlay.vue'
@@ -373,10 +379,14 @@ import { store, loadBrowseDir } from './stores/app.ts'
 import { setPendingCommitNavigation } from './composables/useCommitNavigation.ts'
 import { getFileType } from './utils/fileType.ts'
 import { formatBadgeCount } from './utils/format.ts'
+import { useChatContext } from './composables/useChatContext.ts'
+import { readAttachDragData, hasAttachDragData } from './utils/attachDrag'
 import SplitView from './components/common/SplitView.vue'
 import {
   useBigScreenLayout,
   resolveLeftTabOnEnter,
+  setActivePane,
+  resolveActivePaneOnEnter,
   switchLeftTab,
   setSplitRatio,
   registerBigScreenCallbacks,
@@ -489,12 +499,17 @@ async function hotSwitchProject(newProjectPath, pendingSessionId) {
 const activeTab = ref('chat')
 
 // ── Big-screen layout state ──
-const { isBigScreen, leftTab, splitRatio } = useBigScreenLayout()
+const { isBigScreen, leftTab, splitRatio, activePane } = useBigScreenLayout()
 
 const chatActive = computed(() => (isBigScreen.value ? 'chat' : activeTab.value))
 const leftPanelActive = computed(() => (isBigScreen.value ? leftTab.value : activeTab.value))
 const panelIsActive = (tabId) =>
   isBigScreen.value ? leftTab.value === tabId : activeTab.value === tabId
+
+// Focus-aware keyboard gating: a panel's global shortcuts only fire when the
+// user is actually working in that pane (big-screen) or that tab (narrow).
+const chatShortcutActive = computed(() => (isBigScreen.value ? activePane.value === 'right' : activeTab.value === 'chat'))
+const fileManagerShortcutActive = computed(() => (isBigScreen.value ? activePane.value === 'left' : activeTab.value === 'browse'))
 
 function onSplitRatioChange(ratio) {
   setSplitRatio(ratio)
@@ -1300,8 +1315,23 @@ watch(isBigScreen, (val) => {
     if (leftTab.value !== next) switchLeftTab(next)
     onTabSwitch('chat')
     overflowMenuOpen.value = false
+    // Focus continuity: the pane the user was working in becomes the active one.
+    setActivePane(resolveActivePaneOnEnter(activeTab.value))
+    // Big-screen: the bottom dock is hidden, so bottom-sheet drawers must sit
+    // flush with the screen bottom — don't let a stale --dock-height leave a gap.
+    document.documentElement.style.setProperty('--dock-height', '0px')
   } else {
     onTabSwitch(activeTab.value)
+    // Bottom dock visible again — re-measure (ResizeObserver may miss the
+    // display:none → visible transition, see the keyboard safety-net comment).
+    nextTick(() => {
+      startDockResize()
+      const dw = document.querySelector('.bottom-dock-wrapper')
+      if (dw) {
+        const h = dw.offsetHeight
+        document.documentElement.style.setProperty('--dock-height', h ? `${h}px` : '0px')
+      }
+    })
   }
 }, { immediate: true })
 
@@ -1315,6 +1345,47 @@ registerBigScreenCallbacks({
 })
 
 // ── Big-screen vertical dock helpers ──
+function handleBigDockTabClick(tab) {
+  // Clicking a dock item means the user intends to work in the left pane.
+  setActivePane('left')
+  switchLeftTab(tab)
+}
+
+// ── Drag file/dir from the left panel → attach to chat (big-screen only) ──
+const { addAttachedFile } = useChatContext()
+const chatDropActive = ref(false)
+let chatDropCounter = 0
+
+function onChatColDragEnter(e) {
+  if (!isBigScreen.value || !hasAttachDragData(e.dataTransfer)) return
+  chatDropCounter++
+  chatDropActive.value = true
+}
+
+function onChatColDragOver(e) {
+  // Allow the drop only for internal attach drags (don't hijack OS file drops)
+  if (isBigScreen.value && hasAttachDragData(e.dataTransfer)) e.preventDefault()
+}
+
+function onChatColDragLeave() {
+  chatDropCounter--
+  if (chatDropCounter <= 0) {
+    chatDropCounter = 0
+    chatDropActive.value = false
+  }
+}
+
+function onChatColDrop(e) {
+  chatDropCounter = 0
+  chatDropActive.value = false
+  if (!isBigScreen.value) return
+  const data = readAttachDragData(e.dataTransfer)
+  if (!data) return
+  e.preventDefault()
+  addAttachedFile(data.path, data.isDir)
+  toast.show(t('chat.attach.addedToChat'), { icon: '📎', type: 'success', duration: 1500 })
+}
+
 const bigScreenTabMeta = {
   browse: { icon: FolderOpen, titleKey: 'nav.fileManager' },
   history: { icon: GitBranch, titleKey: 'git.history.projectHistory' },
@@ -1782,14 +1853,15 @@ function handleCtrlF(e) {
     if (_dlg.state.value.visible || projectDialogOpen.value) return
 
     if (isBigScreen.value) {
-        // Two visible panes: browse (left workspace) takes priority, else chat (always visible)
-        if (panelIsActive('browse')) {
-            e.preventDefault()
-            openBrowseSearchDrawer()
-        } else {
+        // Focus-aware: route Ctrl+F to the pane the user is working in
+        if (activePane.value === 'right') {
             e.preventDefault()
             openChatSearchDrawer()
+        } else if (panelIsActive('browse')) {
+            e.preventDefault()
+            openBrowseSearchDrawer()
         }
+        // Left pane focused on a non-searchable tab → native Ctrl+F
     } else if (activeTab.value === 'chat') {
         e.preventDefault()
         openChatSearchDrawer()
@@ -1848,6 +1920,38 @@ onUnmounted(() => {
     height: 100%;
 }
 
+/* Drag file/dir onto the chat column (big-screen) — highlight the drop target */
+.chat-drop-active::after {
+    content: '';
+    position: absolute;
+    inset: 4px;
+    border: 2px dashed var(--accent-color, #0066cc);
+    border-radius: 12px;
+    background: color-mix(in srgb, var(--accent-color, #0066cc) 6%, transparent);
+    pointer-events: none;
+    z-index: 10;
+}
+
+.chat-drop-hint {
+    position: absolute;
+    left: 50%;
+    top: 50%;
+    transform: translate(-50%, -50%);
+    display: flex;
+    align-items: center;
+    gap: 6px;
+    padding: 10px 18px;
+    border-radius: 999px;
+    background: var(--bg-primary);
+    border: 1px solid var(--accent-color, #0066cc);
+    box-shadow: 0 4px 16px rgba(0, 0, 0, 0.15);
+    color: var(--accent-color, #0066cc);
+    font-size: 14px;
+    font-weight: 600;
+    pointer-events: none;
+    z-index: 11;
+}
+
 /* When chat keyboard is open on iOS/PWA (no adjustResize), shrink the app container
    from the bottom so content stays above the keyboard. */
 .chat-keyboard-open {
@@ -1868,13 +1972,14 @@ onUnmounted(() => {
     user-select: none;
 }
 
-/* Big-screen vertical dock (left edge) */
+/* Big-screen vertical dock (left edge) — VS Code activity-bar style */
 .big-dock {
     flex-shrink: 0;
-    width: 60px;
+    width: 48px;
     display: flex;
-    align-items: center;
+    align-items: flex-start;
     justify-content: center;
+    padding-top: 8px;
     background: var(--bg-primary);
     border-right: 1px solid color-mix(in srgb, var(--border-color) 40%, transparent);
     -webkit-tap-highlight-color: transparent;

--- a/web/src/App.vue
+++ b/web/src/App.vue
@@ -1443,7 +1443,7 @@ const bigDockActiveIndex = computed(() => {
   return i >= 0 ? i : 0
 })
 const bigDockIndicatorStyle = computed(() => ({
-  transform: `translate(-50%, ${bigDockActiveIndex.value * DOCK_STEP}px)`,
+  transform: `translateY(${bigDockActiveIndex.value * DOCK_STEP}px)`,
 }))
 
 const isOverflowTabActive = computed(() => popupOverflowTabs.value.includes(activeTab.value))
@@ -1979,25 +1979,54 @@ onUnmounted(() => {
     display: flex;
     align-items: flex-start;
     justify-content: center;
-    padding-top: 8px;
     background: var(--bg-primary);
-    border-right: 1px solid color-mix(in srgb, var(--border-color) 40%, transparent);
+    border-right: 1px solid var(--border-color);
     -webkit-tap-highlight-color: transparent;
     user-select: none;
 }
 
 .big-dock-center {
     position: relative;
+    width: 100%;
     display: flex;
     flex-direction: column;
     align-items: center;
     gap: 12px;
 }
 
-/* Vertical variant of the water-drop indicator (base .dock-active-indicator is already scoped) */
-.big-dock-active-indicator {
-    left: 50%;
+/* VS Code activity-bar style active highlight: faint translucent theme tint
+   spanning the dock width + a thin theme-colored bar on the left edge.
+   Scoped under .big-dock so it outranks the base .dock-active-indicator
+   (same single-class specificity — a bare .big-dock-active-indicator would
+   lose to the later base rule and render as the circular water-drop). */
+.big-dock .big-dock-active-indicator {
+    position: absolute;
+    left: 0;
     top: 0;
+    width: 100%;
+    height: 34px;
+    border-radius: 0;
+    background: color-mix(in srgb, var(--accent-color) 12%, transparent);
+    /* Base uses a springy overshoot (for the bottom-dock water-drop); a smooth
+       ease-out reads better on a full-width highlight. */
+    transition: transform 0.2s cubic-bezier(0.16, 1, 0.3, 1);
+}
+.big-dock .big-dock-active-indicator::before {
+    content: '';
+    position: absolute;
+    left: 0;
+    top: 0;
+    bottom: 0;
+    width: 3px;
+    background: var(--accent-color);
+}
+
+/* Active icon follows the theme color (VS Code activity bar) */
+.big-dock .dock-btn.active {
+    color: var(--accent-color);
+}
+.big-dock .dock-btn.active:hover {
+    color: var(--accent-color);
 }
 
 .bottom-dock {

--- a/web/src/App.vue
+++ b/web/src/App.vue
@@ -648,7 +648,7 @@ const sortField = ref(localConfig.sortField || null)
 const sortDir = ref(localConfig.sortDir || 'asc')
 
 useFileWatch({
-  fileManagerOpen: computed(() => activeTab.value === 'browse'),
+  fileManagerOpen: computed(() => leftPanelActive.value === 'browse'),
   currentDir: computed(() => store.state.currentDir),
   currentFile: computed(() => store.state.currentFile),
 })
@@ -676,15 +676,15 @@ const isPlatformUnsupported = computed(() => platformSupported.value === false)
 // disabled to avoid a flash of the terminal button on first mount.
 const isTerminalDisabled = computed(() => terminalRuntimeEnabled.value !== true)
 watch(isSSHDisabled, (disabled) => {
-  if (disabled && activeTab.value === 'proxy') {
-    switchTab('chat')
+  if (disabled && panelIsActive('proxy')) {
+    switchTab(isBigScreen.value ? 'browse' : 'chat')
   }
 })
 watch(isTerminalDisabled, (disabled) => {
   // Only force-switch when terminal is config-disabled (not platform unsupported).
   // Platform unsupported shows a dedicated empty state — user can stay on the tab.
-  if (disabled && !isPlatformUnsupported.value && activeTab.value === 'terminal') {
-    switchTab('chat')
+  if (disabled && !isPlatformUnsupported.value && panelIsActive('terminal')) {
+    switchTab(isBigScreen.value ? 'browse' : 'chat')
   }
 })
 const { navigateToTaskSettings, navigateToTaskHistory, openExecDetail, loadTasks } = useTaskTab()
@@ -720,7 +720,7 @@ useEdgeSwipeBack()
 // 文件覆盖层的返回手势：overlay 优先级高于 browse，无论 mount 顺序如何
 useFeatureBackHandler(
   'file-overlay',
-  () => activeTab.value === 'browse' && fileNav.overlayOpen.value,
+  () => panelIsActive('browse') && fileNav.overlayOpen.value,
   () => {
     if (fileNav.canGoBack.value) {
       const prevPath = fileNav.goBack()
@@ -767,7 +767,7 @@ const terminalKeyboardNeedsShrink = computed(() => terminalKeyboardActive.value 
 // Chat keyboard — on iOS WKWebView there's no adjustResize, so we detect
 // keyboard via visualViewport and compensate in the web layer.
 const { chatKeyboardHeight } = useChatKeyboard()
-const chatKeyboardActive = computed(() => activeTab.value === 'chat' && chatKeyboardHeight.value > 0)
+const chatKeyboardActive = computed(() => chatActive.value === 'chat' && chatKeyboardHeight.value > 0)
 
 // Unified: any soft keyboard is open (terminal or chat)
 const anyKeyboardActive = computed(() => terminalKeyboardActive.value || chatKeyboardActive.value)
@@ -1748,6 +1748,28 @@ onMounted(async () => {
 
 // ── Ctrl+F / Cmd+F: open context-aware search drawer ──
 const _dlg = useDialog()
+function openChatSearchDrawer() {
+  if (sessionSearchDrawer.isOpen.value) {
+    sessionSearchDrawerRef.value?.focusSearchInput()
+  } else {
+    sessionSearchDrawer.open()
+  }
+}
+function openBrowseSearchDrawer() {
+  if (fileNav.overlayOpen.value) {
+    if (searchDrawer.isOpen.value) {
+      fileOverlayRef.value?.focusSearchInput()
+    } else if (currentFile.value?.content) {
+      searchDrawer.open()
+    }
+  } else {
+    if (fileSearchDrawer.isOpen.value) {
+      fileManagerRef.value?.focusSearchInput()
+    } else {
+      fileSearchDrawer.open()
+    }
+  }
+}
 function handleCtrlF(e) {
     if (!(e.ctrlKey || e.metaKey) || e.key !== 'f') return
     // Skip when focus is in input/textarea/contenteditable/terminal
@@ -1758,30 +1780,21 @@ function handleCtrlF(e) {
     // Skip when modal dialog or project dialog is open
     if (_dlg.state.value.visible || projectDialogOpen.value) return
 
-    if (activeTab.value === 'chat') {
-        // Chat tab → SessionSearchDrawer
-        e.preventDefault()
-        if (sessionSearchDrawer.isOpen.value) {
-            sessionSearchDrawerRef.value?.focusSearchInput()
+    if (isBigScreen.value) {
+        // Two visible panes: browse (left workspace) takes priority, else chat (always visible)
+        if (panelIsActive('browse')) {
+            e.preventDefault()
+            openBrowseSearchDrawer()
         } else {
-            sessionSearchDrawer.open()
+            e.preventDefault()
+            openChatSearchDrawer()
         }
+    } else if (activeTab.value === 'chat') {
+        e.preventDefault()
+        openChatSearchDrawer()
     } else if (activeTab.value === 'browse') {
-        // Browse tab → context-aware: overlay open → SearchDrawer (content), else → FileSearchDrawer (filename)
         e.preventDefault()
-        if (fileNav.overlayOpen.value) {
-            if (searchDrawer.isOpen.value) {
-                fileOverlayRef.value?.focusSearchInput()
-            } else if (currentFile.value?.content) {
-                searchDrawer.open()
-            }
-        } else {
-            if (fileSearchDrawer.isOpen.value) {
-                fileManagerRef.value?.focusSearchInput()
-            } else {
-                fileSearchDrawer.open()
-            }
-        }
+        openBrowseSearchDrawer()
     }
     // Other tabs: don't preventDefault — let browser handle Ctrl+F natively
 }

--- a/web/src/App.vue
+++ b/web/src/App.vue
@@ -1867,6 +1867,33 @@ onUnmounted(() => {
     user-select: none;
 }
 
+/* Big-screen vertical dock (left edge) */
+.big-dock {
+    flex-shrink: 0;
+    width: 60px;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    background: var(--bg-primary);
+    border-right: 1px solid color-mix(in srgb, var(--border-color) 40%, transparent);
+    -webkit-tap-highlight-color: transparent;
+    user-select: none;
+}
+
+.big-dock-center {
+    position: relative;
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    gap: 12px;
+}
+
+/* Vertical variant of the water-drop indicator (base .dock-active-indicator is already scoped) */
+.big-dock-active-indicator {
+    left: 50%;
+    top: 0;
+}
+
 .bottom-dock {
     display: flex;
     align-items: center;

--- a/web/src/App.vue
+++ b/web/src/App.vue
@@ -19,114 +19,141 @@
       />
       <ConnectionOverlay />
 
-      <main class="main-content">
+      <main class="main-content" :class="{ 'big-screen': isBigScreen }">
+        <!-- Big-screen vertical dock (non-chat tabs only) -->
+        <div v-show="isBigScreen" class="big-dock">
+          <div class="big-dock-center">
+            <div class="dock-active-indicator big-dock-active-indicator" :style="bigDockIndicatorStyle"></div>
+            <div v-for="tab in BIG_SCREEN_DOCK_TABS" :key="tab" class="dock-btn-wrap">
+              <button class="dock-btn" :class="bigDockBtnClass(tab)" @click.stop="switchLeftTab(tab)" :title="bigDockTabTitle(tab)">
+                <component :is="bigDockTabIcon(tab)" />
+              </button>
+              <span v-if="bigDockBadgeVisible(tab)" class="dock-badge dock-badge-count" :class="{ 'dock-badge-pop': bigDockBadgeAnim(tab) }" @animationend="bigDockBadgeAnimEnd(tab)">{{ formatBadgeCount(bigDockBadgeCount(tab)) }}</span>
+            </div>
+          </div>
+        </div>
+
         <div class="content-area" id="contentArea">
-          <!-- Chat Tab -->
-          <TabPanel tabId="chat" :activeTab="activeTab">
-            <template #header>
-              <span class="bs-header-title"><AgentIcon v-if="sessionIdentity.currentAgentId.value" :backend="getAgentBackend(sessionIdentity.currentAgentId.value)" :name="getAgentName(sessionIdentity.currentAgentId.value)" :size="18" />{{ sessionIdentity.agentHeaderTitle.value }}</span>
-              <div v-if="sessionIdentity.currentSessionTitle.value" class="bs-header-description">
-                <HeaderMarquee :text="sessionIdentity.currentSessionTitle.value">{{ sessionIdentity.currentSessionTitle.value }}</HeaderMarquee>
+          <SplitView
+            :enabled="isBigScreen"
+            :ratio="splitRatio"
+            @update:ratio="onSplitRatioChange"
+          >
+            <template #left>
+              <div class="col-left" v-show="isBigScreen || activeTab !== 'chat'">
+                <!-- File Browse Tab (合一：目录浏览 + 文件覆盖预览) -->
+                <TabPanel tabId="browse" :activeTab="leftPanelActive" :noHeader="true">
+                  <div class="browse-panel">
+                    <FileManagerContent
+                      ref="fileManagerRef"
+                      :entries="dirEntries"
+                      :current-dir="currentDir"
+                      :current-file="currentFile"
+                      :show-hidden="showHidden"
+                      :sort-field="sortField"
+                      :sort-dir="sortDir"
+                      :dir-loading="store.state.dirLoading"
+                      :search-drawer="fileSearchDrawer"
+                      :recent-drawer="recentFilesDrawer"
+                      @navigate-dir="handleNavigateDir"
+                      @navigate-back="handleNavigateBack"
+                      @select-file="handleBrowseSelectFile"
+                      @toggle-sort="handleToggleSort"
+                      @toggle-hidden="toggleHidden"
+                      @rename="handleRename"
+                      @delete="handleDelete"
+                      @batch-delete="handleBatchDelete"
+                      @refresh="handleRefresh"
+                      @open-terminal="handleOpenTerminal"
+                    />
+                    <FileOverlay
+                      ref="fileOverlayRef"
+                      :overlay-open="fileNav.overlayOpen.value"
+                      :current-file="currentFile"
+                      :file-loading="store.state.fileLoading"
+                      :toc-open="tocDrawer.effectiveOpen.value"
+                      :search-open="searchDrawer.effectiveOpen.value"
+                      :markdown-view-mode="markdownViewMode"
+                      :file-history-open="fileHistoryDrawer.effectiveOpen.value"
+                      :toc-file="tocFile"
+                      :pdf-outline="pdfOutline"
+                      @delete="handleDelete($event)"
+                      @show-details="detailsDrawer.open()"
+                      @open-git-history="openFileHistory"
+                      @toggle-toc="tocDrawer.toggle()"
+                      @toggle-search="currentFile?.content && searchDrawer.toggle()"
+                      @toggle-view="markdownViewMode = markdownViewMode === 'rendered' ? 'raw' : 'rendered'"
+                      @refresh="handleRefresh"
+                      @jump="scrollToLine"
+                      @jump-page="handleJumpPdfPage"
+                      @close-git-history="fileHistoryDrawer.close()"
+                      @open-file="handleOverlayOpenFile"
+                      @overlay-close="handleOverlayClose"
+                      @open-recent-files="recentFilesDrawer.open()"
+                    />
+                  </div>
+                </TabPanel>
+
+                <!-- History Tab -->
+                <TabPanel tabId="history" :activeTab="leftPanelActive" :noHeader="true">
+                  <GitHistoryContent
+                    mode="project"
+                    :active="panelIsActive('history')"
+                    @open-file="handleSelectFile"
+                  />
+                </TabPanel>
+
+                <!-- Proxy Tab -->
+                <TabPanel tabId="proxy" :activeTab="leftPanelActive" :noHeader="true">
+                  <ProxyPanelContent />
+                </TabPanel>
+
+                <!-- Terminal Tab -->
+                <TabPanel tabId="terminal" :activeTab="leftPanelActive" :noHeader="true">
+                  <TerminalPanelContent
+                    :requested-cwd="terminalRequestedCwd"
+                    :active="panelIsActive('terminal')"
+                    :platform-unsupported="isPlatformUnsupported"
+                    @cwd-handled="terminalRequestedCwd = null"
+                  />
+                </TabPanel>
+
+                <!-- Tasks Tab -->
+                <TabPanel tabId="tasks" :activeTab="leftPanelActive" :noHeader="true">
+                  <TaskTab :active="panelIsActive('tasks')" @open-file="handleTaskOpenFile" />
+                </TabPanel>
+
+                <!-- Settings Tab -->
+                <TabPanel tabId="settings" :activeTab="leftPanelActive" :noHeader="true">
+                  <SettingsPage :active="panelIsActive('settings')" />
+                </TabPanel>
               </div>
             </template>
-            <ChatPanelContent
-              :active="activeTab === 'chat'"
-              :current-file="currentFile"
-              :current-dir="currentDir"
-              @open="switchTab('chat')"
-              @open-file="handleSelectFile"
-              @task-card-click="onTaskCardClick"
-              @open-acp-sessions="acpSessionDrawer.open()"
-              @open-session-search="sessionSearchDrawer.open()"
-            />
-          </TabPanel>
 
-          <!-- File Browse Tab (合一：目录浏览 + 文件覆盖预览) -->
-          <TabPanel tabId="browse" :activeTab="activeTab" :noHeader="true">
-            <div class="browse-panel">
-              <FileManagerContent
-                ref="fileManagerRef"
-                :entries="dirEntries"
-                :current-dir="currentDir"
-                :current-file="currentFile"
-                :show-hidden="showHidden"
-                :sort-field="sortField"
-                :sort-dir="sortDir"
-                :dir-loading="store.state.dirLoading"
-                :search-drawer="fileSearchDrawer"
-                :recent-drawer="recentFilesDrawer"
-                @navigate-dir="handleNavigateDir"
-                @navigate-back="handleNavigateBack"
-                @select-file="handleBrowseSelectFile"
-                @toggle-sort="handleToggleSort"
-                @toggle-hidden="toggleHidden"
-                @rename="handleRename"
-                @delete="handleDelete"
-                @batch-delete="handleBatchDelete"
-                @refresh="handleRefresh"
-                @open-terminal="handleOpenTerminal"
-              />
-              <FileOverlay
-                ref="fileOverlayRef"
-                :overlay-open="fileNav.overlayOpen.value"
-                :current-file="currentFile"
-                :file-loading="store.state.fileLoading"
-                :toc-open="tocDrawer.effectiveOpen.value"
-                :search-open="searchDrawer.effectiveOpen.value"
-                :markdown-view-mode="markdownViewMode"
-                :file-history-open="fileHistoryDrawer.effectiveOpen.value"
-                :toc-file="tocFile"
-                :pdf-outline="pdfOutline"
-                @delete="handleDelete($event)"
-                @show-details="detailsDrawer.open()"
-                @open-git-history="openFileHistory"
-                @toggle-toc="tocDrawer.toggle()"
-                @toggle-search="currentFile?.content && searchDrawer.toggle()"
-                @toggle-view="markdownViewMode = markdownViewMode === 'rendered' ? 'raw' : 'rendered'"
-                @refresh="handleRefresh"
-                @jump="scrollToLine"
-                @jump-page="handleJumpPdfPage"
-                @close-git-history="fileHistoryDrawer.close()"
-                @open-file="handleOverlayOpenFile"
-                @overlay-close="handleOverlayClose"
-                @open-recent-files="recentFilesDrawer.open()"
-              />
-            </div>
-          </TabPanel>
-
-          <!-- History Tab -->
-          <TabPanel tabId="history" :activeTab="activeTab" :noHeader="true">
-            <GitHistoryContent
-              mode="project"
-              :active="activeTab === 'history'"
-              @open-file="handleSelectFile"
-            />
-          </TabPanel>
-
-          <!-- Proxy Tab -->
-          <TabPanel tabId="proxy" :activeTab="activeTab" :noHeader="true">
-            <ProxyPanelContent />
-          </TabPanel>
-
-          <!-- Terminal Tab -->
-          <TabPanel tabId="terminal" :activeTab="activeTab" :noHeader="true">
-            <TerminalPanelContent
-              :requested-cwd="terminalRequestedCwd"
-              :active="activeTab === 'terminal'"
-              :platform-unsupported="isPlatformUnsupported"
-              @cwd-handled="terminalRequestedCwd = null"
-            />
-          </TabPanel>
-
-          <!-- Tasks Tab -->
-          <TabPanel tabId="tasks" :activeTab="activeTab" :noHeader="true">
-            <TaskTab :active="activeTab === 'tasks'" @open-file="handleTaskOpenFile" />
-          </TabPanel>
-
-          <!-- Settings Tab -->
-          <TabPanel tabId="settings" :activeTab="activeTab" :noHeader="true">
-            <SettingsPage :active="activeTab === 'settings'" />
-          </TabPanel>
+            <template #right>
+              <div class="col-right" v-show="isBigScreen || activeTab === 'chat'">
+                <!-- Chat Tab -->
+                <TabPanel tabId="chat" :activeTab="chatActive">
+                  <template #header>
+                    <span class="bs-header-title"><AgentIcon v-if="sessionIdentity.currentAgentId.value" :backend="getAgentBackend(sessionIdentity.currentAgentId.value)" :name="getAgentName(sessionIdentity.currentAgentId.value)" :size="18" />{{ sessionIdentity.agentHeaderTitle.value }}</span>
+                    <div v-if="sessionIdentity.currentSessionTitle.value" class="bs-header-description">
+                      <HeaderMarquee :text="sessionIdentity.currentSessionTitle.value">{{ sessionIdentity.currentSessionTitle.value }}</HeaderMarquee>
+                    </div>
+                  </template>
+                  <ChatPanelContent
+                    :active="isBigScreen || activeTab === 'chat'"
+                    :current-file="currentFile"
+                    :current-dir="currentDir"
+                    @open="switchTab('chat')"
+                    @open-file="handleSelectFile"
+                    @task-card-click="onTaskCardClick"
+                    @open-acp-sessions="acpSessionDrawer.open()"
+                    @open-session-search="sessionSearchDrawer.open()"
+                  />
+                </TabPanel>
+              </div>
+            </template>
+          </SplitView>
         </div>
       </main>
 
@@ -193,7 +220,7 @@
       />
 
       <!-- Bottom dock (tab bar) -->
-      <div v-if="isAuthenticated" v-show="!anyKeyboardActive" class="bottom-dock-wrapper">
+      <div v-if="isAuthenticated" v-show="!anyKeyboardActive && !isBigScreen" class="bottom-dock-wrapper">
         <div ref="dockRef" class="bottom-dock">
           <div class="dock-center">
             <div class="dock-active-indicator" :style="dockIndicatorStyle"></div>
@@ -346,6 +373,14 @@ import { store, loadBrowseDir } from './stores/app.ts'
 import { setPendingCommitNavigation } from './composables/useCommitNavigation.ts'
 import { getFileType } from './utils/fileType.ts'
 import { formatBadgeCount } from './utils/format.ts'
+import SplitView from './components/common/SplitView.vue'
+import {
+  useBigScreenLayout,
+  switchLeftTab,
+  setSplitRatio,
+  registerBigScreenCallbacks,
+  BIG_SCREEN_DOCK_TABS,
+} from './composables/useBigScreenLayout'
 import 'highlight.js/styles/github.css'
 import 'highlight.js/styles/github-dark.css'
 import './assets/hljs-light-override.css'
@@ -452,6 +487,18 @@ async function hotSwitchProject(newProjectPath, pendingSessionId) {
 
 const activeTab = ref('chat')
 
+// ── Big-screen layout state ──
+const { isBigScreen, leftTab, splitRatio } = useBigScreenLayout()
+
+const chatActive = computed(() => (isBigScreen.value ? 'chat' : activeTab.value))
+const leftPanelActive = computed(() => (isBigScreen.value ? leftTab.value : activeTab.value))
+const panelIsActive = (tabId) =>
+  isBigScreen.value ? leftTab.value === tabId : activeTab.value === tabId
+
+function onSplitRatioChange(ratio) {
+  setSplitRatio(ratio)
+}
+
 // Dock active indicator — water-drop sliding highlight
 // Dynamic button count: chat, browse, history, [inline overflow...], [overflow btn]
 const DOCK_STEP = 46 // 34 (btn width) + 12 (gap)
@@ -472,6 +519,12 @@ const dockIndicatorStyle = computed(() => ({
 }))
 
 function switchTab(tab) {
+  if (isBigScreen.value) {
+    // Big-screen: chat is always visible; non-chat tabs route to the left column
+    if (tab === 'chat') return
+    switchLeftTab(tab)
+    return
+  }
   if (activeTab.value === tab) return
   activeTab.value = tab
   // Auto-close all drawers not belonging to the new tab
@@ -1237,6 +1290,90 @@ function handleInlineOverflowClick(tab) {
   }
 }
 
+// Big-screen mode transitions: keep useTabDrawer's currentTab coherent
+// (chat drawers work in wide mode; collapse returns to the last active tab).
+watch(isBigScreen, (val) => {
+  if (val) {
+    // Continuity-first (Q1A): adopt activeTab if non-chat, else keep persisted leftTab
+    const next = activeTab.value !== 'chat' ? activeTab.value : leftTab.value
+    if (leftTab.value !== next) switchLeftTab(next)
+    onTabSwitch('chat')
+    overflowMenuOpen.value = false
+  } else {
+    onTabSwitch(activeTab.value)
+  }
+}, { immediate: true })
+
+// Route leftTab side-effects (reuse narrow-mode behaviors) and sync activeTab (Q3B)
+registerBigScreenCallbacks({
+  setActiveTab: (tab) => { activeTab.value = tab },
+  sideEffects: (tab) => {
+    if (tab === 'browse') store.loadFiles(store.state.currentDir)
+    if (tab === 'tasks') { store.state.taskUnreadCount = 0; loadTasks() }
+  },
+})
+
+// ── Big-screen vertical dock helpers ──
+const bigScreenTabMeta = {
+  browse: { icon: FolderOpen, titleKey: 'nav.fileManager' },
+  history: { icon: GitBranch, titleKey: 'git.history.projectHistory' },
+  tasks: overflowTabMeta.tasks,
+  proxy: overflowTabMeta.proxy,
+  terminal: overflowTabMeta.terminal,
+  settings: overflowTabMeta.settings,
+}
+
+function bigDockTabIcon(tab) {
+  return bigScreenTabMeta[tab]?.icon ?? FolderOpen
+}
+function bigDockTabTitle(tab) {
+  return bigScreenTabMeta[tab] ? t(bigScreenTabMeta[tab].titleKey) : ''
+}
+function bigDockBtnClass(tab) {
+  return {
+    active: leftTab.value === tab,
+    'has-unread': tab === 'tasks' && store.state.taskUnreadCount > 0 && leftTab.value !== 'tasks',
+    'just-completed': tab === 'tasks' && store.state.taskJustCompleted && leftTab.value !== 'tasks',
+    'has-running': tab === 'tasks' && store.state.taskRunning && leftTab.value !== 'tasks',
+  }
+}
+function bigDockBadgeCount(tab) {
+  switch (tab) {
+    case 'history': return store.state.gitWorkingTreeChangeCount
+    case 'tasks': return store.state.taskUnreadCount
+    case 'terminal': return store.state.terminalSessionCount
+    case 'proxy': return store.state.portForwardActiveCount
+    default: return 0
+  }
+}
+function bigDockBadgeVisible(tab) {
+  return bigDockBadgeCount(tab) > 0 && leftTab.value !== tab
+}
+function bigDockBadgeAnim(tab) {
+  switch (tab) {
+    case 'history': return historyBadgeAnim.value
+    case 'tasks': return taskBadgeAnim.value
+    case 'terminal': return terminalBadgeAnim.value
+    case 'proxy': return proxyBadgeAnim.value
+    default: return false
+  }
+}
+function bigDockBadgeAnimEnd(tab) {
+  switch (tab) {
+    case 'history': historyBadgeAnim.value = false; break
+    case 'tasks': taskBadgeAnim.value = false; break
+    case 'terminal': terminalBadgeAnim.value = false; break
+    case 'proxy': proxyBadgeAnim.value = false; break
+  }
+}
+const bigDockActiveIndex = computed(() => {
+  const i = BIG_SCREEN_DOCK_TABS.indexOf(leftTab.value)
+  return i >= 0 ? i : 0
+})
+const bigDockIndicatorStyle = computed(() => ({
+  transform: `translate(-50%, ${bigDockActiveIndex.value * DOCK_STEP}px)`,
+}))
+
 const isOverflowTabActive = computed(() => popupOverflowTabs.value.includes(activeTab.value))
 
 const overflowPopupStyle = computed(() => {
@@ -1688,6 +1825,13 @@ onUnmounted(() => {
   display: flex;
   flex-direction: column;
   overflow: hidden;
+}
+
+/* Big-screen split panes — positioned ancestors for the absolute TabPanels */
+.col-left,
+.col-right {
+    position: relative;
+    height: 100%;
 }
 
 /* When chat keyboard is open on iOS/PWA (no adjustResize), shrink the app container

--- a/web/src/App.vue
+++ b/web/src/App.vue
@@ -376,6 +376,7 @@ import { formatBadgeCount } from './utils/format.ts'
 import SplitView from './components/common/SplitView.vue'
 import {
   useBigScreenLayout,
+  resolveLeftTabOnEnter,
   switchLeftTab,
   setSplitRatio,
   registerBigScreenCallbacks,
@@ -1295,7 +1296,7 @@ function handleInlineOverflowClick(tab) {
 watch(isBigScreen, (val) => {
   if (val) {
     // Continuity-first (Q1A): adopt activeTab if non-chat, else keep persisted leftTab
-    const next = activeTab.value !== 'chat' ? activeTab.value : leftTab.value
+    const next = resolveLeftTabOnEnter(activeTab.value, leftTab.value)
     if (leftTab.value !== next) switchLeftTab(next)
     onTabSwitch('chat')
     overflowMenuOpen.value = false

--- a/web/src/App.vue
+++ b/web/src/App.vue
@@ -730,6 +730,16 @@ const handleForeground = () => {
     }
 }
 
+// WS reconnect: refresh WS-push state that may have changed while disconnected.
+// Lighter than handleForeground — skips file/dir refresh (SSE reconnects independently)
+// and terminal status (not WS-push state).
+const handleReconnect = () => {
+    if (!isAuthenticated.value) return
+    loadSessionsOnce()
+    loadTasks()
+    store.loadGitBranch()
+}
+
 // Edge swipe back gesture detection (right-edge-left-swipe → go back)
 useEdgeSwipeBack()
 
@@ -767,6 +777,7 @@ window.addEventListener('clawbench-back-press', () => {
     }
 })
 window.addEventListener('clawbench-foreground', handleForeground)
+window.addEventListener('clawbench-reconnect', handleReconnect)
 const terminalRequestedCwd = ref(null)
 
 // Terminal keyboard height for detecting when soft keyboard is open in terminal tab.
@@ -1880,6 +1891,7 @@ onUnmounted(() => {
     stopDockResize()
     removeTaskHandler()
     window.removeEventListener('clawbench-foreground', handleForeground)
+    window.removeEventListener('clawbench-reconnect', handleReconnect)
     destroyGlobalEvents()
     window.removeEventListener('open-file-manager', handleOpenFileManager)
     window.removeEventListener('open-file-overlay', handleOpenFileOverlay)

--- a/web/src/components/chat/AcpSessionDrawer.vue
+++ b/web/src/components/chat/AcpSessionDrawer.vue
@@ -1,5 +1,5 @@
 <template>
-  <BottomSheet :open="open" auto :title="drawerTitle" @close="$emit('close')">
+  <BottomSheet :open="open" auto wide :title="drawerTitle" @close="$emit('close')">
     <template #header>
       <RotateCwIcon v-if="acpSessionsLoading" :size="16" class="bs-header-icon spin" />
       <HistoryIcon v-else :size="16" class="bs-header-icon" />

--- a/web/src/components/chat/ChatPanelContent.vue
+++ b/web/src/components/chat/ChatPanelContent.vue
@@ -191,6 +191,9 @@ const TAG = 'ChatPanel'
 
 const props = defineProps({
     active: Boolean,
+    // Focus-aware keyboard gating: global chat shortcuts (Ctrl+←/→, Ctrl+Delete)
+    // fire only when the chat pane is the one the user is working in.
+    keyboardActive: { type: Boolean, default: true },
     currentFile: Object,
     currentDir: String,
 })
@@ -899,7 +902,7 @@ async function handleResumeSession({ sessionId, sessionTitle }) {
 
 // Desktop: Ctrl+Left/Right to switch sessions (always enabled, independent of swipeSession toggle)
 function handleCtrlArrowSessionSwitch(e) {
-  if (!props.active) return
+  if (!props.keyboardActive) return
   const tag = e.target?.tagName
   if (tag === 'INPUT' || tag === 'TEXTAREA') return
   if (e.target?.closest?.('.terminal-panel')) return
@@ -915,7 +918,7 @@ function handleCtrlArrowSessionSwitch(e) {
 
 // Desktop: Ctrl+Delete to archive current session
 function handleDeleteKey(e) {
-  if (!props.active) return
+  if (!props.keyboardActive) return
   if (e.key !== 'Delete' || !(e.ctrlKey || e.metaKey)) return
   inputBarRef.value?.handleDelete()
 }

--- a/web/src/components/common/AgentSelectorDrawer.vue
+++ b/web/src/components/common/AgentSelectorDrawer.vue
@@ -1,5 +1,5 @@
 <template>
-  <BottomSheet :open="open" auto @close="handleClose">
+  <BottomSheet :open="open" auto wide @close="handleClose">
     <template #header>
       <Bot :size="16" class="bs-header-icon" />
       <span class="bs-header-title">{{ title }}</span>

--- a/web/src/components/common/BottomSheet.vue
+++ b/web/src/components/common/BottomSheet.vue
@@ -10,7 +10,7 @@
       @click.self="handleClose"
       @keydown.escape="handleEscapeKey"
     >
-      <div class="bs-panel" :class="{ 'bs-leaving': leaving, 'bs-instant': instant, 'bs-compact': compact, 'bs-auto': auto, 'bs-handle-only': handleOnly }">
+      <div class="bs-panel" :class="{ 'bs-leaving': leaving, 'bs-instant': instant, 'bs-compact': compact, 'bs-auto': auto, 'bs-handle-only': handleOnly, 'bs-wide': wide }">
         <!-- Header -->
         <div v-if="!noHeader" class="bs-header" :class="{ 'bs-header-handle-only': handleOnly }" @click="handleClose">
           <div class="bs-handle" />
@@ -47,6 +47,7 @@ const props = defineProps({
   auto: Boolean,     // 自适应模式，高度按内容需要，最大全屏
   noHeader: Boolean, // 隐藏Header（含手柄）
   handleOnly: Boolean, // 仅显示拖拽手柄，无标题栏
+  wide: Boolean, // 大屏模式放宽面板宽度（默认 560px → 820px）
   transparentOverlay: Boolean, // 透明遮罩（可点击关闭但可见底层内容）
   fullscreen: Boolean, // 全屏模式，覆盖 app header，用于无 header 的页面（如终端）
   closeGuard: Boolean, // 阻止一切关闭操作（overlay点击/header点击/返回手势），用于内部有原生选择器等场景
@@ -359,5 +360,17 @@ defineExpose({
   top: 0;
   bottom: 0;
   z-index: 1200;
+}
+
+/* Big-screen (≥1024px): constrain bottom-sheet width and center it.
+   Keep narrow screens full-width. */
+@media (min-width: 1024px) {
+  .bs-panel {
+    max-width: 560px;
+    margin: 0 auto;
+  }
+  .bs-panel.bs-wide {
+    max-width: 820px;
+  }
 }
 </style>

--- a/web/src/components/common/BottomSheet.vue
+++ b/web/src/components/common/BottomSheet.vue
@@ -126,10 +126,14 @@ onBeforeUnmount(() => {
 })
 
 function handleEscapeKey(e) {
-  // Don't close if focus is inside an input/textarea/contenteditable —
-  // let the native Escape behavior (blur/IME cancel) happen first
+  // If focus is inside an input/textarea/contenteditable, blur first and
+  // move focus back to the overlay so the next ESC closes the drawer
   const tag = e.target?.tagName
-  if (tag === 'INPUT' || tag === 'TEXTAREA' || e.target?.isContentEditable) return
+  if (tag === 'INPUT' || tag === 'TEXTAREA' || e.target?.isContentEditable) {
+    e.target.blur()
+    overlayRef.value?.focus()
+    return
+  }
   handleClose()
 }
 

--- a/web/src/components/common/SearchDrawer.vue
+++ b/web/src/components/common/SearchDrawer.vue
@@ -36,7 +36,7 @@
 
 <script setup>
 import { Search } from 'lucide-vue-next'
-import { ref, computed, watch, nextTick } from 'vue'
+import { ref, computed, watch } from 'vue'
 import { useI18n } from 'vue-i18n'
 import BottomSheet from './BottomSheet.vue'
 import HeaderMarquee from './HeaderMarquee.vue'

--- a/web/src/components/common/SearchDrawer.vue
+++ b/web/src/components/common/SearchDrawer.vue
@@ -65,7 +65,8 @@ const isRenderedView = computed(() => {
 
 watch(() => props.open, async (val) => {
   if (val) {
-    await nextTick()
+    // Wait for BottomSheet slide-up animation (250ms) to complete before focusing
+    await new Promise(r => setTimeout(r, 300))
     inputRef.value?.focus()
   }
 })

--- a/web/src/components/common/SplitView.vue
+++ b/web/src/components/common/SplitView.vue
@@ -1,0 +1,188 @@
+<template>
+  <div ref="rootRef" class="split-view" :class="{ 'split-view--active': enabled }">
+    <div class="split-view__left" :style="leftStyle">
+      <slot name="left" />
+    </div>
+    <div
+      v-if="enabled"
+      ref="dividerRef"
+      class="split-view__divider"
+      role="separator"
+      aria-orientation="vertical"
+      :aria-valuenow="Math.round(internalRatio * 100)"
+      :aria-valuemin="Math.round(minLeftRatio)"
+      :aria-valuemax="Math.round(maxLeftRatio)"
+      :title="title"
+      @pointerdown="onDividerPointerDown"
+    >
+      <div class="split-view__gutter-line" />
+    </div>
+    <div class="split-view__right">
+      <slot name="right" />
+    </div>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { computed, onBeforeUnmount, onMounted, ref, watch } from 'vue'
+import { clampRatio, normalizeRatio, MIN_PANEL_WIDTH } from '@/utils/splitRatio'
+
+const props = withDefaults(defineProps<{
+  enabled: boolean
+  ratio?: number
+  minLeft?: number
+  minRight?: number
+  gutterSize?: number
+  title?: string
+}>(), {
+  ratio: 0.5,
+  minLeft: MIN_PANEL_WIDTH,
+  minRight: MIN_PANEL_WIDTH,
+  gutterSize: 6,
+  title: '拖动调整面板宽度',
+})
+
+const emit = defineEmits<{ (e: 'update:ratio', ratio: number): void }>()
+
+const rootRef = ref<HTMLDivElement | null>(null)
+const dividerRef = ref<HTMLDivElement | null>(null)
+const internalRatio = ref(normalizeRatio(props.ratio))
+const containerWidth = ref(0)
+let dragActive = false
+let observer: ResizeObserver | null = null
+
+watch(() => props.ratio, (r) => {
+  internalRatio.value = normalizeRatio(r)
+})
+
+const leftStyle = computed(() => {
+  if (!props.enabled) return {}
+  return { width: `${internalRatio.value * 100}%` }
+})
+
+const minLeftRatio = computed(() => (containerWidth.value > 0 ? props.minLeft / containerWidth.value : 0))
+const maxLeftRatio = computed(() => (containerWidth.value > 0 ? 1 - props.minRight / containerWidth.value : 1))
+
+function measureContainer() {
+  if (rootRef.value) containerWidth.value = rootRef.value.getBoundingClientRect().width
+}
+
+function onMove(e: PointerEvent) {
+  const rect = rootRef.value?.getBoundingClientRect()
+  if (!rect || rect.width <= 0) return
+  const raw = (e.clientX - rect.left) / rect.width
+  const ratio = clampRatio(raw, rect.width, props.minLeft, props.minRight)
+  internalRatio.value = ratio
+  emit('update:ratio', ratio)
+}
+
+function onDividerPointerDown(e: PointerEvent) {
+  if (e.button !== 0) return
+  dragActive = true
+  dividerRef.value?.setPointerCapture?.(e.pointerId)
+  document.body.classList.add('split-view-dragging')
+  onMove(e)
+}
+
+function onPointerMove(e: PointerEvent) {
+  if (dragActive) onMove(e)
+}
+
+function onPointerUp(e: PointerEvent) {
+  if (!dragActive) return
+  dragActive = false
+  dividerRef.value?.releasePointerCapture?.(e.pointerId)
+  document.body.classList.remove('split-view-dragging')
+}
+
+onMounted(() => {
+  measureContainer()
+  if (typeof ResizeObserver !== 'undefined') {
+    observer = new ResizeObserver(measureContainer)
+    if (rootRef.value) observer.observe(rootRef.value)
+  }
+  window.addEventListener('pointermove', onPointerMove)
+  window.addEventListener('pointerup', onPointerUp)
+  window.addEventListener('pointercancel', onPointerUp)
+})
+
+onBeforeUnmount(() => {
+  observer?.disconnect()
+  window.removeEventListener('pointermove', onPointerMove)
+  window.removeEventListener('pointerup', onPointerUp)
+  window.removeEventListener('pointercancel', onPointerUp)
+  document.body.classList.remove('split-view-dragging')
+})
+</script>
+
+<style scoped>
+.split-view {
+  position: relative;
+  height: 100%;
+  width: 100%;
+}
+.split-view--active {
+  display: flex;
+  flex-direction: row;
+  align-items: stretch;
+}
+.split-view__left,
+.split-view__right {
+  position: absolute;
+  inset: 0;
+}
+.split-view--active .split-view__left,
+.split-view--active .split-view__right {
+  position: relative;
+  inset: auto;
+  height: 100%;
+}
+.split-view--active .split-view__left {
+  flex: 0 0 auto;
+  min-width: 320px;
+  max-width: calc(100% - 320px - 6px);
+}
+.split-view--active .split-view__right {
+  flex: 1 1 auto;
+  min-width: 320px;
+}
+/* Divider: narrow by default, wider hit-area + highlight on hover/touch */
+.split-view__divider {
+  position: relative;
+  flex: 0 0 auto;
+  width: 6px;
+  cursor: col-resize;
+  touch-action: none;
+  -webkit-tap-highlight-color: transparent;
+}
+.split-view__divider::before {
+  content: '';
+  position: absolute;
+  top: 0;
+  bottom: 0;
+  left: -4px;
+  right: -4px;
+}
+.split-view__divider:hover,
+.split-view__divider:active {
+  background: color-mix(in srgb, var(--accent-color, #0066cc) 12%, transparent);
+}
+.split-view__gutter-line {
+  position: absolute;
+  left: 50%;
+  top: 0;
+  bottom: 0;
+  width: 2px;
+  transform: translateX(-50%);
+  background: var(--border-color, rgba(0, 0, 0, 0.12));
+  transition: background 0.15s ease;
+}
+.split-view__divider:hover .split-view__gutter-line,
+.split-view__divider:active .split-view__gutter-line {
+  background: var(--accent-color, #0066cc);
+}
+body.split-view-dragging {
+  user-select: none;
+  cursor: col-resize;
+}
+</style>

--- a/web/src/components/common/SplitView.vue
+++ b/web/src/components/common/SplitView.vue
@@ -136,6 +136,14 @@ onBeforeUnmount(() => {
   position: absolute;
   inset: 0;
 }
+/* Disabled (single-column) mode: the wrappers are pure pass-throughs. If both
+   stayed absolutely positioned, the later one would overlay the other and,
+   when its slot content is v-show hidden, silently block every pointer event
+   (touch/scroll) on the visible pane — mobile regression on non-chat tabs. */
+.split-view:not(.split-view--active) .split-view__left,
+.split-view:not(.split-view--active) .split-view__right {
+  display: contents;
+}
 .split-view--active .split-view__left,
 .split-view--active .split-view__right {
   position: relative;

--- a/web/src/components/common/SplitView.vue
+++ b/web/src/components/common/SplitView.vue
@@ -43,7 +43,7 @@ const props = withDefaults(defineProps<{
   ratio: 0.5,
   minLeft: MIN_PANEL_WIDTH,
   minRight: MIN_PANEL_WIDTH,
-  gutterSize: 6,
+  gutterSize: 1,
   title: '拖动调整面板宽度',
 })
 
@@ -153,31 +153,39 @@ onBeforeUnmount(() => {
 .split-view--active .split-view__left {
   flex: 0 0 auto;
   min-width: 320px;
-  max-width: calc(100% - 320px - var(--split-gutter, 6px));
+  max-width: calc(100% - 320px - var(--split-gutter, 1px));
 }
 .split-view--active .split-view__right {
   flex: 1 1 auto;
   min-width: 320px;
 }
-/* Divider: narrow by default, wider hit-area + highlight on hover/touch */
+/* Divider: a single 1px line by default — no visible gap. On hover/drag it
+   expands (via negative margins so layout does NOT shift) into a grab-able
+   gap with an accent highlight. */
 .split-view__divider {
   position: relative;
   flex: 0 0 auto;
-  width: var(--split-gutter, 6px);
+  width: var(--split-gutter, 1px);
+  margin: 0;
   cursor: col-resize;
   touch-action: none;
   -webkit-tap-highlight-color: transparent;
+  z-index: 2;
+  transition: width 0.15s ease, margin 0.15s ease, background 0.15s ease;
 }
+/* invisible wider hit area so hover/touch can catch the 1px line */
 .split-view__divider::before {
   content: '';
   position: absolute;
   top: 0;
   bottom: 0;
-  left: -4px;
-  right: -4px;
+  left: -6px;
+  right: -6px;
 }
 .split-view__divider:hover,
 .split-view__divider:active {
+  width: 12px;
+  margin: 0 -5.5px;
   background: color-mix(in srgb, var(--accent-color, #0066cc) 12%, transparent);
 }
 .split-view__gutter-line {
@@ -185,7 +193,7 @@ onBeforeUnmount(() => {
   left: 50%;
   top: 0;
   bottom: 0;
-  width: 2px;
+  width: 1px;
   transform: translateX(-50%);
   background: var(--border-color, rgba(0, 0, 0, 0.12));
   transition: background 0.15s ease;

--- a/web/src/components/common/SplitView.vue
+++ b/web/src/components/common/SplitView.vue
@@ -1,5 +1,10 @@
 <template>
-  <div ref="rootRef" class="split-view" :class="{ 'split-view--active': enabled }">
+  <div
+    ref="rootRef"
+    class="split-view"
+    :class="{ 'split-view--active': enabled }"
+    :style="{ '--split-gutter': `${gutterSize}px` }"
+  >
     <div class="split-view__left" :style="leftStyle">
       <slot name="left" />
     </div>
@@ -10,8 +15,8 @@
       role="separator"
       aria-orientation="vertical"
       :aria-valuenow="Math.round(internalRatio * 100)"
-      :aria-valuemin="Math.round(minLeftRatio)"
-      :aria-valuemax="Math.round(maxLeftRatio)"
+      :aria-valuemin="Math.round(minLeftRatio * 100)"
+      :aria-valuemax="Math.round(maxLeftRatio * 100)"
       :title="title"
       @pointerdown="onDividerPointerDown"
     >
@@ -140,7 +145,7 @@ onBeforeUnmount(() => {
 .split-view--active .split-view__left {
   flex: 0 0 auto;
   min-width: 320px;
-  max-width: calc(100% - 320px - 6px);
+  max-width: calc(100% - 320px - var(--split-gutter, 6px));
 }
 .split-view--active .split-view__right {
   flex: 1 1 auto;
@@ -150,7 +155,7 @@ onBeforeUnmount(() => {
 .split-view__divider {
   position: relative;
   flex: 0 0 auto;
-  width: 6px;
+  width: var(--split-gutter, 6px);
   cursor: col-resize;
   touch-action: none;
   -webkit-tap-highlight-color: transparent;

--- a/web/src/components/common/SplitView.vue
+++ b/web/src/components/common/SplitView.vue
@@ -186,7 +186,7 @@ onBeforeUnmount(() => {
 .split-view__divider:active .split-view__gutter-line {
   background: var(--accent-color, #0066cc);
 }
-body.split-view-dragging {
+:global(body.split-view-dragging) {
   user-select: none;
   cursor: col-resize;
 }

--- a/web/src/components/common/__tests__/BottomSheet.test.ts
+++ b/web/src/components/common/__tests__/BottomSheet.test.ts
@@ -467,3 +467,25 @@ describe('BottomSheet unmount cleanup', () => {
     vi.advanceTimersByTime(300)
   })
 })
+
+describe('BottomSheet wide prop', () => {
+  let wrapper: VueWrapper<any> | null = null
+
+  afterEach(() => {
+    if (wrapper) {
+      wrapper.unmount()
+      wrapper = null
+    }
+    document.body.querySelectorAll('.bs-overlay').forEach(el => el.remove())
+  })
+
+  it('adds bs-wide class to the panel when wide=true', () => {
+    wrapper = mountSheet({ wide: true })
+    expect($('.bs-panel')?.classList.contains('bs-wide')).toBe(true)
+  })
+
+  it('does not add bs-wide class by default', () => {
+    wrapper = mountSheet({})
+    expect($('.bs-panel')?.classList.contains('bs-wide')).toBe(false)
+  })
+})

--- a/web/src/components/common/__tests__/SplitView.test.ts
+++ b/web/src/components/common/__tests__/SplitView.test.ts
@@ -61,4 +61,21 @@ describe('SplitView', () => {
     // 100px / 1000 = 0.1, clamped up to 320/1000 = 0.32
     expect(emitted[emitted.length - 1][0]).toBeCloseTo(0.32)
   })
+
+  it('gutterSize prop drives the divider width via --split-gutter CSS var', () => {
+    wrapper = mountSplit({ enabled: true, ratio: 0.5, gutterSize: 12 })
+    const root = wrapper.find('.split-view').element as HTMLElement
+    expect(root.style.getPropertyValue('--split-gutter')).toBe('12px')
+  })
+
+  it('aria-valuenow/min/max are on the same percentage scale', async () => {
+    const rect = { left: 0, width: 1000, top: 0, bottom: 0, height: 600, right: 1000, x: 0, y: 0, toJSON() {} }
+    vi.spyOn(Element.prototype, 'getBoundingClientRect').mockReturnValue(rect as DOMRect)
+    wrapper = mountSplit({ enabled: true, ratio: 0.5 })
+    await nextTick()
+    const divider = wrapper.find('.split-view__divider').element as HTMLElement
+    expect(divider.getAttribute('aria-valuenow')).toBe('50')
+    expect(divider.getAttribute('aria-valuemin')).toBe('32')
+    expect(divider.getAttribute('aria-valuemax')).toBe('68')
+  })
 })

--- a/web/src/components/common/__tests__/SplitView.test.ts
+++ b/web/src/components/common/__tests__/SplitView.test.ts
@@ -1,0 +1,64 @@
+import { describe, expect, it, vi, afterEach } from 'vitest'
+import { mount, VueWrapper } from '@vue/test-utils'
+import { nextTick } from 'vue'
+import SplitView from '@/components/common/SplitView.vue'
+
+vi.mock('@/utils/appLog', () => ({
+  appLog: { d: vi.fn(), i: vi.fn(), w: vi.fn(), e: vi.fn() },
+}))
+
+function mountSplit(props = {}) {
+  return mount(SplitView, {
+    props,
+    slots: {
+      left: '<div class="pane-left">L</div>',
+      right: '<div class="pane-right">R</div>',
+    },
+    attachTo: document.body,
+  })
+}
+
+let wrapper: VueWrapper | null = null
+afterEach(() => {
+  wrapper?.unmount()
+  wrapper = null
+  vi.restoreAllMocks()
+})
+
+describe('SplitView', () => {
+  it('enabled=false: no divider, panes render inline', () => {
+    wrapper = mountSplit({ enabled: false })
+    expect(wrapper.find('.split-view__divider').exists()).toBe(false)
+    expect(wrapper.find('.pane-left').text()).toBe('L')
+    expect(wrapper.find('.pane-right').text()).toBe('R')
+  })
+
+  it('enabled=true: renders divider and left width follows ratio', async () => {
+    wrapper = mountSplit({ enabled: true, ratio: 0.4 })
+    expect(wrapper.find('.split-view__divider').exists()).toBe(true)
+    const left = wrapper.find('.split-view__left')
+    await nextTick()
+    expect(left.attributes('style')).toContain('width: 40%')
+  })
+
+  it('emits update:ratio on divider drag, clamped to min widths', async () => {
+    wrapper = mountSplit({ enabled: true, ratio: 0.5 })
+    const divider = wrapper.find('.split-view__divider').element as HTMLElement
+    divider.setPointerCapture = vi.fn()
+    divider.releasePointerCapture = vi.fn()
+
+    Object.defineProperty(wrapper.find('.split-view').element, 'getBoundingClientRect', {
+      configurable: true,
+      value: () => ({ left: 0, width: 1000, top: 0, bottom: 0, height: 600, right: 1000, x: 0, y: 0, toJSON() {} }),
+    })
+
+    divider.dispatchEvent(new PointerEvent('pointerdown', { pointerId: 1, button: 0, bubbles: true, clientX: 300 }))
+    window.dispatchEvent(new PointerEvent('pointermove', { pointerId: 1, bubbles: true, clientX: 100 }))
+    window.dispatchEvent(new PointerEvent('pointerup', { pointerId: 1, bubbles: true }))
+
+    const emitted = wrapper.emitted('update:ratio') as Array<Array<number>>
+    expect(emitted).toBeTruthy()
+    // 100px / 1000 = 0.1, clamped up to 320/1000 = 0.32
+    expect(emitted[emitted.length - 1][0]).toBeCloseTo(0.32)
+  })
+})

--- a/web/src/components/common/__tests__/SplitView.test.ts
+++ b/web/src/components/common/__tests__/SplitView.test.ts
@@ -33,6 +33,24 @@ describe('SplitView', () => {
     expect(wrapper.find('.pane-right').text()).toBe('R')
   })
 
+  it('enabled=false: wrappers are display:contents (no absolute overlay blocking pointer events)', () => {
+    // Regression: if the disabled-mode wrappers stayed position:absolute, the
+    // later one would overlay the visible pane and swallow all touch/scroll.
+    wrapper = mountSplit({ enabled: false })
+    const left = wrapper.find('.split-view__left').element as HTMLElement
+    const right = wrapper.find('.split-view__right').element as HTMLElement
+    expect(getComputedStyle(left).display).toBe('contents')
+    expect(getComputedStyle(right).display).toBe('contents')
+  })
+
+  it('enabled=true: wrappers are positioned flex panes (not display:contents)', async () => {
+    wrapper = mountSplit({ enabled: true, ratio: 0.5 })
+    const left = wrapper.find('.split-view__left').element as HTMLElement
+    const right = wrapper.find('.split-view__right').element as HTMLElement
+    expect(getComputedStyle(left).display).not.toBe('contents')
+    expect(getComputedStyle(right).display).not.toBe('contents')
+  })
+
   it('enabled=true: renders divider and left width follows ratio', async () => {
     wrapper = mountSplit({ enabled: true, ratio: 0.4 })
     expect(wrapper.find('.split-view__divider').exists()).toBe(true)

--- a/web/src/components/file/DiffDrawer.vue
+++ b/web/src/components/file/DiffDrawer.vue
@@ -2,6 +2,7 @@
   <BottomSheet
     :open="visible"
     :auto="true"
+    wide
     :transparent-overlay="true"
     @close="emit('close')"
   >

--- a/web/src/components/file/FileDetailsDrawer.vue
+++ b/web/src/components/file/FileDetailsDrawer.vue
@@ -1,5 +1,5 @@
 <template>
-  <BottomSheet :open="open" auto @close="$emit('close')">
+  <BottomSheet :open="open" auto wide @close="$emit('close')">
     <template #header>
       <FileIcon :path="file?.name || ''" :size="16" class="bs-header-icon" />
       <span class="bs-header-title">{{ t('file.details.title') }}</span>

--- a/web/src/components/file/FileManagerContent.vue
+++ b/web/src/components/file/FileManagerContent.vue
@@ -184,6 +184,8 @@
         <div
           v-long-press="(e) => onLongPress(entry, e)"
           class="file-item"
+          :draggable="isBigScreen"
+          @dragstart="onItemDragStart(entry, $event)"
           :class="{
             'dir-item': entry.type === 'dir',
             active: !multiSelect.active && selectedPath === itemPath(entry.name),
@@ -244,6 +246,8 @@
       <div v-for="entry in visibleEntries" :key="entry.name"
         v-long-press="(e) => onLongPress(entry, e)"
         class="grid-item"
+        :draggable="isBigScreen"
+        @dragstart="onItemDragStart(entry, $event)"
         :class="{
           'grid-dir': entry.type === 'dir',
           'grid-active': !multiSelect.active && selectedPath === itemPath(entry.name),
@@ -397,6 +401,8 @@ import { useTerminalStatus } from '@/composables/useTerminalStatus.ts'
 import { useFeatureBackHandler, PRIORITY_PAGE } from '@/composables/useEdgeSwipeBack'
 import { useFileUpload } from '@/composables/useFileUpload.ts'
 import { useChatContext } from '@/composables/useChatContext.ts'
+import { useBigScreenLayout } from '@/composables/useBigScreenLayout'
+import { setAttachDragData, hasAttachDragData } from '@/utils/attachDrag'
 import { downloadFileByPath } from '@/utils/download.ts'
 import { useFileNavStack } from '@/composables/useFileNavStack'
 import { useToolbarOverflow } from '@/composables/useToolbarOverflow'
@@ -433,7 +439,9 @@ async function onUploadFileSelect(e) {
 
 // ── Drag-and-drop handlers (file-list / file-grid) ──
 
-function onDragEnter() {
+function onDragEnter(e) {
+  // Internal drags (file → chat) must not trigger the OS "drop to upload" overlay
+  if (hasAttachDragData(e.dataTransfer)) return
   dragCounter.value++
   isDragOver.value = true
 }
@@ -453,6 +461,14 @@ async function onDrop(e) {
   if (files.length === 0) return
   await handleFileDropToDir(files, props.currentDir || '.')
   emit('refresh')
+}
+
+/** Start an internal drag of a file/dir so it can be dropped onto the chat column. */
+function onItemDragStart(entry, e) {
+  if (!isBigScreen.value) return
+  const path = itemPath(entry.name)
+  setAttachDragData(e.dataTransfer, path, entry.type === 'dir')
+  e.dataTransfer.effectAllowed = 'copy'
 }
 
 // ── Clipboard paste handler ──
@@ -503,6 +519,7 @@ const dialog = useDialog()
 const { addAttachedFile, hasAttachedFile, removeAttachedFileByPath } = useChatContext()
 const { terminalRuntimeEnabled } = useTerminalStatus()
 const isTerminalDisabled = computed(() => terminalRuntimeEnabled.value !== true)
+const { isBigScreen } = useBigScreenLayout()
 
 const activeTab = inject('activeTab', ref(''))
 
@@ -529,6 +546,7 @@ const props = defineProps({
     dirLoading: Boolean,
     searchDrawer: Object, // TabDrawer from useTabDrawer('browse')
     recentDrawer: Object, // TabDrawer from useTabDrawer('browse')
+    keyboardActive: { type: Boolean, default: true }, // focus-aware gating for global file shortcuts
 })
 
 const emit = defineEmits(['navigateDir', 'navigateBack', 'selectFile', 'toggleSort', 'toggleHidden', 'rename', 'delete', 'refresh', 'openTerminal', 'batchDelete'])
@@ -1241,6 +1259,8 @@ function doDelete() {
 function handleKeydown(e) {
     // Only active when browse tab is focused
     if (activeTab.value !== 'browse') return
+    // Focus-aware: in big-screen mode also require the left pane to be focused
+    if (props.keyboardActive === false) return
     // Skip in Android app mode
     if (isAppMode.value) return
     // Skip if a dialog/prompt is open (don't interfere with input fields)

--- a/web/src/components/file/FileSearchDrawer.vue
+++ b/web/src/components/file/FileSearchDrawer.vue
@@ -85,7 +85,7 @@
 </template>
 
 <script setup lang="ts">
-import { ref, watch, nextTick, computed } from 'vue'
+import { ref, watch, computed } from 'vue'
 import { useI18n } from 'vue-i18n'
 import { Search, FolderTree, Globe, RotateCcw, FolderOpen } from 'lucide-vue-next'
 import BottomSheet from '@/components/common/BottomSheet.vue'

--- a/web/src/components/file/FileSearchDrawer.vue
+++ b/web/src/components/file/FileSearchDrawer.vue
@@ -127,7 +127,8 @@ const headerTitle = computed(() => {
 // Focus input when drawer opens
 watch(() => props.open, async (val) => {
   if (val) {
-    await nextTick()
+    // Wait for BottomSheet slide-up animation (250ms) to complete before focusing
+    await new Promise(r => setTimeout(r, 300))
     inputRef.value?.focus()
     // Re-run search if query exists (results may be stale)
     if (search.state.query.trim()) {

--- a/web/src/components/file/FileSearchDrawer.vue
+++ b/web/src/components/file/FileSearchDrawer.vue
@@ -1,5 +1,5 @@
 <template>
-  <BottomSheet :open="open" auto @close="handleClose">
+  <BottomSheet :open="open" auto wide @close="handleClose">
     <template #header>
       <Search :size="16" class="bs-header-icon" />
       <span class="bs-header-title">{{ headerTitle }}</span>

--- a/web/src/components/file/RecentFilesDrawer.vue
+++ b/web/src/components/file/RecentFilesDrawer.vue
@@ -1,5 +1,5 @@
 <template>
-  <BottomSheet :open="open" auto @close="handleClose">
+  <BottomSheet :open="open" auto wide @close="handleClose">
     <template #header>
       <FileStack :size="16" class="bs-header-icon" />
       <span class="bs-header-title">{{ t('file.recent.title') }}</span>

--- a/web/src/components/git/GitHistoryDrawer.vue
+++ b/web/src/components/git/GitHistoryDrawer.vue
@@ -1,5 +1,5 @@
 <template>
-  <BottomSheet ref="bottomSheetRef" :open="open" @close="handleClose">
+  <BottomSheet ref="bottomSheetRef" :open="open" wide @close="handleClose">
     <template #header>
       <GitBranch :size="16" class="bs-header-icon" />
       <span class="bs-header-title">{{ mode === 'file' ? t('git.history.fileHistory') : t('git.history.projectHistory') }}</span>

--- a/web/src/components/session/SessionDrawer.vue
+++ b/web/src/components/session/SessionDrawer.vue
@@ -1,5 +1,5 @@
 <template>
-  <BottomSheet ref="bottomSheetRef" :open="open" auto :title="t('session.title')" @close="$emit('close')">
+  <BottomSheet ref="bottomSheetRef" :open="open" auto wide :title="t('session.title')" @close="$emit('close')">
     <template #header>
       <Bot :size="16" class="bs-header-icon" />
       <span class="bs-header-title">{{ t('session.title') }}</span>

--- a/web/src/components/session/SessionSearchDrawer.vue
+++ b/web/src/components/session/SessionSearchDrawer.vue
@@ -1,5 +1,5 @@
 <template>
-  <BottomSheet :open="open" auto @close="handleClose">
+  <BottomSheet :open="open" auto wide @close="handleClose">
     <template #header>
       <!-- Search results list view -->
       <template v-if="!selectedSession">

--- a/web/src/components/session/SessionSearchDrawer.vue
+++ b/web/src/components/session/SessionSearchDrawer.vue
@@ -271,7 +271,8 @@ function getPreviewHtml(session: SessionSearchResult) {
 // ── Lifecycle ──
 watch(() => props.open, async (val) => {
   if (val) {
-    await nextTick()
+    // Wait for BottomSheet slide-up animation (250ms) to complete before focusing
+    await new Promise(r => setTimeout(r, 300))
     inputRef.value?.focus()
   } else {
     search.clear()

--- a/web/src/composables/__tests__/useBigScreenLayout.test.ts
+++ b/web/src/composables/__tests__/useBigScreenLayout.test.ts
@@ -1,4 +1,4 @@
-import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import {
   useBigScreenLayout,
   getBigScreenState,
@@ -65,6 +65,11 @@ describe('useBigScreenLayout', () => {
     expect(leftTab.value).toBe('settings')
   })
 
+  it('fresh init with no persisted ratio keeps splitRatio at 0.5', () => {
+    const { splitRatio } = useBigScreenLayout()
+    expect(splitRatio.value).toBe(0.5)
+  })
+
   it('big-screen mode makes getBigScreenState expose chat + leftTab as active tabs', () => {
     const { isBigScreen, leftTab } = getBigScreenState()
     _setBigScreenForTest(true)
@@ -75,6 +80,10 @@ describe('useBigScreenLayout', () => {
 })
 
 describe('useBigScreenLayout matchMedia wiring', () => {
+  afterEach(() => {
+    vi.unstubAllGlobals()
+  })
+
   it('reflects matchMedia matches and change events', async () => {
     vi.resetModules()
     const listeners: Array<(e: { matches: boolean }) => void> = []
@@ -89,6 +98,5 @@ describe('useBigScreenLayout matchMedia wiring', () => {
     mql.matches = false
     listeners.forEach((cb) => cb({ matches: false }))
     expect(mod.getBigScreenState().isBigScreen.value).toBe(false)
-    vi.unstubAllGlobals()
   })
 })

--- a/web/src/composables/__tests__/useBigScreenLayout.test.ts
+++ b/web/src/composables/__tests__/useBigScreenLayout.test.ts
@@ -11,6 +11,7 @@ import {
   resolveLeftTabOnEnter,
   resolveActivePaneOnEnter,
   setActivePane,
+  computeIsBigScreen,
   BIG_SCREEN_DOCK_TABS,
   LEFT_TAB_KEY,
   SPLIT_RATIO_KEY,
@@ -22,8 +23,38 @@ beforeEach(() => {
   localStorage.clear()
 })
 
+describe('computeIsBigScreen', () => {
+  it('desktop: CSS width ≥1024 → big screen', () => {
+    expect(computeIsBigScreen(1280, 800, 1)).toBe(true)
+    expect(computeIsBigScreen(1024, 768, 1)).toBe(true)
+  })
+
+  it('high-DPR tablet landscape (CSS <1024) → big screen via physical width', () => {
+    // 2400 physical px at DPR 2.5 → CSS 960 (the user's tablet case)
+    expect(computeIsBigScreen(960, 600, 2.5)).toBe(true)
+  })
+
+  it('high-DPR phone portrait → NOT big screen (landscape gate)', () => {
+    // 430×3 = 1290 physical ≥1280, but portrait
+    expect(computeIsBigScreen(430, 900, 3)).toBe(false)
+  })
+
+  it('high-DPR phone landscape → big screen (wide physical viewport)', () => {
+    expect(computeIsBigScreen(844, 390, 3)).toBe(true)
+  })
+
+  it('small CSS width and small physical width → NOT big screen', () => {
+    expect(computeIsBigScreen(800, 1280, 1)).toBe(false)
+    expect(computeIsBigScreen(360, 800, 2)).toBe(false) // 720 physical
+  })
+})
+
 describe('useBigScreenLayout', () => {
-  it('matchMedia absent → isBigScreen stays false and does not throw', () => {
+  it('initializes big-screen from the viewport and does not throw', () => {
+    Object.defineProperty(window, 'innerWidth', { configurable: true, value: 800 })
+    Object.defineProperty(window, 'innerHeight', { configurable: true, value: 1280 })
+    Object.defineProperty(window, 'devicePixelRatio', { configurable: true, value: 1 })
+    _resetForTest()
     const { isBigScreen } = useBigScreenLayout()
     expect(isBigScreen.value).toBe(false)
   })
@@ -122,24 +153,31 @@ describe('activePane focus tracking', () => {
   })
 })
 
-describe('useBigScreenLayout matchMedia wiring', () => {
+describe('useBigScreenLayout viewport wiring', () => {
   afterEach(() => {
     vi.unstubAllGlobals()
   })
 
-  it('reflects matchMedia matches and change events', async () => {
+  it('activates for a high-DPR landscape tablet and reacts to resize/rotation', async () => {
     vi.resetModules()
-    const listeners: Array<(e: { matches: boolean }) => void> = []
-    const mql = {
-      matches: true,
-      addEventListener: (_t: string, cb: (e: { matches: boolean }) => void) => { listeners.push(cb) },
-      removeEventListener: vi.fn(),
-    }
-    vi.stubGlobal('matchMedia', vi.fn(() => mql))
+    // 960 CSS × 2.5 = 2400 physical px, landscape → big screen
+    Object.defineProperty(window, 'innerWidth', { configurable: true, value: 960 })
+    Object.defineProperty(window, 'innerHeight', { configurable: true, value: 600 })
+    Object.defineProperty(window, 'devicePixelRatio', { configurable: true, value: 2.5 })
     const mod = await import('@/composables/useBigScreenLayout')
     expect(mod.getBigScreenState().isBigScreen.value).toBe(true)
-    mql.matches = false
-    listeners.forEach((cb) => cb({ matches: false }))
+
+    // Rotate to portrait → back to single column
+    Object.defineProperty(window, 'innerWidth', { configurable: true, value: 600 })
+    Object.defineProperty(window, 'innerHeight', { configurable: true, value: 960 })
+    window.dispatchEvent(new Event('resize'))
+    expect(mod.getBigScreenState().isBigScreen.value).toBe(false)
+
+    // Phone portrait, high DPR → stays single column
+    Object.defineProperty(window, 'innerWidth', { configurable: true, value: 430 })
+    Object.defineProperty(window, 'innerHeight', { configurable: true, value: 900 })
+    Object.defineProperty(window, 'devicePixelRatio', { configurable: true, value: 3 })
+    window.dispatchEvent(new Event('resize'))
     expect(mod.getBigScreenState().isBigScreen.value).toBe(false)
   })
 })

--- a/web/src/composables/__tests__/useBigScreenLayout.test.ts
+++ b/web/src/composables/__tests__/useBigScreenLayout.test.ts
@@ -8,6 +8,7 @@ import {
   registerBigScreenCallbacks,
   _setBigScreenForTest,
   _resetForTest,
+  resolveLeftTabOnEnter,
   BIG_SCREEN_DOCK_TABS,
   LEFT_TAB_KEY,
   SPLIT_RATIO_KEY,
@@ -76,6 +77,22 @@ describe('useBigScreenLayout', () => {
     switchLeftTab('terminal')
     expect(isBigScreen.value).toBe(true)
     expect(leftTab.value).toBe('terminal')
+  })
+})
+
+describe('resolveLeftTabOnEnter', () => {
+  it('adopts a non-chat activeTab as the left tab', () => {
+    expect(resolveLeftTabOnEnter('terminal', 'browse')).toBe('terminal')
+    expect(resolveLeftTabOnEnter('settings', 'browse')).toBe('settings')
+  })
+
+  it('keeps persisted leftTab when activeTab is chat', () => {
+    expect(resolveLeftTabOnEnter('chat', 'settings')).toBe('settings')
+    expect(resolveLeftTabOnEnter('chat', 'browse')).toBe('browse')
+  })
+
+  it('falls back to browse for invalid persisted value', () => {
+    expect(resolveLeftTabOnEnter('chat', 'not-a-tab')).toBe('browse')
   })
 })
 

--- a/web/src/composables/__tests__/useBigScreenLayout.test.ts
+++ b/web/src/composables/__tests__/useBigScreenLayout.test.ts
@@ -1,0 +1,94 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import {
+  useBigScreenLayout,
+  getBigScreenState,
+  switchLeftTab,
+  setSplitRatio,
+  resetBigScreenState,
+  registerBigScreenCallbacks,
+  _setBigScreenForTest,
+  _resetForTest,
+  BIG_SCREEN_DOCK_TABS,
+  LEFT_TAB_KEY,
+  SPLIT_RATIO_KEY,
+} from '@/composables/useBigScreenLayout'
+
+beforeEach(() => {
+  _resetForTest()
+  resetBigScreenState()
+  localStorage.clear()
+})
+
+describe('useBigScreenLayout', () => {
+  it('matchMedia absent → isBigScreen stays false and does not throw', () => {
+    const { isBigScreen } = useBigScreenLayout()
+    expect(isBigScreen.value).toBe(false)
+  })
+
+  it('leftTab defaults to browse and is clamped to allowed tabs', () => {
+    const { leftTab } = useBigScreenLayout()
+    expect(leftTab.value).toBe('browse')
+    expect(BIG_SCREEN_DOCK_TABS).toContain(leftTab.value)
+  })
+
+  it('switchLeftTab ignores invalid tabs and persists valid ones', () => {
+    switchLeftTab('terminal')
+    expect(localStorage.getItem(LEFT_TAB_KEY)).toBe('terminal')
+    switchLeftTab('not-a-tab' as never)
+    expect(localStorage.getItem(LEFT_TAB_KEY)).toBe('terminal')
+  })
+
+  it('switchLeftTab runs registered side-effects and activeTab setter, but only on change', () => {
+    const sideEffects = vi.fn()
+    const setActiveTab = vi.fn()
+    registerBigScreenCallbacks({ sideEffects, setActiveTab })
+
+    switchLeftTab('tasks')
+    expect(setActiveTab).toHaveBeenCalledWith('tasks')
+    expect(sideEffects).toHaveBeenCalledWith('tasks')
+
+    switchLeftTab('tasks') // same tab → early return
+    expect(sideEffects).toHaveBeenCalledTimes(1)
+  })
+
+  it('setSplitRatio normalizes and persists', () => {
+    setSplitRatio(1.9)
+    expect(Number(localStorage.getItem(SPLIT_RATIO_KEY))).toBe(1)
+    setSplitRatio(0.35)
+    expect(Number(localStorage.getItem(SPLIT_RATIO_KEY))).toBeCloseTo(0.35)
+  })
+
+  it('restores persisted leftTab on init', () => {
+    localStorage.setItem(LEFT_TAB_KEY, 'settings')
+    _resetForTest()
+    const { leftTab } = useBigScreenLayout()
+    expect(leftTab.value).toBe('settings')
+  })
+
+  it('big-screen mode makes getBigScreenState expose chat + leftTab as active tabs', () => {
+    const { isBigScreen, leftTab } = getBigScreenState()
+    _setBigScreenForTest(true)
+    switchLeftTab('terminal')
+    expect(isBigScreen.value).toBe(true)
+    expect(leftTab.value).toBe('terminal')
+  })
+})
+
+describe('useBigScreenLayout matchMedia wiring', () => {
+  it('reflects matchMedia matches and change events', async () => {
+    vi.resetModules()
+    const listeners: Array<(e: { matches: boolean }) => void> = []
+    const mql = {
+      matches: true,
+      addEventListener: (_t: string, cb: (e: { matches: boolean }) => void) => { listeners.push(cb) },
+      removeEventListener: vi.fn(),
+    }
+    vi.stubGlobal('matchMedia', vi.fn(() => mql))
+    const mod = await import('@/composables/useBigScreenLayout')
+    expect(mod.getBigScreenState().isBigScreen.value).toBe(true)
+    mql.matches = false
+    listeners.forEach((cb) => cb({ matches: false }))
+    expect(mod.getBigScreenState().isBigScreen.value).toBe(false)
+    vi.unstubAllGlobals()
+  })
+})

--- a/web/src/composables/__tests__/useBigScreenLayout.test.ts
+++ b/web/src/composables/__tests__/useBigScreenLayout.test.ts
@@ -9,6 +9,8 @@ import {
   _setBigScreenForTest,
   _resetForTest,
   resolveLeftTabOnEnter,
+  resolveActivePaneOnEnter,
+  setActivePane,
   BIG_SCREEN_DOCK_TABS,
   LEFT_TAB_KEY,
   SPLIT_RATIO_KEY,
@@ -93,6 +95,30 @@ describe('resolveLeftTabOnEnter', () => {
 
   it('falls back to browse for invalid persisted value', () => {
     expect(resolveLeftTabOnEnter('chat', 'not-a-tab')).toBe('browse')
+  })
+})
+
+describe('activePane focus tracking', () => {
+  it('resolveActivePaneOnEnter: chat → right, any left tab → left', () => {
+    expect(resolveActivePaneOnEnter('chat')).toBe('right')
+    expect(resolveActivePaneOnEnter('browse')).toBe('left')
+    expect(resolveActivePaneOnEnter('terminal')).toBe('left')
+  })
+
+  it('setActivePane updates the shared activePane ref', () => {
+    const { activePane } = useBigScreenLayout()
+    expect(activePane.value).toBe('right')
+    setActivePane('left')
+    expect(activePane.value).toBe('left')
+    setActivePane('right')
+    expect(activePane.value).toBe('right')
+  })
+
+  it('resetBigScreenState resets activePane to right', () => {
+    setActivePane('left')
+    resetBigScreenState()
+    const { activePane } = useBigScreenLayout()
+    expect(activePane.value).toBe('right')
   })
 })
 

--- a/web/src/composables/__tests__/useConnectionOverlay.test.ts
+++ b/web/src/composables/__tests__/useConnectionOverlay.test.ts
@@ -79,7 +79,7 @@ describe('useConnectionOverlay', () => {
         expect(overlay.mode.value).toBeNull()
     })
 
-    it('does NOT show when reconnected within the 1.5s window', async () => {
+    it('does NOT show when reconnected within the 5s window', async () => {
         hasConnectedOnceRef.value = true
         const overlay = make()
         wsStatusRef.value = 'disconnected'

--- a/web/src/composables/__tests__/useGlobalEvents.test.ts
+++ b/web/src/composables/__tests__/useGlobalEvents.test.ts
@@ -471,6 +471,37 @@ describe('useGlobalEvents', () => {
         })
     })
 
+    describe('reconnect state refresh event', () => {
+        it('does NOT dispatch clawbench-reconnect on the first connect (startup already loads state)', () => {
+            const dispatchSpy = vi.spyOn(window, 'dispatchEvent')
+            connectAndGetWs()
+
+            expect(dispatchSpy).not.toHaveBeenCalledWith(
+                expect.objectContaining({ type: 'clawbench-reconnect' })
+            )
+            dispatchSpy.mockRestore()
+        })
+
+        it('dispatches clawbench-reconnect on a reconnect (after a disconnect)', () => {
+            const dispatchSpy = vi.spyOn(window, 'dispatchEvent')
+
+            // First connection — no event
+            connectAndGetWs()
+            expect(dispatchSpy).not.toHaveBeenCalledWith(
+                expect.objectContaining({ type: 'clawbench-reconnect' })
+            )
+
+            // Disconnect, then reconnect — the event fires
+            events.disconnect()
+            connectAndGetWs()
+            expect(dispatchSpy).toHaveBeenCalledWith(
+                expect.objectContaining({ type: 'clawbench-reconnect' })
+            )
+
+            dispatchSpy.mockRestore()
+        })
+    })
+
     describe('processedEventIds eviction', () => {
         it('evicts old event IDs when exceeding MAX_PROCESSED_IDS', () => {
             const handler = vi.fn()

--- a/web/src/composables/__tests__/useTabDrawer.test.ts
+++ b/web/src/composables/__tests__/useTabDrawer.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it, beforeEach } from 'vitest'
 import { useTabDrawer, onTabSwitch, resetTabDrawerState } from '@/composables/useTabDrawer'
+import { _setBigScreenForTest, resetBigScreenState as resetBigScreen, switchLeftTab } from '@/composables/useBigScreenLayout'
 
 beforeEach(() => {
   resetTabDrawerState()
@@ -125,5 +126,39 @@ describe('useTabDrawer', () => {
     // effectiveOpen follows currentTab + openRef logic.
     onTabSwitch('browse')
     expect(drawer.effectiveOpen.value).toBe(drawer.isOpen.value && true)
+  })
+})
+
+describe('useTabDrawer big-screen awareness', () => {
+  beforeEach(() => {
+    resetBigScreen()
+    _setBigScreenForTest(false)
+  })
+
+  it('big-screen: chat and leftTab drawers both open simultaneously', () => {
+    _setBigScreenForTest(true)
+    switchLeftTab('browse')
+    const chatDrawer = useTabDrawer('chat')
+    const browseDrawer = useTabDrawer('browse')
+
+    chatDrawer.open()
+    browseDrawer.open()
+    expect(chatDrawer.effectiveOpen.value).toBe(true)
+    expect(browseDrawer.effectiveOpen.value).toBe(true)
+
+    switchLeftTab('terminal')
+    expect(browseDrawer.effectiveOpen.value).toBe(false)
+    expect(chatDrawer.effectiveOpen.value).toBe(true)
+  })
+
+  it('big-screen: autoRestore:false closes when leftTab switches away', () => {
+    _setBigScreenForTest(true)
+    switchLeftTab('browse')
+    const drawer = useTabDrawer('browse', { autoRestore: false })
+    drawer.open()
+    expect(drawer.effectiveOpen.value).toBe(true)
+
+    switchLeftTab('tasks')
+    expect(drawer.effectiveOpen.value).toBe(false)
   })
 })

--- a/web/src/composables/__tests__/useTabDrawer.test.ts
+++ b/web/src/composables/__tests__/useTabDrawer.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it, beforeEach } from 'vitest'
+import { nextTick } from 'vue'
 import { useTabDrawer, onTabSwitch, resetTabDrawerState } from '@/composables/useTabDrawer'
 import { _setBigScreenForTest, resetBigScreenState as resetBigScreen, switchLeftTab } from '@/composables/useBigScreenLayout'
 
@@ -151,7 +152,7 @@ describe('useTabDrawer big-screen awareness', () => {
     expect(chatDrawer.effectiveOpen.value).toBe(true)
   })
 
-  it('big-screen: autoRestore:false closes when leftTab switches away', () => {
+  it('big-screen: autoRestore:false closes when leftTab switches away', async () => {
     _setBigScreenForTest(true)
     switchLeftTab('browse')
     const drawer = useTabDrawer('browse', { autoRestore: false })
@@ -159,6 +160,8 @@ describe('useTabDrawer big-screen awareness', () => {
     expect(drawer.effectiveOpen.value).toBe(true)
 
     switchLeftTab('tasks')
+    await nextTick()
+    expect(drawer.isOpen.value).toBe(false)
     expect(drawer.effectiveOpen.value).toBe(false)
   })
 })

--- a/web/src/composables/__tests__/useTabDrawer.test.ts
+++ b/web/src/composables/__tests__/useTabDrawer.test.ts
@@ -5,6 +5,10 @@ import { _setBigScreenForTest, resetBigScreenState as resetBigScreen, switchLeft
 
 beforeEach(() => {
   resetTabDrawerState()
+  // Narrow-mode default: jsdom's innerWidth (1024) makes useBigScreenLayout's
+  // physical-width detection init to big-screen — force it off so the plain
+  // drawer tests exercise narrow behavior.
+  _setBigScreenForTest(false)
 })
 
 describe('useTabDrawer', () => {

--- a/web/src/composables/useBigScreenLayout.ts
+++ b/web/src/composables/useBigScreenLayout.ts
@@ -2,9 +2,25 @@ import { ref } from 'vue'
 import { normalizeRatio } from '@/utils/splitRatio'
 
 export const BIG_SCREEN_MIN_WIDTH = 1024
+// Physical (device-pixel) width threshold for the big-screen layout. CSS width
+// alone can miss high-resolution tablets whose devicePixelRatio shrinks the CSS
+// viewport below 1024 (e.g. 2400 physical px at DPR 2.5 → 960 CSS px).
+export const BIG_SCREEN_MIN_PHYSICAL_WIDTH = 1280
 export const LEFT_TAB_KEY = 'clawbench-bigscreen-left-tab'
 export const SPLIT_RATIO_KEY = 'clawbench-bigscreen-split-ratio'
 export const BIG_SCREEN_DOCK_TABS = ['browse', 'history', 'proxy', 'terminal', 'tasks', 'settings']
+
+/**
+ * Big-screen detection. Active when the CSS viewport is ≥1024px (desktop), or
+ * when the device's physical width (CSS width × devicePixelRatio) is ≥1280px
+ * AND the viewport is landscape. The landscape gate keeps high-DPR phones in
+ * portrait (e.g. 430×3 = 1290) from accidentally splitting.
+ */
+export function computeIsBigScreen(cssWidth: number, cssHeight: number, devicePixelRatio: number): boolean {
+  const physicalWidth = cssWidth * (devicePixelRatio || 1)
+  return cssWidth >= BIG_SCREEN_MIN_WIDTH
+    || (physicalWidth >= BIG_SCREEN_MIN_PHYSICAL_WIDTH && cssWidth > cssHeight)
+}
 
 const isBigScreen = ref(false)
 const leftTab = ref<string>('browse')
@@ -38,14 +54,25 @@ function initBigScreen() {
   } catch {
     // ignore
   }
-  if (typeof window !== 'undefined' && typeof window.matchMedia === 'function') {
-    const mql = window.matchMedia(`(min-width: ${BIG_SCREEN_MIN_WIDTH}px)`)
-    isBigScreen.value = mql.matches
-    const onChange = (e: MediaQueryListEvent) => { isBigScreen.value = e.matches }
-    if (typeof mql.addEventListener === 'function') {
-      mql.addEventListener('change', onChange)
-    } else if (typeof (mql as { addListener?: unknown }).addListener === 'function') {
-      ;(mql as { addListener: (cb: (e: MediaQueryListEvent) => void) => void }).addListener(onChange)
+  if (typeof window !== 'undefined') {
+    const recompute = () => {
+      isBigScreen.value = computeIsBigScreen(
+        window.innerWidth,
+        window.innerHeight,
+        window.devicePixelRatio || 1,
+      )
+    }
+    recompute()
+    // Viewport resize covers rotation, window resize and browser-zoom DPR changes.
+    window.addEventListener('resize', recompute)
+    if (typeof window.matchMedia === 'function') {
+      const mql = window.matchMedia(`(min-width: ${BIG_SCREEN_MIN_WIDTH}px)`)
+      const onChange = () => recompute()
+      if (typeof mql.addEventListener === 'function') {
+        mql.addEventListener('change', onChange)
+      } else if (typeof (mql as { addListener?: unknown }).addListener === 'function') {
+        ;(mql as { addListener: (cb: () => void) => void }).addListener(onChange)
+      }
     }
   }
 }

--- a/web/src/composables/useBigScreenLayout.ts
+++ b/web/src/composables/useBigScreenLayout.ts
@@ -1,0 +1,104 @@
+import { ref } from 'vue'
+import { normalizeRatio } from '@/utils/splitRatio'
+
+export const BIG_SCREEN_MIN_WIDTH = 1024
+export const LEFT_TAB_KEY = 'clawbench-bigscreen-left-tab'
+export const SPLIT_RATIO_KEY = 'clawbench-bigscreen-split-ratio'
+export const BIG_SCREEN_DOCK_TABS = ['browse', 'history', 'proxy', 'terminal', 'tasks', 'settings']
+
+const isBigScreen = ref(false)
+const leftTab = ref<string>('browse')
+const splitRatio = ref(0.5)
+let initialized = false
+let sideEffects: ((tab: string) => void) | null = null
+let setActiveTab: ((tab: string) => void) | null = null
+
+function readPersistedLeftTab(): string {
+  try {
+    const v = localStorage.getItem(LEFT_TAB_KEY)
+    if (v && BIG_SCREEN_DOCK_TABS.includes(v)) return v
+  } catch {
+    // localStorage may throw in restricted environments — fall through to default
+  }
+  return 'browse'
+}
+
+function initBigScreen() {
+  if (initialized) return
+  initialized = true
+  leftTab.value = readPersistedLeftTab()
+  try {
+    const raw = Number(localStorage.getItem(SPLIT_RATIO_KEY))
+    if (Number.isFinite(raw)) splitRatio.value = normalizeRatio(raw)
+  } catch {
+    // ignore
+  }
+  if (typeof window !== 'undefined' && typeof window.matchMedia === 'function') {
+    const mql = window.matchMedia(`(min-width: ${BIG_SCREEN_MIN_WIDTH}px)`)
+    isBigScreen.value = mql.matches
+    const onChange = (e: MediaQueryListEvent) => { isBigScreen.value = e.matches }
+    if (typeof mql.addEventListener === 'function') {
+      mql.addEventListener('change', onChange)
+    } else if (typeof (mql as { addListener?: unknown }).addListener === 'function') {
+      ;(mql as { addListener: (cb: (e: MediaQueryListEvent) => void) => void }).addListener(onChange)
+    }
+  }
+}
+
+/** Returns the shared big-screen state refs (initializes once). */
+export function useBigScreenLayout() {
+  initBigScreen()
+  return { isBigScreen, leftTab, splitRatio }
+}
+
+/** Ref access for useTabDrawer (avoids importing refs eagerly at module scope). */
+export function getBigScreenState() {
+  initBigScreen()
+  return { isBigScreen, leftTab }
+}
+
+export function registerBigScreenCallbacks(opts: { sideEffects?: (tab: string) => void; setActiveTab?: (tab: string) => void }) {
+  sideEffects = opts.sideEffects ?? null
+  setActiveTab = opts.setActiveTab ?? null
+}
+
+/** Switch the big-screen left column tab. Writes activeTab + side-effects via callbacks; does NOT call onTabSwitch. */
+export function switchLeftTab(tab: string) {
+  if (!BIG_SCREEN_DOCK_TABS.includes(tab)) return
+  if (leftTab.value === tab) return
+  leftTab.value = tab
+  try {
+    localStorage.setItem(LEFT_TAB_KEY, tab)
+  } catch {
+    // ignore
+  }
+  setActiveTab?.(tab)
+  sideEffects?.(tab)
+}
+
+/** Normalize + persist the split ratio (persistence owned here, not in SplitView). */
+export function setSplitRatio(ratio: number) {
+  splitRatio.value = normalizeRatio(ratio)
+  try {
+    localStorage.setItem(SPLIT_RATIO_KEY, String(splitRatio.value))
+  } catch {
+    // ignore
+  }
+}
+
+export function resetBigScreenState() {
+  leftTab.value = 'browse'
+  splitRatio.value = 0.5
+  isBigScreen.value = false
+  sideEffects = null
+  setActiveTab = null
+}
+
+/** Test hooks — do not use in production code. */
+export function _setBigScreenForTest(val: boolean) {
+  isBigScreen.value = val
+}
+export function _resetForTest() {
+  initialized = false
+  resetBigScreenState()
+}

--- a/web/src/composables/useBigScreenLayout.ts
+++ b/web/src/composables/useBigScreenLayout.ts
@@ -9,6 +9,8 @@ export const BIG_SCREEN_DOCK_TABS = ['browse', 'history', 'proxy', 'terminal', '
 const isBigScreen = ref(false)
 const leftTab = ref<string>('browse')
 const splitRatio = ref(0.5)
+/** Big-screen focus tracking: which pane the user is currently working in. */
+const activePane = ref<'left' | 'right'>('right')
 let initialized = false
 let sideEffects: ((tab: string) => void) | null = null
 let setActiveTab: ((tab: string) => void) | null = null
@@ -51,13 +53,26 @@ function initBigScreen() {
 /** Returns the shared big-screen state refs (initializes once). */
 export function useBigScreenLayout() {
   initBigScreen()
-  return { isBigScreen, leftTab, splitRatio }
+  return { isBigScreen, leftTab, splitRatio, activePane }
 }
 
 /** Ref access for useTabDrawer (init once, return only the refs it needs). */
 export function getBigScreenState() {
   initBigScreen()
   return { isBigScreen, leftTab }
+}
+
+/** Record which pane the user is currently working in (drives focus-aware shortcuts). */
+export function setActivePane(pane: 'left' | 'right') {
+  activePane.value = pane
+}
+
+/**
+ * Focus continuity on entering big-screen: if the user was on chat, the right
+ * pane (chat) is focused; otherwise they were in a left-column tab.
+ */
+export function resolveActivePaneOnEnter(currentActiveTab: string): 'left' | 'right' {
+  return currentActiveTab === 'chat' ? 'right' : 'left'
 }
 
 export function registerBigScreenCallbacks(opts: { sideEffects?: (tab: string) => void; setActiveTab?: (tab: string) => void }) {
@@ -103,6 +118,7 @@ export function resetBigScreenState() {
   leftTab.value = 'browse'
   splitRatio.value = 0.5
   isBigScreen.value = false
+  activePane.value = 'right'
   sideEffects = null
   setActiveTab = null
 }

--- a/web/src/composables/useBigScreenLayout.ts
+++ b/web/src/composables/useBigScreenLayout.ts
@@ -28,8 +28,11 @@ function initBigScreen() {
   initialized = true
   leftTab.value = readPersistedLeftTab()
   try {
-    const raw = Number(localStorage.getItem(SPLIT_RATIO_KEY))
-    if (Number.isFinite(raw)) splitRatio.value = normalizeRatio(raw)
+    const stored = localStorage.getItem(SPLIT_RATIO_KEY)
+    if (stored !== null) {
+      const raw = Number(stored)
+      if (Number.isFinite(raw)) splitRatio.value = normalizeRatio(raw)
+    }
   } catch {
     // ignore
   }
@@ -51,7 +54,7 @@ export function useBigScreenLayout() {
   return { isBigScreen, leftTab, splitRatio }
 }
 
-/** Ref access for useTabDrawer (avoids importing refs eagerly at module scope). */
+/** Ref access for useTabDrawer (init once, return only the refs it needs). */
 export function getBigScreenState() {
   initBigScreen()
   return { isBigScreen, leftTab }

--- a/web/src/composables/useBigScreenLayout.ts
+++ b/web/src/composables/useBigScreenLayout.ts
@@ -79,6 +79,16 @@ export function switchLeftTab(tab: string) {
   sideEffects?.(tab)
 }
 
+/**
+ * Q1A continuity rule: entering big-screen mode adopts the current narrow-mode
+ * tab as the left column tab when it is a non-chat tab; otherwise keeps the
+ * persisted/default leftTab.
+ */
+export function resolveLeftTabOnEnter(currentActiveTab: string, persistedLeftTab: string): string {
+  if (currentActiveTab !== 'chat' && BIG_SCREEN_DOCK_TABS.includes(currentActiveTab)) return currentActiveTab
+  return BIG_SCREEN_DOCK_TABS.includes(persistedLeftTab) ? persistedLeftTab : 'browse'
+}
+
 /** Normalize + persist the split ratio (persistence owned here, not in SplitView). */
 export function setSplitRatio(ratio: number) {
   splitRatio.value = normalizeRatio(ratio)

--- a/web/src/composables/useConnectionOverlay.ts
+++ b/web/src/composables/useConnectionOverlay.ts
@@ -4,7 +4,7 @@ import { useSettingsNavigation } from './useSettingsNavigation'
 
 // Delay before showing the reconnect mask, so transient blips that recover
 // within this window never flash a fullscreen overlay.
-export const RECONNECT_OVERLAY_DELAY_MS = 1500
+export const RECONNECT_OVERLAY_DELAY_MS = 5000
 
 export type ConnectionOverlayMode = 'restart' | 'reconnect' | null
 

--- a/web/src/composables/useGlobalEvents.ts
+++ b/web/src/composables/useGlobalEvents.ts
@@ -179,12 +179,23 @@ function connect() {
 
     ws.onopen = () => {
         connected.value = true
+        // True reconnect only if we've connected before — the app-startup first
+        // connect already loads sessions/tasks/git, so dispatching here too
+        // would duplicate those requests.
+        const isReconnect = hasConnectedOnce.value
         hasConnectedOnce.value = true
         missedPongs = 0
         reconnect.reset()
 
         // Fetch missed events that occurred while offline
         fetchPendingEvents()
+
+        // Notify other composables to refresh stale state
+        // (sessions, tasks, git — WS-push state that may have changed
+        // while disconnected beyond the 10s buffer window)
+        if (isReconnect) {
+            window.dispatchEvent(new CustomEvent('clawbench-reconnect'))
+        }
 
         // Start heartbeat monitoring
         startHeartbeat()

--- a/web/src/composables/useQuoteQuestion.ts
+++ b/web/src/composables/useQuoteQuestion.ts
@@ -39,7 +39,9 @@ function onSelectionChange() {
   debounceTimer = setTimeout(() => {
     const sel = window.getSelection()
     if (!sel || sel.isCollapsed || !sel.toString().trim()) {
-      // When bar is pinned (user clicked "引用提问"), don't auto-hide on selection loss
+      // When the selection is gone, drop the quote (both modes) — unless the
+      // user explicitly pinned it via "引用提问". A stale quote chip must not
+      // linger in the chat input after the user deselects the text.
       if (!barPinned.value) {
         barVisible.value = false
         setQuoteData(null)

--- a/web/src/composables/useTabDrawer.ts
+++ b/web/src/composables/useTabDrawer.ts
@@ -1,5 +1,8 @@
 import { ref, computed, watch, onUnmounted, getCurrentInstance, type Ref, type ComputedRef, readonly } from 'vue'
 import { appLog } from '@/utils/appLog'
+import { getBigScreenState } from './useBigScreenLayout'
+
+const { isBigScreen, leftTab } = getBigScreenState()
 
 /**
  * Tab-drawer declarative binding registry.
@@ -109,15 +112,24 @@ export function useTabDrawer(tabId: string, openRefOrOptions?: Ref<boolean> | Ta
     })
   }
 
-  const effectiveOpen = computed(() => currentTab.value === tabId && openRef.value)
+  const effectiveOpen = computed(() => {
+    const tabActive =
+      currentTab.value === tabId ||
+      (isBigScreen.value && (tabId === 'chat' || tabId === leftTab.value))
+    return tabActive && openRef.value
+  })
 
-  // For autoRestore: false, close the drawer when tab switches away
+  // For autoRestore: false, close the drawer when its tab is no longer active
+  // (narrow: currentTab changed; big-screen: leftTab changed away)
   if (!autoRestore) {
-    watch(() => currentTab.value, (newTab) => {
-      if (newTab !== tabId && openRef.value) {
-        openRef.value = false
-      }
-    })
+    const closeIfInactive = () => {
+      if (!openRef.value) return
+      const active =
+        currentTab.value === tabId ||
+        (isBigScreen.value && (tabId === 'chat' || tabId === leftTab.value))
+      if (!active) openRef.value = false
+    }
+    watch(() => [currentTab.value, isBigScreen.value, leftTab.value], closeIfInactive)
   }
 
   return {

--- a/web/src/composables/useTabDrawer.ts
+++ b/web/src/composables/useTabDrawer.ts
@@ -112,22 +112,18 @@ export function useTabDrawer(tabId: string, openRefOrOptions?: Ref<boolean> | Ta
     })
   }
 
-  const effectiveOpen = computed(() => {
-    const tabActive =
-      currentTab.value === tabId ||
-      (isBigScreen.value && (tabId === 'chat' || tabId === leftTab.value))
-    return tabActive && openRef.value
-  })
+  const isTabActive = () =>
+    currentTab.value === tabId ||
+    (isBigScreen.value && (tabId === 'chat' || tabId === leftTab.value))
+
+  const effectiveOpen = computed(() => isTabActive() && openRef.value)
 
   // For autoRestore: false, close the drawer when its tab is no longer active
   // (narrow: currentTab changed; big-screen: leftTab changed away)
   if (!autoRestore) {
     const closeIfInactive = () => {
       if (!openRef.value) return
-      const active =
-        currentTab.value === tabId ||
-        (isBigScreen.value && (tabId === 'chat' || tabId === leftTab.value))
-      if (!active) openRef.value = false
+      if (!isTabActive()) openRef.value = false
     }
     watch(() => [currentTab.value, isBigScreen.value, leftTab.value], closeIfInactive)
   }

--- a/web/src/i18n/locales/en.ts
+++ b/web/src/i18n/locales/en.ts
@@ -633,6 +633,7 @@ export default {
     showHiddenFiles: 'Show hidden files',
     uploadHere: 'Upload files',
     dropToUpload: 'Drop to upload to current folder',
+    dropToAttach: 'Drop to attach to chat',
     pasteToUpload: 'Pasting files...',
     truncateHint: 'Showing first {max} of {total} items, use search to narrow down',
     emptyDir: 'This directory is empty.',

--- a/web/src/i18n/locales/zh.ts
+++ b/web/src/i18n/locales/zh.ts
@@ -634,6 +634,7 @@ export default {
     showHiddenFiles: '显示隐藏文件',
     uploadHere: '上传文件',
     dropToUpload: '松开上传到当前目录',
+    dropToAttach: '松开添加到会话',
     pasteToUpload: '粘贴上传文件...',
     truncateHint: '仅展示前 {max} 项（共 {total} 项），请使用搜索精确定位',
     emptyDir: '此目录为空',

--- a/web/src/utils/__tests__/attachDrag.test.ts
+++ b/web/src/utils/__tests__/attachDrag.test.ts
@@ -1,0 +1,69 @@
+import { describe, expect, it } from 'vitest'
+import {
+  ATTACH_DRAG_MIME,
+  setAttachDragData,
+  readAttachDragData,
+  hasAttachDragData,
+} from '@/utils/attachDrag'
+
+/** Minimal DataTransfer stand-in that mirrors jsdom/browser behavior for set/getData + types. */
+function makeDataTransfer() {
+  const store = new Map<string, string>()
+  const types: string[] = []
+  return {
+    setData(type: string, value: string) {
+      if (!store.has(type)) types.push(type)
+      store.set(type, value)
+    },
+    getData(type: string) {
+      return store.get(type) ?? ''
+    },
+    types: types as unknown as readonly string[],
+  } as unknown as DataTransfer
+}
+
+describe('attachDrag helpers', () => {
+  it('round-trips a file/dir payload through the custom MIME type', () => {
+    const dt = makeDataTransfer()
+    setAttachDragData(dt, '/home/u/a.txt', false)
+    expect(readAttachDragData(dt)).toEqual({ path: '/home/u/a.txt', isDir: false })
+
+    const dtDir = makeDataTransfer()
+    setAttachDragData(dtDir, '/home/u/src', true)
+    expect(readAttachDragData(dtDir)).toEqual({ path: '/home/u/src', isDir: true })
+  })
+
+  it('also writes a plain-text fallback path', () => {
+    const dt = makeDataTransfer()
+    setAttachDragData(dt, '/x/y.md', false)
+    expect(dt.getData('text/plain')).toBe('/x/y.md')
+  })
+
+  it('hasAttachDragData detects the internal drag by MIME type only', () => {
+    const internal = makeDataTransfer()
+    setAttachDragData(internal, '/p', false)
+    expect(hasAttachDragData(internal)).toBe(true)
+
+    // An OS file drop exposes 'Files' but not our MIME
+    const osDrop = makeDataTransfer()
+    osDrop.setData('text/plain', '')
+    expect(hasAttachDragData(osDrop)).toBe(false)
+  })
+
+  it('readAttachDragData returns null for non-internal / malformed payloads', () => {
+    expect(readAttachDragData(null)).toBe(null)
+    expect(readAttachDragData(undefined)).toBe(null)
+
+    const plain = makeDataTransfer()
+    plain.setData('text/plain', 'just a path')
+    expect(readAttachDragData(plain)).toBe(null)
+
+    const bad = makeDataTransfer()
+    bad.setData(ATTACH_DRAG_MIME, 'not-json')
+    expect(readAttachDragData(bad)).toBe(null)
+
+    const missingPath = makeDataTransfer()
+    missingPath.setData(ATTACH_DRAG_MIME, JSON.stringify({ isDir: true }))
+    expect(readAttachDragData(missingPath)).toBe(null)
+  })
+})

--- a/web/src/utils/__tests__/contentBlocks.test.ts
+++ b/web/src/utils/__tests__/contentBlocks.test.ts
@@ -84,6 +84,16 @@ describe('getWarningText', () => {
   it('handles null/undefined text gracefully', () => {
     expect(getWarningText({ reason: undefined, text: undefined }, t)).toBe('')
   })
+
+  it('appends detail for request_failed with text', () => {
+    const tFound = (key: string) => key === 'chat.contentBlocks.warningReasons.request_failed' ? 'AI request failed' : key
+    expect(getWarningText({ reason: 'request_failed', text: 'Internal error: Upstream request failed: Insufficient Balance' }, tFound)).toBe('AI request failed: Internal error: Upstream request failed: Insufficient Balance')
+  })
+
+  it('returns translated text for request_failed without text', () => {
+    const tFound = (key: string) => key === 'chat.contentBlocks.warningReasons.request_failed' ? 'AI request failed' : key
+    expect(getWarningText({ reason: 'request_failed' }, tFound)).toBe('AI request failed')
+  })
 })
 
 // ── statusClass ──

--- a/web/src/utils/__tests__/splitRatio.test.ts
+++ b/web/src/utils/__tests__/splitRatio.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, it } from 'vitest'
+import { normalizeRatio, clampRatio, MIN_PANEL_WIDTH, DEFAULT_RATIO } from '@/utils/splitRatio'
+
+describe('normalizeRatio', () => {
+  it('returns DEFAULT_RATIO for non-finite / non-number input', () => {
+    expect(normalizeRatio(Number.NaN)).toBe(DEFAULT_RATIO)
+    expect(normalizeRatio('0.3' as unknown as number)).toBe(DEFAULT_RATIO)
+    expect(normalizeRatio(undefined as unknown as number)).toBe(DEFAULT_RATIO)
+    expect(normalizeRatio(Number.POSITIVE_INFINITY)).toBe(DEFAULT_RATIO)
+  })
+
+  it('clamps to [0, 1]', () => {
+    expect(normalizeRatio(-0.5)).toBe(0)
+    expect(normalizeRatio(1.7)).toBe(1)
+    expect(normalizeRatio(0.4)).toBe(0.4)
+  })
+})
+
+describe('clampRatio', () => {
+  it('respects symmetric min widths on both sides', () => {
+    // container 1000, minLeft=320, minRight=320 → left ∈ [320, 680]
+    expect(clampRatio(0.1, 1000)).toBeCloseTo(0.32)   // 320/1000
+    expect(clampRatio(0.9, 1000)).toBeCloseTo(0.68)   // 680/1000
+    expect(clampRatio(0.5, 1000)).toBeCloseTo(0.5)
+  })
+
+  it('returns DEFAULT_RATIO when container is too small for two panels', () => {
+    expect(clampRatio(0.3, MIN_PANEL_WIDTH * 2 - 10)).toBe(DEFAULT_RATIO)
+  })
+
+  it('returns DEFAULT_RATIO for invalid container width', () => {
+    expect(clampRatio(0.3, 0)).toBe(DEFAULT_RATIO)
+    expect(clampRatio(0.3, Number.NaN)).toBe(DEFAULT_RATIO)
+  })
+})

--- a/web/src/utils/attachDrag.ts
+++ b/web/src/utils/attachDrag.ts
@@ -1,0 +1,53 @@
+/**
+ * Internal drag-and-drop payload for attaching files/directories to chat.
+ *
+ * HTML5 DnD only carries a restricted set of types across the app, so we use
+ * a custom MIME type holding a JSON payload. The file manager writes it on
+ * dragstart; the chat column reads it on drop and attaches via useChatContext.
+ * This deliberately does NOT put the item in dataTransfer.files, so the
+ * file manager's own OS-file upload drop handler ignores internal drags.
+ */
+
+export const ATTACH_DRAG_MIME = 'application/x-clawbench-attach'
+
+export interface AttachDragData {
+  path: string
+  isDir: boolean
+}
+
+/** Write the internal attach payload into a drag event's dataTransfer. */
+export function setAttachDragData(dt: DataTransfer, path: string, isDir: boolean) {
+  try {
+    dt.setData(ATTACH_DRAG_MIME, JSON.stringify({ path, isDir } satisfies AttachDragData))
+    dt.setData('text/plain', path)
+  } catch {
+    // dataTransfer may be unavailable in some synthetic events — ignore
+  }
+}
+
+/** Read the internal attach payload, or null if this is not an internal drag. */
+export function readAttachDragData(dt: DataTransfer | null | undefined): AttachDragData | null {
+  if (!dt) return null
+  try {
+    const raw = dt.getData(ATTACH_DRAG_MIME)
+    if (!raw) return null
+    const parsed: unknown = JSON.parse(raw)
+    if (parsed && typeof parsed === 'object' && typeof (parsed as AttachDragData).path === 'string') {
+      const data = parsed as AttachDragData
+      return { path: data.path, isDir: data.isDir === true }
+    }
+  } catch {
+    // malformed payload — treat as non-internal
+  }
+  return null
+}
+
+/** Whether a drag event carries our internal attach payload (used to gate dragover/drop). */
+export function hasAttachDragData(dt: DataTransfer | null | undefined): boolean {
+  if (!dt) return false
+  try {
+    return !!dt.types?.includes?.(ATTACH_DRAG_MIME)
+  } catch {
+    return false
+  }
+}

--- a/web/src/utils/contentBlocks.ts
+++ b/web/src/utils/contentBlocks.ts
@@ -18,6 +18,7 @@ export function isSevereWarning(block: { reason?: string }): boolean {
  * Get localized warning/error text.
  * Uses reason code to look up i18n key, falls back to block.text.
  * For parse_error and backend_exit, appends detail after colon/newline.
+ * For request_failed, appends the human-readable error detail.
  */
 export function getWarningText(
   block: { reason?: string; text?: string },
@@ -30,6 +31,7 @@ export function getWarningText(
     if (translated !== key) {
       // For parse_error: append detail after ": " from block.text
       // For backend_exit: append stderr after "\n" from block.text
+      // For request_failed: append human-readable error detail
       if ((block.reason === 'parse_error' || block.reason === 'backend_exit') && block.text) {
         const newlineIdx = block.text.indexOf('\n')
         if (newlineIdx >= 0) {
@@ -39,6 +41,9 @@ export function getWarningText(
         if (colonIdx >= 0) {
           return translated + ': ' + block.text.substring(colonIdx + 2)
         }
+      }
+      if (block.reason === 'request_failed' && block.text) {
+        return translated + ': ' + block.text
       }
       return translated
     }

--- a/web/src/utils/highlight.ts
+++ b/web/src/utils/highlight.ts
@@ -111,6 +111,7 @@ const languages: Record<string, typeof javascript> = {
     json,
     yaml,
     xml: xmlLang,
+    vue: xmlLang,
     markdown,
     graphql,
     handlebars,

--- a/web/src/utils/splitRatio.ts
+++ b/web/src/utils/splitRatio.ts
@@ -1,0 +1,25 @@
+export const MIN_PANEL_WIDTH = 320
+export const DEFAULT_RATIO = 0.5
+
+/** Coerce an unknown value into a ratio in [0, 1]; defaults to DEFAULT_RATIO. */
+export function normalizeRatio(raw: unknown): number {
+  if (typeof raw !== 'number' || !Number.isFinite(raw)) return DEFAULT_RATIO
+  return Math.min(1, Math.max(0, raw))
+}
+
+/**
+ * Clamp a ratio so the left panel stays within [minLeft, containerWidth - minRight].
+ * Returns DEFAULT_RATIO when the container can't hold two min-width panels.
+ */
+export function clampRatio(
+  ratio: number,
+  containerWidth: number,
+  minLeft = MIN_PANEL_WIDTH,
+  minRight = MIN_PANEL_WIDTH,
+): number {
+  if (!Number.isFinite(containerWidth) || containerWidth <= 0) return DEFAULT_RATIO
+  if (containerWidth <= minLeft + minRight) return DEFAULT_RATIO
+  const maxLeft = containerWidth - minRight
+  const leftPx = Math.min(maxLeft, Math.max(minLeft, ratio * containerWidth))
+  return leftPx / containerWidth
+}


### PR DESCRIPTION
Removes the unused `splitLines` function in `internal/handler/file_ops_test.go` that was flagged by staticcheck (U1000).

The function had a `//nolint:unused` comment but was never actually called, so removing it is the correct fix.