### PR TITLE
fix: resolve golangci-lint issues (goconst, gocyclo, gofumpt) and add tests

### DIFF
--- a/internal/handler/chat.go
+++ b/internal/handler/chat.go
@@ -954,7 +954,7 @@ func buildForkContext(sessionID string) string {
 				if tcJSON != "" {
 					msgParts = append(msgParts, tcJSON)
 				}
-			// thinking, warning, error: skipped
+				// thinking, warning, error: skipped
 			}
 		}
 		if len(msgParts) == 0 {

--- a/internal/handler/chat.go
+++ b/internal/handler/chat.go
@@ -895,8 +895,15 @@ func buildForkContext(sessionID string) string {
 		return ""
 	}
 
-	const maxPerMsg = 2000
-	const maxTotal = 10000
+	// Batch-fetch tool call details for the session
+	toolCalls, _ := service.GetToolCallsBySession(sessionID)
+	toolCallMap := make(map[string]*service.ToolCallRecord, len(toolCalls))
+	for i := range toolCalls {
+		toolCallMap[toolCalls[i].ToolID] = &toolCalls[i]
+	}
+
+	const maxPerMsg = 4000
+	const maxTotal = 20000
 
 	var sb strings.Builder
 	sb.WriteString("[Below is the conversation history from before this session. Continue based on this context.]\n\n")
@@ -907,13 +914,54 @@ func buildForkContext(sessionID string) string {
 		if m.Role == "assistant" {
 			role = "Assistant"
 		}
-		// Convert JSON block format to readable plain text.
-		// For assistant messages this strips tool_use/tool_result blocks
-		// and keeps only the text content.
-		content := service.ExtractPlainText(m.Content)
-		if content == "" {
-			continue // skip messages with no readable text (e.g. pure tool calls)
+
+		if m.Role != "user" && m.Role != "assistant" {
+			continue
 		}
+
+		var wrapper struct {
+			Blocks []model.ContentBlock `json:"blocks"`
+		}
+		if !strings.HasPrefix(m.Content, `{"blocks":`) || json.Unmarshal([]byte(m.Content), &wrapper) != nil {
+			// Non-block content: treat as plain text
+			content := m.Content
+			if content == "" {
+				continue
+			}
+			if len(content) > maxPerMsg {
+				content = content[:maxPerMsg] + "...(truncated)"
+			}
+			line := fmt.Sprintf("%s: %s\n\n", role, content)
+			if total+len(line) > maxTotal {
+				sb.WriteString("...(history too long, remaining messages omitted)\n\n")
+				break
+			}
+			sb.WriteString(line)
+			total += len(line)
+			continue
+		}
+
+		// Render blocks: text as-is, tool_use as structured JSON, thinking skipped
+		var msgParts []string
+		for _, b := range wrapper.Blocks {
+			switch b.Type {
+			case "text":
+				if b.Text != "" {
+					msgParts = append(msgParts, b.Text)
+				}
+			case "tool_use":
+				tcJSON := service.FormatToolUseBlock(b, toolCallMap)
+				if tcJSON != "" {
+					msgParts = append(msgParts, tcJSON)
+				}
+			// thinking, warning, error: skipped
+			}
+		}
+		if len(msgParts) == 0 {
+			continue
+		}
+
+		content := strings.Join(msgParts, "\n\n")
 		if len(content) > maxPerMsg {
 			content = content[:maxPerMsg] + "...(truncated)"
 		}

--- a/internal/service/session_command.go
+++ b/internal/service/session_command.go
@@ -413,11 +413,26 @@ func appendMediaPrompt(systemPrompt string) string {
 
 // BuildForkContext reads the chat history from DB and formats it as a text block
 // that can be prepended to the user's prompt for fork sessions.
+// Includes text blocks as-is and tool_use blocks as structured JSON wrapped in
+// <tool_use> tags. Thinking blocks are excluded.
 func BuildForkContext(sessionID string) string {
 	messages, err := GetMessagesBySessionID(sessionID)
 	if err != nil || len(messages) == 0 {
 		return ""
 	}
+
+	// Batch-fetch tool call details for the session (input/output are stored
+	// separately in chat_tool_calls, not in content JSON).
+	toolCalls, err := GetToolCallsBySession(sessionID)
+	if err != nil {
+		toolCalls = nil // proceed without tool details; blocks get slim version
+	}
+	// Build lookup: toolID → ToolCallRecord for quick enrichment
+	toolCallMap := make(map[string]*ToolCallRecord, len(toolCalls))
+	for i := range toolCalls {
+		toolCallMap[toolCalls[i].ToolID] = &toolCalls[i]
+	}
+
 	var sb strings.Builder
 	for _, msg := range messages {
 		if msg.Role != roleUser && msg.Role != roleAssistant {
@@ -429,16 +444,89 @@ func BuildForkContext(sessionID string) string {
 		if err := json.Unmarshal([]byte(msg.Content), &content); err != nil {
 			continue
 		}
+
+		// Collect all non-skipped block outputs for this message
+		var msgParts []string
 		for _, b := range content.Blocks {
-			if b.Type == contentKeyText && b.Text != "" {
-				sb.WriteString(msg.Role)
-				sb.WriteString(": ")
-				sb.WriteString(b.Text)
-				sb.WriteString("\n\n")
+			switch b.Type {
+			case contentKeyText:
+				if b.Text != "" {
+					msgParts = append(msgParts, b.Text)
+				}
+			case "tool_use":
+				tcJSON := FormatToolUseBlock(b, toolCallMap)
+				if tcJSON != "" {
+					msgParts = append(msgParts, tcJSON)
+				}
+			// thinking, warning, error: skipped
 			}
 		}
+		if len(msgParts) == 0 {
+			continue
+		}
+		sb.WriteString(msg.Role)
+		sb.WriteString(": ")
+		for i, part := range msgParts {
+			if i > 0 {
+				sb.WriteString("\n\n")
+			}
+			sb.WriteString(part)
+		}
+		sb.WriteString("\n\n")
 	}
 	return sb.String()
+}
+
+// FormatToolUseBlock renders a tool_use ContentBlock as structured JSON wrapped
+// in <tool_use> tags. Enriches the block with input/output from the detail table
+// when available. Applies truncation to keep the output reasonable.
+func FormatToolUseBlock(b model.ContentBlock, toolCallMap map[string]*ToolCallRecord) string {
+	// Base fields from the slim content block
+	obj := map[string]any{
+		"name": b.Name,
+		"id":   b.ID,
+	}
+	if b.Status != "" {
+		obj["status"] = b.Status
+	}
+	if b.Done {
+		obj["done"] = true
+	}
+	if b.DurationMs > 0 {
+		obj["duration_ms"] = b.DurationMs
+	}
+	if b.Summary != "" {
+		obj["summary"] = truncateString(b.Summary, 500)
+	}
+
+	// Enrich with input/output from chat_tool_calls detail table
+	tc, found := toolCallMap[b.ID]
+	if found {
+		inputStr := string(tc.Input)
+		obj["input"] = truncateString(inputStr, 500)
+		obj["output"] = truncateString(tc.Output, 1000)
+	} else if b.Input != nil {
+		// Fallback: use input from content block (interactive tools keep input inline)
+		inputJSON, _ := json.Marshal(b.Input)
+		obj["input"] = truncateString(string(inputJSON), 500)
+		if b.Output != "" {
+			obj["output"] = truncateString(b.Output, 1000)
+		}
+	}
+
+	jsonBytes, err := json.Marshal(obj)
+	if err != nil {
+		return ""
+	}
+	return "<tool_use>" + string(jsonBytes) + "</tool_use>"
+}
+
+// truncateString truncates s to maxLen bytes, appending "...(truncated)" if exceeded.
+func truncateString(s string, maxLen int) string {
+	if len(s) <= maxLen {
+		return s
+	}
+	return s[:maxLen] + "...(truncated)"
 }
 
 type streamRunResultShared struct {

--- a/internal/service/session_command.go
+++ b/internal/service/session_command.go
@@ -36,7 +36,8 @@ func FindSessionsByPrefix(prefix string) ([]DingTalkSessionInfo, error) {
 	if dbRead == nil {
 		return nil, fmt.Errorf("database not initialized")
 	}
-	rows, err := dbRead.QueryContext(context.Background(),
+	rows, err := dbRead.QueryContext(
+		context.Background(),
 		`SELECT id, title, project_path, backend, agent_id, model
 		 FROM chat_sessions
 		 WHERE LOWER(id) LIKE LOWER(?) AND archived = 0 AND session_type = 'chat'
@@ -59,7 +60,8 @@ func ListRecentSessions(limit int) ([]DingTalkSessionInfo, error) {
 	if limit <= 0 {
 		limit = 10
 	}
-	rows, err := dbRead.QueryContext(context.Background(),
+	rows, err := dbRead.QueryContext(
+		context.Background(),
 		`SELECT id, title, project_path, backend, agent_id, model
 		 FROM chat_sessions
 		 WHERE archived = 0 AND session_type = 'chat'
@@ -106,7 +108,8 @@ func FindRunningSessionsByPrefix(prefix string) ([]DingTalkSessionInfo, error) {
 		args[i] = id
 	}
 
-	rows, err := dbRead.QueryContext(context.Background(),
+	rows, err := dbRead.QueryContext(
+		context.Background(),
 		fmt.Sprintf(
 			`SELECT id, title, project_path, backend, agent_id, model
 			 FROM chat_sessions
@@ -258,7 +261,8 @@ func LaunchSessionExecution(cfg LaunchConfig) {
 // handleSessionPanic recovers from panics in the session goroutine.
 func handleSessionPanic(cfg LaunchConfig, sessionID string, cancel context.CancelFunc) {
 	if r := recover(); r != nil {
-		slog.Error("session goroutine panicked",
+		slog.Error(
+			"session goroutine panicked",
 			slog.String("session", sessionID),
 			slog.Any("panic", r),
 			slog.String("stack", string(debug.Stack())),
@@ -446,21 +450,7 @@ func BuildForkContext(sessionID string) string {
 		}
 
 		// Collect all non-skipped block outputs for this message
-		var msgParts []string
-		for _, b := range content.Blocks {
-			switch b.Type {
-			case contentKeyText:
-				if b.Text != "" {
-					msgParts = append(msgParts, b.Text)
-				}
-			case "tool_use":
-				tcJSON := FormatToolUseBlock(b, toolCallMap)
-				if tcJSON != "" {
-					msgParts = append(msgParts, tcJSON)
-				}
-			// thinking, warning, error: skipped
-			}
-		}
+		msgParts := extractMessageParts(content.Blocks, toolCallMap)
 		if len(msgParts) == 0 {
 			continue
 		}
@@ -475,6 +465,26 @@ func BuildForkContext(sessionID string) string {
 		sb.WriteString("\n\n")
 	}
 	return sb.String()
+}
+
+// extractMessageParts collects non-skipped block outputs from content blocks.
+func extractMessageParts(blocks []model.ContentBlock, toolCallMap map[string]*ToolCallRecord) []string {
+	var parts []string
+	for _, b := range blocks {
+		switch b.Type {
+		case contentKeyText:
+			if b.Text != "" {
+				parts = append(parts, b.Text)
+			}
+		case eventTypeToolUse:
+			tcJSON := FormatToolUseBlock(b, toolCallMap)
+			if tcJSON != "" {
+				parts = append(parts, tcJSON)
+			}
+			// thinking, warning, error: skipped
+		}
+	}
+	return parts
 }
 
 // FormatToolUseBlock renders a tool_use ContentBlock as structured JSON wrapped

--- a/internal/service/session_command_test.go
+++ b/internal/service/session_command_test.go
@@ -933,6 +933,32 @@ func TestBuildForkContext_MultipleTextBlocks(t *testing.T) {
 	assert.NotContains(t, result, "thinking part")
 }
 
+func TestGetToolCallsBySession_ClosedDB(t *testing.T) {
+	dbDir := t.TempDir()
+	if err := initTestDB(dbDir); err != nil {
+		t.Fatalf("initTestDB: %v", err)
+	}
+	// Close the database to trigger error in GetToolCallsBySession
+	db.Close()
+	dbRead.Close()
+
+	_, err := GetToolCallsBySession("any-session")
+	assert.Error(t, err)
+}
+
+func TestGetThinkingBySessionAll_ClosedDB(t *testing.T) {
+	dbDir := t.TempDir()
+	if err := initTestDB(dbDir); err != nil {
+		t.Fatalf("initTestDB: %v", err)
+	}
+	// Close the database to trigger error in GetThinkingBySessionAll
+	db.Close()
+	dbRead.Close()
+
+	_, err := GetThinkingBySessionAll("any-session")
+	assert.Error(t, err)
+}
+
 // ============================================================================
 // handleACPCleanup tests
 // ============================================================================
@@ -2238,6 +2264,56 @@ func TestExtractMessageParts_SkipsThinkingAndWarning(t *testing.T) {
 func TestExtractMessageParts_EmptyBlocks(t *testing.T) {
 	parts := extractMessageParts(nil, nil)
 	assert.Nil(t, parts)
+}
+
+func TestFormatToolUseBlock_InlineInputFallback(t *testing.T) {
+	t.Run("uses Input from content block when no toolCallMap entry", func(t *testing.T) {
+		b := model.ContentBlock{
+			Type:  eventTypeToolUse,
+			Name:  "AskUserQuestion",
+			ID:    "ask-001",
+			Input: map[string]any{"question": "Continue?"},
+		}
+		result := FormatToolUseBlock(b, nil)
+		assert.Contains(t, result, "<tool_use>")
+		assert.Contains(t, result, "AskUserQuestion")
+		assert.Contains(t, result, `"input"`)
+	})
+
+	t.Run("uses Output from content block as fallback", func(t *testing.T) {
+		b := model.ContentBlock{
+			Type:   eventTypeToolUse,
+			Name:   "Bash",
+			ID:     "ask-002",
+			Input:  map[string]any{"command": "ls"},
+			Output: "file1.txt\nfile2.txt",
+		}
+		result := FormatToolUseBlock(b, nil)
+		assert.Contains(t, result, "<tool_use>")
+		assert.Contains(t, result, `"input"`)
+		assert.Contains(t, result, `"output"`)
+		assert.Contains(t, result, "file1.txt")
+	})
+
+	t.Run("prefers toolCallMap over inline input", func(t *testing.T) {
+		b := model.ContentBlock{
+			Type:   eventTypeToolUse,
+			Name:   "Read",
+			ID:     "toolu_map",
+			Input:  map[string]any{"file_path": "/inline.go"},
+			Output: "inline output",
+		}
+		tc := ToolCallRecord{
+			ToolID: "toolu_map",
+			Input:  json.RawMessage(`{"file_path":"/db.go"}`),
+			Output: "db output",
+		}
+		toolCallMap := map[string]*ToolCallRecord{"toolu_map": &tc}
+		result := FormatToolUseBlock(b, toolCallMap)
+		assert.Contains(t, result, "/db.go")
+		assert.Contains(t, result, "db output")
+		assert.NotContains(t, result, "/inline.go")
+	})
 }
 
 // ============================================================================

--- a/internal/service/session_command_test.go
+++ b/internal/service/session_command_test.go
@@ -2181,9 +2181,9 @@ func TestFormatToolUseBlock_Truncation(t *testing.T) {
 		Summary:    longSummary,
 	}
 	tc := ToolCallRecord{
-		ToolID:  "toolu_trunc",
-		Input:   json.RawMessage(longInput),
-		Output:  longOutput,
+		ToolID: "toolu_trunc",
+		Input:  json.RawMessage(longInput),
+		Output: longOutput,
 	}
 	toolCallMap := map[string]*ToolCallRecord{"toolu_trunc": &tc}
 
@@ -2194,6 +2194,50 @@ func TestFormatToolUseBlock_Truncation(t *testing.T) {
 	assert.NotContains(t, result, strings.Repeat("a", 600))
 	// Summary truncated at 500
 	assert.Contains(t, result, strings.Repeat("c", 500))
+}
+
+func TestExtractMessageParts_TextBlocks(t *testing.T) {
+	blocks := []model.ContentBlock{
+		{Type: contentKeyText, Text: "hello"},
+		{Type: contentKeyText, Text: "world"},
+	}
+	parts := extractMessageParts(blocks, nil)
+	assert.Equal(t, []string{"hello", "world"}, parts)
+}
+
+func TestExtractMessageParts_SkipsEmptyText(t *testing.T) {
+	blocks := []model.ContentBlock{
+		{Type: contentKeyText, Text: ""},
+		{Type: contentKeyText, Text: "visible"},
+	}
+	parts := extractMessageParts(blocks, nil)
+	assert.Equal(t, []string{"visible"}, parts)
+}
+
+func TestExtractMessageParts_ToolUseBlock(t *testing.T) {
+	blocks := []model.ContentBlock{
+		{Type: contentKeyText, Text: "preamble"},
+		{Type: eventTypeToolUse, Name: "Bash", ID: "t1", Status: "success", Done: true},
+	}
+	parts := extractMessageParts(blocks, nil)
+	assert.Len(t, parts, 2)
+	assert.Equal(t, "preamble", parts[0])
+	assert.Contains(t, parts[1], "<tool_use>")
+}
+
+func TestExtractMessageParts_SkipsThinkingAndWarning(t *testing.T) {
+	blocks := []model.ContentBlock{
+		{Type: contentKeyText, Text: "msg"},
+		{Type: "thinking", Text: "hidden"},
+		{Type: "warning", Text: "also hidden"},
+	}
+	parts := extractMessageParts(blocks, nil)
+	assert.Equal(t, []string{"msg"}, parts)
+}
+
+func TestExtractMessageParts_EmptyBlocks(t *testing.T) {
+	parts := extractMessageParts(nil, nil)
+	assert.Nil(t, parts)
 }
 
 // ============================================================================

--- a/internal/service/session_command_test.go
+++ b/internal/service/session_command_test.go
@@ -5,6 +5,7 @@ import (
 	"database/sql"
 	"encoding/json"
 	"fmt"
+	"strings"
 	"sync"
 	"testing"
 	"time"
@@ -64,6 +65,21 @@ func setupTestDBForSessionCommand(t *testing.T) *sql.DB {
 			summary     TEXT NOT NULL,
 			created_at  DATETIME DEFAULT CURRENT_TIMESTAMP,
 			UNIQUE(target_type, target_id)
+		);
+		CREATE TABLE IF NOT EXISTS chat_tool_calls (
+			id INTEGER PRIMARY KEY AUTOINCREMENT,
+			message_id INTEGER NOT NULL,
+			session_id TEXT NOT NULL,
+			tool_id TEXT NOT NULL,
+			name TEXT NOT NULL,
+			input TEXT NOT NULL DEFAULT '{}',
+			output TEXT NOT NULL DEFAULT '',
+			status TEXT NOT NULL DEFAULT '',
+			done INTEGER NOT NULL DEFAULT 0,
+			summary TEXT NOT NULL DEFAULT '',
+			duration_ms INTEGER NOT NULL DEFAULT 0,
+			created_at DATETIME DEFAULT CURRENT_TIMESTAMP,
+			UNIQUE(tool_id, message_id)
 		);
 	`)
 	require.NoError(t, err)
@@ -912,10 +928,9 @@ func TestBuildForkContext_MultipleTextBlocks(t *testing.T) {
 
 	result := BuildForkContext(sessionID)
 	assert.Contains(t, result, "user: first part")
-	assert.Contains(t, result, "user: second part")
-	// thinking blocks don't match contentKeyText="text", they have type="thinking"
-	// so "thinking part" should not appear as a "user: thinking part" line
-	assert.NotContains(t, result, "user: thinking part")
+	assert.Contains(t, result, "second part")
+	// thinking blocks are excluded
+	assert.NotContains(t, result, "thinking part")
 }
 
 // ============================================================================
@@ -2069,17 +2084,116 @@ func TestBuildForkContext_SkipsSystemMessages(t *testing.T) {
 	sessionID := "fork-sys-skip"
 	// The chat_history table has a CHECK(role IN ('user', 'assistant')),
 	// so we can't insert system messages directly. But we can verify
-	// that messages with only non-text blocks produce empty fork context.
-	// Instead, test with tool_use blocks that are not type="text"
+	// that messages with only thinking blocks produce empty fork context
+	// (thinking blocks are now excluded, tool_use blocks are included).
 	_, err := WriteExec(
 		"INSERT INTO chat_history (project_path, role, content, session_id, backend, streaming) VALUES (?, 'user', ?, ?, 'claude', 0)",
-		"/proj", `{"blocks":[{"type":"tool_use","id":"t1","name":"Read"}]}`, sessionID,
+		"/proj", `{"blocks":[{"type":"thinking","text":"thinking content"}]}`, sessionID,
 	)
 	require.NoError(t, err)
 
 	result := BuildForkContext(sessionID)
-	// tool_use blocks don't match contentKeyText="text", so they're skipped
-	assert.Equal(t, "", result, "non-text blocks should be skipped in fork context")
+	// thinking blocks are excluded, so only-thinking messages produce empty fork context
+	assert.Equal(t, "", result, "thinking-only messages should be skipped in fork context")
+}
+
+func TestBuildForkContext_ToolUseBlock(t *testing.T) {
+	db := setupTestDBForSessionCommand(t)
+	defer func() { _ = db.Close() }()
+
+	sessionID := "fork-tooluse"
+	// Insert assistant message with tool_use block + text
+	_, err := WriteExec(
+		"INSERT INTO chat_history (project_path, role, content, session_id, backend, streaming) VALUES (?, 'assistant', ?, ?, 'claude', 0)",
+		"/proj", `{"blocks":[{"type":"text","text":"I'll read the file"},{"type":"tool_use","name":"Read","id":"toolu_1","status":"success","done":true,"duration_ms":150,"summary":"Read /path/to/file.go"}]}`, sessionID,
+	)
+	require.NoError(t, err)
+	// Insert tool call detail record
+	_, err = WriteExec(
+		"INSERT INTO chat_tool_calls (message_id, session_id, tool_id, name, input, output, status, done, summary, duration_ms) VALUES (?, ?, 'toolu_1', 'Read', ?, ?, 'success', 1, 'Read /path/to/file.go', 150)",
+		1, sessionID, `{"file_path":"/path/to/file.go"}`, "package main\n\nfunc main() {}",
+	)
+	require.NoError(t, err)
+
+	result := BuildForkContext(sessionID)
+	assert.Contains(t, result, "assistant: I'll read the file")
+	assert.Contains(t, result, "<tool_use>")
+	assert.Contains(t, result, `"name":"Read"`)
+	assert.Contains(t, result, `"id":"toolu_1"`)
+	assert.Contains(t, result, `"status":"success"`)
+	assert.Contains(t, result, `"input"`)
+	assert.Contains(t, result, `"output"`)
+	assert.Contains(t, result, "</tool_use>")
+}
+
+func TestBuildForkContext_ToolUseBlockWithoutDetail(t *testing.T) {
+	db := setupTestDBForSessionCommand(t)
+	defer func() { _ = db.Close() }()
+
+	sessionID := "fork-tooluse-no-detail"
+	// Insert assistant message with tool_use block but no matching detail record
+	_, err := WriteExec(
+		"INSERT INTO chat_history (project_path, role, content, session_id, backend, streaming) VALUES (?, 'assistant', ?, ?, 'claude', 0)",
+		"/proj", `{"blocks":[{"type":"tool_use","name":"Bash","id":"toolu_2","status":"success","done":true}]}`, sessionID,
+	)
+	require.NoError(t, err)
+
+	result := BuildForkContext(sessionID)
+	assert.Contains(t, result, "assistant:")
+	assert.Contains(t, result, "<tool_use>")
+	assert.Contains(t, result, `"name":"Bash"`)
+	assert.Contains(t, result, `"id":"toolu_2"`)
+	// Without detail record, no input/output
+	assert.NotContains(t, result, `"input"`)
+	assert.NotContains(t, result, `"output"`)
+}
+
+func TestBuildForkContext_ThinkingExcluded(t *testing.T) {
+	db := setupTestDBForSessionCommand(t)
+	defer func() { _ = db.Close() }()
+
+	sessionID := "fork-thinking-excl"
+	// Insert assistant message with thinking + text
+	_, err := WriteExec(
+		"INSERT INTO chat_history (project_path, role, content, session_id, backend, streaming) VALUES (?, 'assistant', ?, ?, 'claude', 0)",
+		"/proj", `{"blocks":[{"type":"thinking","text":"I should think about this"},{"type":"text","text":"Here is my answer"}]}`, sessionID,
+	)
+	require.NoError(t, err)
+
+	result := BuildForkContext(sessionID)
+	assert.Contains(t, result, "assistant: Here is my answer")
+	assert.NotContains(t, result, "I should think about this")
+}
+
+func TestFormatToolUseBlock_Truncation(t *testing.T) {
+	// Test truncation of long input/output/summary
+	longInput := strings.Repeat("a", 600)
+	longOutput := strings.Repeat("b", 1100)
+	longSummary := strings.Repeat("c", 600)
+
+	b := model.ContentBlock{
+		Type:       "tool_use",
+		Name:       "Bash",
+		ID:         "toolu_trunc",
+		Status:     "success",
+		Done:       true,
+		DurationMs: 100,
+		Summary:    longSummary,
+	}
+	tc := ToolCallRecord{
+		ToolID:  "toolu_trunc",
+		Input:   json.RawMessage(longInput),
+		Output:  longOutput,
+	}
+	toolCallMap := map[string]*ToolCallRecord{"toolu_trunc": &tc}
+
+	result := FormatToolUseBlock(b, toolCallMap)
+	assert.Contains(t, result, "...(truncated)")
+	// Input truncated at 500
+	assert.Contains(t, result, strings.Repeat("a", 500))
+	assert.NotContains(t, result, strings.Repeat("a", 600))
+	// Summary truncated at 500
+	assert.Contains(t, result, strings.Repeat("c", 500))
 }
 
 // ============================================================================

--- a/internal/service/session_executor.go
+++ b/internal/service/session_executor.go
@@ -393,7 +393,7 @@ func (e *SessionExecutor) upsertToolCallToDB(event ai.StreamEvent) {
 	}
 	// Find the matching block in accumulated blocks
 	for i := len(e.blocks) - 1; i >= 0; i-- {
-		if e.blocks[i].Type == "tool_use" && e.blocks[i].ID == event.Tool.ID {
+		if e.blocks[i].Type == eventTypeToolUse && e.blocks[i].ID == event.Tool.ID {
 			block := &e.blocks[i]
 			inputJSON, _ := json.Marshal(block.Input)
 			if err := UpsertToolCall(

--- a/internal/service/thinking.go
+++ b/internal/service/thinking.go
@@ -93,6 +93,29 @@ func GetThinkingBySession(thinkID, sessionID string) (*ThinkingRecord, error) {
 	return &r, nil
 }
 
+// GetThinkingBySessionAll retrieves all thinking records for a session.
+// Used by BuildForkContext to batch-fetch thinking text without N+1 queries.
+func GetThinkingBySessionAll(sessionID string) ([]ThinkingRecord, error) {
+	rows, err := dbRead.QueryContext(context.Background(), `
+		SELECT id, message_id, session_id, think_id, text, created_at
+		FROM chat_thinking WHERE session_id = ?
+	`, sessionID)
+	if err != nil {
+		return nil, fmt.Errorf("GetThinkingBySessionAll: %w", err)
+	}
+	defer func() { _ = rows.Close() }()
+
+	var records []ThinkingRecord
+	for rows.Next() {
+		var r ThinkingRecord
+		if err := rows.Scan(&r.ID, &r.MessageID, &r.SessionID, &r.ThinkID, &r.Text, &r.CreatedAt); err != nil {
+			return nil, fmt.Errorf("GetThinkingBySessionAll scan: %w", err)
+		}
+		records = append(records, r)
+	}
+	return records, rows.Err()
+}
+
 // slimThinkingInContent parses content JSON, extracts thinking block text into
 // ThinkingRecord entries (generating think_id), and rewrites the content with
 // slim thinking blocks ({type:"thinking", think_id, done} — text removed).

--- a/internal/service/thinking_test.go
+++ b/internal/service/thinking_test.go
@@ -80,6 +80,60 @@ func TestThinkingCRUD(t *testing.T) {
 	})
 }
 
+func TestGetThinkingBySessionAll(t *testing.T) {
+	dbDir := t.TempDir()
+	if err := initTestDB(dbDir); err != nil {
+		t.Fatalf("initTestDB: %v", err)
+	}
+	defer func() {
+		db.Close()
+		dbRead.Close()
+	}()
+
+	sessionID := "thinking-all-sess"
+	_, _ = db.Exec("INSERT INTO chat_sessions (id, project_path, backend, title) VALUES (?, ?, ?, ?)",
+		sessionID, "/test", "test", "Test Session")
+	res, err := db.Exec("INSERT INTO chat_history (project_path, role, content, session_id, backend) VALUES (?, ?, ?, ?, ?)",
+		"/test", "assistant", `{"blocks":[]}`, sessionID, "test")
+	if err != nil {
+		t.Fatalf("insert message: %v", err)
+	}
+	msgID, _ := res.LastInsertId()
+
+	t.Run("returns empty for session with no thinking", func(t *testing.T) {
+		records, err := GetThinkingBySessionAll(sessionID)
+		if err != nil {
+			t.Fatalf("GetThinkingBySessionAll: %v", err)
+		}
+		if len(records) != 0 {
+			t.Errorf("expected 0 records, got %d", len(records))
+		}
+	})
+
+	t.Run("returns all thinking records for session", func(t *testing.T) {
+		if err := UpsertThinking(msgID, sessionID, "th_001", "first thought"); err != nil {
+			t.Fatalf("UpsertThinking: %v", err)
+		}
+		if err := UpsertThinking(msgID, sessionID, "th_002", "second thought"); err != nil {
+			t.Fatalf("UpsertThinking: %v", err)
+		}
+		records, err := GetThinkingBySessionAll(sessionID)
+		if err != nil {
+			t.Fatalf("GetThinkingBySessionAll: %v", err)
+		}
+		if len(records) != 2 {
+			t.Fatalf("expected 2 records, got %d", len(records))
+		}
+		got := map[string]string{}
+		for _, r := range records {
+			got[r.ThinkID] = r.Text
+		}
+		if got["th_001"] != "first thought" || got["th_002"] != "second thought" {
+			t.Errorf("mismatch: %+v", got)
+		}
+	})
+}
+
 func TestGenerateThinkingID(t *testing.T) {
 	a, b := generateThinkingID(), generateThinkingID()
 	if a == "" || b == "" {

--- a/internal/service/tool_calls.go
+++ b/internal/service/tool_calls.go
@@ -71,6 +71,36 @@ func GetToolCall(toolID string, messageID int64) (*ToolCallRecord, error) {
 	return &r, nil
 }
 
+// GetToolCallsBySession retrieves all tool call records for a session.
+// Used by BuildForkContext to batch-fetch tool details without N+1 queries.
+func GetToolCallsBySession(sessionID string) ([]ToolCallRecord, error) {
+	rows, err := dbRead.QueryContext(context.Background(), `
+		SELECT id, message_id, session_id, tool_id, name, input, output, status, done, summary, duration_ms, created_at
+		FROM chat_tool_calls WHERE session_id = ?
+	`, sessionID)
+	if err != nil {
+		return nil, fmt.Errorf("GetToolCallsBySession: %w", err)
+	}
+	defer func() { _ = rows.Close() }()
+
+	var records []ToolCallRecord
+	for rows.Next() {
+		var r ToolCallRecord
+		var doneInt int
+		var inputStr string
+		if err := rows.Scan(
+			&r.ID, &r.MessageID, &r.SessionID, &r.ToolID, &r.Name,
+			&inputStr, &r.Output, &r.Status, &doneInt, &r.Summary, &r.DurationMs, &r.CreatedAt,
+		); err != nil {
+			return nil, fmt.Errorf("GetToolCallsBySession scan: %w", err)
+		}
+		r.Input = json.RawMessage(inputStr)
+		r.Done = doneInt != 0
+		records = append(records, r)
+	}
+	return records, rows.Err()
+}
+
 // GetToolCallBySession retrieves a tool call record by tool_id and session_id.
 // This is a fallback for task executions where the session has multiple assistant
 // messages and the tool call may be stored

--- a/internal/service/tool_calls_test.go
+++ b/internal/service/tool_calls_test.go
@@ -173,6 +173,62 @@ func TestUpsertAndGetToolCall(t *testing.T) {
 	})
 }
 
+func TestGetToolCallsBySession(t *testing.T) {
+	dbDir := t.TempDir()
+	if err := initTestDB(dbDir); err != nil {
+		t.Fatalf("initTestDB: %v", err)
+	}
+	defer func() {
+		db.Close()
+		dbRead.Close()
+	}()
+
+	sessionID := "tc-session-all"
+	_, _ = db.Exec("INSERT INTO chat_sessions (id, project_path, backend, title) VALUES (?, ?, ?, ?)",
+		sessionID, "/test", "test", "Test Session")
+	res, err := db.Exec("INSERT INTO chat_history (project_path, role, content, session_id, backend) VALUES (?, ?, ?, ?, ?)",
+		"/test", "assistant", `{"blocks":[]}`, sessionID, "test")
+	if err != nil {
+		t.Fatalf("insert message: %v", err)
+	}
+	msgID, _ := res.LastInsertId()
+
+	t.Run("returns empty for session with no tool calls", func(t *testing.T) {
+		records, err := GetToolCallsBySession(sessionID)
+		if err != nil {
+			t.Fatalf("GetToolCallsBySession: %v", err)
+		}
+		if len(records) != 0 {
+			t.Errorf("expected 0 records, got %d", len(records))
+		}
+	})
+
+	t.Run("returns all tool calls for session", func(t *testing.T) {
+		input1 := json.RawMessage(`{"file_path":"/a.go"}`)
+		input2 := json.RawMessage(`{"command":"ls"}`)
+		if err := UpsertToolCall(msgID, sessionID, "toolu_s1", "Read", input1, "content-a", "success", "", true, 100); err != nil {
+			t.Fatalf("UpsertToolCall 1: %v", err)
+		}
+		if err := UpsertToolCall(msgID, sessionID, "toolu_s2", "Bash", input2, "output", "success", "", true, 200); err != nil {
+			t.Fatalf("UpsertToolCall 2: %v", err)
+		}
+		records, err := GetToolCallsBySession(sessionID)
+		if err != nil {
+			t.Fatalf("GetToolCallsBySession: %v", err)
+		}
+		if len(records) != 2 {
+			t.Fatalf("expected 2 records, got %d", len(records))
+		}
+		got := map[string]string{}
+		for _, r := range records {
+			got[r.ToolID] = r.Name
+		}
+		if got["toolu_s1"] != "Read" || got["toolu_s2"] != "Bash" {
+			t.Errorf("mismatch: %+v", got)
+		}
+	})
+}
+
 // initTestDB creates a test database in the given directory
 func initTestDB(dbDir string) error {
 	origBinDir := model.BinDir

--- a/web/css/wide-screen.css
+++ b/web/css/wide-screen.css
@@ -1,14 +1,14 @@
 /* ==========================================================================
-   Big-screen (≥1024px) two-column layout
-   Activated via .big-screen class on .main-content (bound to useBigScreenLayout.isBigScreen)
+   Wide-screen (≥1024px) two-column layout
+   Activated via .wide-screen class on .main-content (bound to useWideScreenLayout.isWideScreen)
    ========================================================================== */
 
 /* Switch the single-column flex to a horizontal dock + split layout */
-.main-content.big-screen {
+.main-content.wide-screen {
   flex-direction: row;
 }
 
 /* Let the split area shrink when the vertical dock is present */
-.main-content.big-screen .content-area {
+.main-content.wide-screen .content-area {
   min-width: 0;
 }

--- a/web/index.html
+++ b/web/index.html
@@ -40,7 +40,7 @@
     <link rel="stylesheet" href="/css/variables.css">
     <link rel="stylesheet" href="/css/base.css">
     <link rel="stylesheet" href="/css/layout.css">
-    <link rel="stylesheet" href="/css/big-screen.css">
+    <link rel="stylesheet" href="/css/wide-screen.css">
     <link rel="stylesheet" href="/css/markdown-common.css">
     <link rel="stylesheet" href="/css/code-block.css">
     <link rel="stylesheet" href="/css/code-block-header.css">

--- a/web/src/App.vue
+++ b/web/src/App.vue
@@ -19,28 +19,28 @@
       />
       <ConnectionOverlay />
 
-      <main class="main-content" :class="{ 'big-screen': isBigScreen }">
-        <!-- Big-screen vertical dock (non-chat tabs only) -->
-        <div v-show="isBigScreen" class="big-dock">
-          <div class="big-dock-center">
-            <div class="dock-active-indicator big-dock-active-indicator" :style="bigDockIndicatorStyle"></div>
-            <div v-for="tab in BIG_SCREEN_DOCK_TABS" :key="tab" class="dock-btn-wrap">
-              <button class="dock-btn" :class="bigDockBtnClass(tab)" @click.stop="handleBigDockTabClick(tab)" :title="bigDockTabTitle(tab)">
-                <component :is="bigDockTabIcon(tab)" />
+      <main class="main-content" :class="{ 'wide-screen': isWideScreen }">
+        <!-- Wide-screen vertical dock (non-chat tabs only) -->
+        <div v-show="isWideScreen" class="wide-dock">
+          <div class="wide-dock-center">
+            <div class="dock-active-indicator wide-dock-active-indicator" :style="wideDockIndicatorStyle"></div>
+            <div v-for="tab in WIDE_SCREEN_DOCK_TABS" :key="tab" class="dock-btn-wrap">
+              <button class="dock-btn" :class="wideDockBtnClass(tab)" @click.stop="handleWideDockTabClick(tab)" :title="wideDockTabTitle(tab)">
+                <component :is="wideDockTabIcon(tab)" />
               </button>
-              <span v-if="bigDockBadgeVisible(tab)" class="dock-badge dock-badge-count" :class="{ 'dock-badge-pop': bigDockBadgeAnim(tab) }" @animationend="bigDockBadgeAnimEnd(tab)">{{ formatBadgeCount(bigDockBadgeCount(tab)) }}</span>
+              <span v-if="wideDockBadgeVisible(tab)" class="dock-badge dock-badge-count" :class="{ 'dock-badge-pop': wideDockBadgeAnim(tab) }" @animationend="wideDockBadgeAnimEnd(tab)">{{ formatBadgeCount(wideDockBadgeCount(tab)) }}</span>
             </div>
           </div>
         </div>
 
         <div class="content-area" id="contentArea">
           <SplitView
-            :enabled="isBigScreen"
+            :enabled="isWideScreen"
             :ratio="splitRatio"
             @update:ratio="onSplitRatioChange"
           >
             <template #left>
-              <div class="col-left" v-show="isBigScreen || activeTab !== 'chat'" @pointerdown="setActivePane('left')" @focusin="setActivePane('left')">
+              <div class="col-left" v-show="isWideScreen || activeTab !== 'chat'" @pointerdown="setActivePane('left')" @focusin="setActivePane('left')">
                 <!-- File Browse Tab (合一：目录浏览 + 文件覆盖预览) -->
                 <TabPanel tabId="browse" :activeTab="leftPanelActive" :noHeader="true">
                   <div class="browse-panel">
@@ -132,7 +132,7 @@
             </template>
 
             <template #right>
-              <div class="col-right" v-show="isBigScreen || activeTab === 'chat'" :class="{ 'chat-drop-active': chatDropActive }" @pointerdown="setActivePane('right')" @focusin="setActivePane('right')" @dragenter="onChatColDragEnter" @dragover="onChatColDragOver" @dragleave="onChatColDragLeave" @drop="onChatColDrop">
+              <div class="col-right" v-show="isWideScreen || activeTab === 'chat'" :class="{ 'chat-drop-active': chatDropActive }" @pointerdown="setActivePane('right')" @focusin="setActivePane('right')" @dragenter="onChatColDragEnter" @dragover="onChatColDragOver" @dragleave="onChatColDragLeave" @drop="onChatColDrop">
                 <!-- Chat Tab -->
                 <TabPanel tabId="chat" :activeTab="chatActive">
                   <template #header>
@@ -142,7 +142,7 @@
                     </div>
                   </template>
                   <ChatPanelContent
-                    :active="isBigScreen || activeTab === 'chat'"
+                    :active="isWideScreen || activeTab === 'chat'"
                     :keyboard-active="chatShortcutActive"
                     :current-file="currentFile"
                     :current-dir="currentDir"
@@ -226,7 +226,7 @@
       />
 
       <!-- Bottom dock (tab bar) -->
-      <div v-if="isAuthenticated" v-show="!anyKeyboardActive && !isBigScreen" class="bottom-dock-wrapper">
+      <div v-if="isAuthenticated" v-show="!anyKeyboardActive && !isWideScreen" class="bottom-dock-wrapper">
         <div ref="dockRef" class="bottom-dock">
           <div class="dock-center">
             <div class="dock-active-indicator" :style="dockIndicatorStyle"></div>
@@ -383,15 +383,15 @@ import { useChatContext } from './composables/useChatContext.ts'
 import { readAttachDragData, hasAttachDragData } from './utils/attachDrag'
 import SplitView from './components/common/SplitView.vue'
 import {
-  useBigScreenLayout,
+  useWideScreenLayout,
   resolveLeftTabOnEnter,
   setActivePane,
   resolveActivePaneOnEnter,
   switchLeftTab,
   setSplitRatio,
-  registerBigScreenCallbacks,
-  BIG_SCREEN_DOCK_TABS,
-} from './composables/useBigScreenLayout'
+  registerWideScreenCallbacks,
+  WIDE_SCREEN_DOCK_TABS,
+} from './composables/useWideScreenLayout'
 import 'highlight.js/styles/github.css'
 import 'highlight.js/styles/github-dark.css'
 import './assets/hljs-light-override.css'
@@ -498,18 +498,18 @@ async function hotSwitchProject(newProjectPath, pendingSessionId) {
 
 const activeTab = ref('chat')
 
-// ── Big-screen layout state ──
-const { isBigScreen, leftTab, splitRatio, activePane } = useBigScreenLayout()
+// ── Wide-screen layout state ──
+const { isWideScreen, leftTab, splitRatio, activePane } = useWideScreenLayout()
 
-const chatActive = computed(() => (isBigScreen.value ? 'chat' : activeTab.value))
-const leftPanelActive = computed(() => (isBigScreen.value ? leftTab.value : activeTab.value))
+const chatActive = computed(() => (isWideScreen.value ? 'chat' : activeTab.value))
+const leftPanelActive = computed(() => (isWideScreen.value ? leftTab.value : activeTab.value))
 const panelIsActive = (tabId) =>
-  isBigScreen.value ? leftTab.value === tabId : activeTab.value === tabId
+  isWideScreen.value ? leftTab.value === tabId : activeTab.value === tabId
 
 // Focus-aware keyboard gating: a panel's global shortcuts only fire when the
-// user is actually working in that pane (big-screen) or that tab (narrow).
-const chatShortcutActive = computed(() => (isBigScreen.value ? activePane.value === 'right' : activeTab.value === 'chat'))
-const fileManagerShortcutActive = computed(() => (isBigScreen.value ? activePane.value === 'left' : activeTab.value === 'browse'))
+// user is actually working in that pane (wide-screen) or that tab (narrow).
+const chatShortcutActive = computed(() => (isWideScreen.value ? activePane.value === 'right' : activeTab.value === 'chat'))
+const fileManagerShortcutActive = computed(() => (isWideScreen.value ? activePane.value === 'left' : activeTab.value === 'browse'))
 
 function onSplitRatioChange(ratio) {
   setSplitRatio(ratio)
@@ -535,8 +535,8 @@ const dockIndicatorStyle = computed(() => ({
 }))
 
 function switchTab(tab) {
-  if (isBigScreen.value) {
-    // Big-screen: chat is always visible; non-chat tabs route to the left column
+  if (isWideScreen.value) {
+    // Wide-screen: chat is always visible; non-chat tabs route to the left column
     if (tab === 'chat') return
     switchLeftTab(tab)
     return
@@ -693,14 +693,14 @@ const isPlatformUnsupported = computed(() => platformSupported.value === false)
 const isTerminalDisabled = computed(() => terminalRuntimeEnabled.value !== true)
 watch(isSSHDisabled, (disabled) => {
   if (disabled && panelIsActive('proxy')) {
-    switchTab(isBigScreen.value ? 'browse' : 'chat')
+    switchTab(isWideScreen.value ? 'browse' : 'chat')
   }
 })
 watch(isTerminalDisabled, (disabled) => {
   // Only force-switch when terminal is config-disabled (not platform unsupported).
   // Platform unsupported shows a dedicated empty state — user can stay on the tab.
   if (disabled && !isPlatformUnsupported.value && panelIsActive('terminal')) {
-    switchTab(isBigScreen.value ? 'browse' : 'chat')
+    switchTab(isWideScreen.value ? 'browse' : 'chat')
   }
 })
 const { navigateToTaskSettings, navigateToTaskHistory, openExecDetail, loadTasks } = useTaskTab()
@@ -1317,9 +1317,9 @@ function handleInlineOverflowClick(tab) {
   }
 }
 
-// Big-screen mode transitions: keep useTabDrawer's currentTab coherent
+// Wide-screen mode transitions: keep useTabDrawer's currentTab coherent
 // (chat drawers work in wide mode; collapse returns to the last active tab).
-watch(isBigScreen, (val) => {
+watch(isWideScreen, (val) => {
   if (val) {
     // Continuity-first (Q1A): adopt activeTab if non-chat, else keep persisted leftTab
     const next = resolveLeftTabOnEnter(activeTab.value, leftTab.value)
@@ -1328,7 +1328,7 @@ watch(isBigScreen, (val) => {
     overflowMenuOpen.value = false
     // Focus continuity: the pane the user was working in becomes the active one.
     setActivePane(resolveActivePaneOnEnter(activeTab.value))
-    // Big-screen: the bottom dock is hidden, so bottom-sheet drawers must sit
+    // Wide-screen: the bottom dock is hidden, so bottom-sheet drawers must sit
     // flush with the screen bottom — don't let a stale --dock-height leave a gap.
     document.documentElement.style.setProperty('--dock-height', '0px')
   } else {
@@ -1347,7 +1347,7 @@ watch(isBigScreen, (val) => {
 }, { immediate: true })
 
 // Route leftTab side-effects (reuse narrow-mode behaviors) and sync activeTab (Q3B)
-registerBigScreenCallbacks({
+registerWideScreenCallbacks({
   setActiveTab: (tab) => { activeTab.value = tab },
   sideEffects: (tab) => {
     if (tab === 'browse') store.loadFiles(store.state.currentDir)
@@ -1355,27 +1355,27 @@ registerBigScreenCallbacks({
   },
 })
 
-// ── Big-screen vertical dock helpers ──
-function handleBigDockTabClick(tab) {
+// ── Wide-screen vertical dock helpers ──
+function handleWideDockTabClick(tab) {
   // Clicking a dock item means the user intends to work in the left pane.
   setActivePane('left')
   switchLeftTab(tab)
 }
 
-// ── Drag file/dir from the left panel → attach to chat (big-screen only) ──
+// ── Drag file/dir from the left panel → attach to chat (wide-screen only) ──
 const { addAttachedFile } = useChatContext()
 const chatDropActive = ref(false)
 let chatDropCounter = 0
 
 function onChatColDragEnter(e) {
-  if (!isBigScreen.value || !hasAttachDragData(e.dataTransfer)) return
+  if (!isWideScreen.value || !hasAttachDragData(e.dataTransfer)) return
   chatDropCounter++
   chatDropActive.value = true
 }
 
 function onChatColDragOver(e) {
   // Allow the drop only for internal attach drags (don't hijack OS file drops)
-  if (isBigScreen.value && hasAttachDragData(e.dataTransfer)) e.preventDefault()
+  if (isWideScreen.value && hasAttachDragData(e.dataTransfer)) e.preventDefault()
 }
 
 function onChatColDragLeave() {
@@ -1389,7 +1389,7 @@ function onChatColDragLeave() {
 function onChatColDrop(e) {
   chatDropCounter = 0
   chatDropActive.value = false
-  if (!isBigScreen.value) return
+  if (!isWideScreen.value) return
   const data = readAttachDragData(e.dataTransfer)
   if (!data) return
   e.preventDefault()
@@ -1397,7 +1397,7 @@ function onChatColDrop(e) {
   toast.show(t('chat.attach.addedToChat'), { icon: '📎', type: 'success', duration: 1500 })
 }
 
-const bigScreenTabMeta = {
+const wideScreenTabMeta = {
   browse: { icon: FolderOpen, titleKey: 'nav.fileManager' },
   history: { icon: GitBranch, titleKey: 'git.history.projectHistory' },
   tasks: overflowTabMeta.tasks,
@@ -1406,13 +1406,13 @@ const bigScreenTabMeta = {
   settings: overflowTabMeta.settings,
 }
 
-function bigDockTabIcon(tab) {
-  return bigScreenTabMeta[tab]?.icon ?? FolderOpen
+function wideDockTabIcon(tab) {
+  return wideScreenTabMeta[tab]?.icon ?? FolderOpen
 }
-function bigDockTabTitle(tab) {
-  return bigScreenTabMeta[tab] ? t(bigScreenTabMeta[tab].titleKey) : ''
+function wideDockTabTitle(tab) {
+  return wideScreenTabMeta[tab] ? t(wideScreenTabMeta[tab].titleKey) : ''
 }
-function bigDockBtnClass(tab) {
+function wideDockBtnClass(tab) {
   return {
     active: leftTab.value === tab,
     'has-unread': tab === 'tasks' && store.state.taskUnreadCount > 0 && leftTab.value !== 'tasks',
@@ -1420,7 +1420,7 @@ function bigDockBtnClass(tab) {
     'has-running': tab === 'tasks' && store.state.taskRunning && leftTab.value !== 'tasks',
   }
 }
-function bigDockBadgeCount(tab) {
+function wideDockBadgeCount(tab) {
   switch (tab) {
     case 'history': return store.state.gitWorkingTreeChangeCount
     case 'tasks': return store.state.taskUnreadCount
@@ -1429,10 +1429,10 @@ function bigDockBadgeCount(tab) {
     default: return 0
   }
 }
-function bigDockBadgeVisible(tab) {
-  return bigDockBadgeCount(tab) > 0 && leftTab.value !== tab
+function wideDockBadgeVisible(tab) {
+  return wideDockBadgeCount(tab) > 0 && leftTab.value !== tab
 }
-function bigDockBadgeAnim(tab) {
+function wideDockBadgeAnim(tab) {
   switch (tab) {
     case 'history': return historyBadgeAnim.value
     case 'tasks': return taskBadgeAnim.value
@@ -1441,7 +1441,7 @@ function bigDockBadgeAnim(tab) {
     default: return false
   }
 }
-function bigDockBadgeAnimEnd(tab) {
+function wideDockBadgeAnimEnd(tab) {
   switch (tab) {
     case 'history': historyBadgeAnim.value = false; break
     case 'tasks': taskBadgeAnim.value = false; break
@@ -1449,12 +1449,12 @@ function bigDockBadgeAnimEnd(tab) {
     case 'proxy': proxyBadgeAnim.value = false; break
   }
 }
-const bigDockActiveIndex = computed(() => {
-  const i = BIG_SCREEN_DOCK_TABS.indexOf(leftTab.value)
+const wideDockActiveIndex = computed(() => {
+  const i = WIDE_SCREEN_DOCK_TABS.indexOf(leftTab.value)
   return i >= 0 ? i : 0
 })
-const bigDockIndicatorStyle = computed(() => ({
-  transform: `translateY(${bigDockActiveIndex.value * DOCK_STEP}px)`,
+const wideDockIndicatorStyle = computed(() => ({
+  transform: `translateY(${wideDockActiveIndex.value * DOCK_STEP}px)`,
 }))
 
 const isOverflowTabActive = computed(() => popupOverflowTabs.value.includes(activeTab.value))
@@ -1863,7 +1863,7 @@ function handleCtrlF(e) {
     // Skip when modal dialog or project dialog is open
     if (_dlg.state.value.visible || projectDialogOpen.value) return
 
-    if (isBigScreen.value) {
+    if (isWideScreen.value) {
         // Focus-aware: route Ctrl+F to the pane the user is working in
         if (activePane.value === 'right') {
             e.preventDefault()
@@ -1925,14 +1925,14 @@ onUnmounted(() => {
   overflow: hidden;
 }
 
-/* Big-screen split panes — positioned ancestors for the absolute TabPanels */
+/* Wide-screen split panes — positioned ancestors for the absolute TabPanels */
 .col-left,
 .col-right {
     position: relative;
     height: 100%;
 }
 
-/* Drag file/dir onto the chat column (big-screen) — highlight the drop target */
+/* Drag file/dir onto the chat column (wide-screen) — highlight the drop target */
 .chat-drop-active::after {
     content: '';
     position: absolute;
@@ -1984,8 +1984,8 @@ onUnmounted(() => {
     user-select: none;
 }
 
-/* Big-screen vertical dock (left edge) — VS Code activity-bar style */
-.big-dock {
+/* Wide-screen vertical dock (left edge) — VS Code activity-bar style */
+.wide-dock {
     flex-shrink: 0;
     width: 48px;
     display: flex;
@@ -1997,7 +1997,7 @@ onUnmounted(() => {
     user-select: none;
 }
 
-.big-dock-center {
+.wide-dock-center {
     position: relative;
     width: 100%;
     display: flex;
@@ -2008,10 +2008,10 @@ onUnmounted(() => {
 
 /* VS Code activity-bar style active highlight: faint translucent theme tint
    spanning the dock width + a thin theme-colored bar on the left edge.
-   Scoped under .big-dock so it outranks the base .dock-active-indicator
-   (same single-class specificity — a bare .big-dock-active-indicator would
+   Scoped under .wide-dock so it outranks the base .dock-active-indicator
+   (same single-class specificity — a bare .wide-dock-active-indicator would
    lose to the later base rule and render as the circular water-drop). */
-.big-dock .big-dock-active-indicator {
+.wide-dock .wide-dock-active-indicator {
     position: absolute;
     left: 0;
     top: 0;
@@ -2023,7 +2023,7 @@ onUnmounted(() => {
        ease-out reads better on a full-width highlight. */
     transition: transform 0.2s cubic-bezier(0.16, 1, 0.3, 1);
 }
-.big-dock .big-dock-active-indicator::before {
+.wide-dock .wide-dock-active-indicator::before {
     content: '';
     position: absolute;
     left: 0;
@@ -2034,10 +2034,10 @@ onUnmounted(() => {
 }
 
 /* Active icon follows the theme color (VS Code activity bar) */
-.big-dock .dock-btn.active {
+.wide-dock .dock-btn.active {
     color: var(--accent-color);
 }
-.big-dock .dock-btn.active:hover {
+.wide-dock .dock-btn.active:hover {
     color: var(--accent-color);
 }
 

--- a/web/src/App.vue
+++ b/web/src/App.vue
@@ -376,7 +376,7 @@ import ConnectionOverlay from './components/common/ConnectionOverlay.vue'
 import { useUpgrade } from './composables/useUpgrade'
 import { useEdgeSwipeBack, useFeatureBackHandler, PRIORITY_OVERLAY } from './composables/useEdgeSwipeBack'
 import { handleBackNavigation, requestExitConfirm } from './composables/useBackHandler'
-import { store, loadBrowseDir } from './stores/app.ts'
+import { store, loadBrowseDir, loadOpenFile, clearOpenFile } from './stores/app.ts'
 import { setPendingCommitNavigation } from './composables/useCommitNavigation.ts'
 import { getFileType } from './utils/fileType.ts'
 import { formatBadgeCount } from './utils/format.ts'
@@ -415,6 +415,8 @@ async function hotSwitchProject(newProjectPath, pendingSessionId) {
   await new Promise(r => setTimeout(r, 150))
 
   // ── Phase 2: POST to backend — now returns full init data (roots, homeDir, config) ──
+  // Clear open file for the OLD project before switching (setProject resets projectRoot)
+  clearOpenFile()
   try {
     await store.setProject(newProjectPath)
   } catch (err) {
@@ -466,6 +468,12 @@ async function hotSwitchProject(newProjectPath, pendingSessionId) {
       }
     } else {
       await store.loadFiles('')
+    }
+    // Restore last opened file for this project
+    const savedFile = loadOpenFile()
+    if (savedFile) {
+      const ok = await store.selectFile(savedFile)
+      if (ok) fileNav.openFile(savedFile)
     }
   }
   await sessionIdentity.initSessionFromAPI()
@@ -686,6 +694,7 @@ const fileNav = useFileNavStack()
 
 function closeOverlayAndSync() {
   fileNav.closeOverlay()
+  clearOpenFile()
   tocDrawer.close()
   detailsDrawer.close()
   searchDrawer.close()
@@ -986,6 +995,12 @@ async function initializeApp() {
     try { await store.loadFiles('') } catch {
       toast.show(t('toast.fileListLoadFailed'), { icon: '⚠️', type: 'error', duration: 6000 })
     }
+  }
+  // Restore last opened file (per-project)
+  const savedFile = loadOpenFile()
+  if (savedFile) {
+    const ok = await store.selectFile(savedFile)
+    if (ok) fileNav.openFile(savedFile)
   }
   return true
 }

--- a/web/src/App.vue
+++ b/web/src/App.vue
@@ -40,7 +40,7 @@
             @update:ratio="onSplitRatioChange"
           >
             <template #left>
-              <div class="col-left" v-show="isWideScreen || activeTab !== 'chat'" @pointerdown="setActivePane('left')" @focusin="setActivePane('left')">
+              <div class="col-left" v-show="isWideScreen || activeTab !== 'chat'" @pointerdown="onLeftPanePointerDown" @focusin="setActivePane('left')">
                 <!-- File Browse Tab (合一：目录浏览 + 文件覆盖预览) -->
                 <TabPanel tabId="browse" :activeTab="leftPanelActive" :noHeader="true">
                   <div class="browse-panel">
@@ -183,8 +183,9 @@
         @select-file="handleRecentFileSelect"
       />
 
-      <!-- Quote question floating bar -->
+      <!-- Quote question floating bar (narrow mode only; wide-screen uses ChatInputBar quote tag) -->
       <QuoteQuestionBar
+        v-if="!isWideScreen"
         :visible="quoteQuestion.visible.value"
         :quoteData="quoteQuestion.quoteData.value"
         @send="quoteQuestion.sendMessage($event)"
@@ -349,7 +350,7 @@ import HeaderMarquee from './components/common/HeaderMarquee.vue'
 import AgentIcon from './components/common/AgentIcon.vue'
 import SettingsPage from './components/settings/SettingsPage.vue'
 import TaskTab from '@/components/task/TaskTab.vue'
-import { useQuoteQuestion } from './composables/useQuoteQuestion.ts'
+import { useQuoteQuestion, restoreBarVisibility } from './composables/useQuoteQuestion.ts'
 import { useTaskTab, registerSwitchTab, onTaskEvent } from '@/composables/useTaskTab.ts'
 import { useTabDrawer, onTabSwitch, resetTabDrawerState } from '@/composables/useTabDrawer.ts'
 import { resetAgents, useAgents } from '@/composables/useAgents'
@@ -513,6 +514,18 @@ const fileManagerShortcutActive = computed(() => (isWideScreen.value ? activePan
 
 function onSplitRatioChange(ratio) {
   setSplitRatio(ratio)
+}
+
+// Clicking into the left pane must also move keyboard focus out of any text
+// field (e.g. the chat input on the right). Otherwise the focused INPUT/TEXTAREA
+// stays the event target and the file manager's input-focus guard swallows all
+// its keyboard shortcuts even though the user has clearly clicked into it.
+function onLeftPanePointerDown() {
+  setActivePane('left')
+  const el = document.activeElement
+  if (el && (el.tagName === 'INPUT' || el.tagName === 'TEXTAREA' || el.isContentEditable)) {
+    el.blur()
+  }
 }
 
 // Dock active indicator — water-drop sliding highlight
@@ -1323,7 +1336,15 @@ watch(isWideScreen, (val) => {
   if (val) {
     // Continuity-first (Q1A): adopt activeTab if non-chat, else keep persisted leftTab
     const next = resolveLeftTabOnEnter(activeTab.value, leftTab.value)
-    if (leftTab.value !== next) switchLeftTab(next)
+    if (leftTab.value !== next) {
+      switchLeftTab(next) // updates leftTab + activeTab + side effects
+    } else if (activeTab.value !== next) {
+      // leftTab already matches but activeTab is stale (e.g. entered wide-screen
+      // from chat while leftTab was persisted as browse). Sync it so tab-gated
+      // logic — like the file manager's `activeTab !== 'browse'` shortcut gate —
+      // isn't blocked by a stale 'chat' activeTab.
+      activeTab.value = next
+    }
     onTabSwitch('chat')
     overflowMenuOpen.value = false
     // Focus continuity: the pane the user was working in becomes the active one.
@@ -1333,6 +1354,10 @@ watch(isWideScreen, (val) => {
     document.documentElement.style.setProperty('--dock-height', '0px')
   } else {
     onTabSwitch(activeTab.value)
+    // Restore QuoteQuestionBar visibility if a pinned quote exists
+    // (wide-screen auto-pin sets barVisible=false because the floating bar
+    // is hidden there; switching to narrow needs the bar back).
+    restoreBarVisibility()
     // Bottom dock visible again — re-measure (ResizeObserver may miss the
     // display:none → visible transition, see the keyboard safety-net comment).
     nextTick(() => {

--- a/web/src/components/__tests__/gitGraphUtils.test.ts
+++ b/web/src/components/__tests__/gitGraphUtils.test.ts
@@ -760,6 +760,47 @@ describe('lane compression for non-overlapping branches', () => {
   })
 })
 
+describe('lane compression does not leave empty lanes next to the mainline', () => {
+  // Regression: a long branch forked off the mainline must land on the lane
+  // immediately adjacent to the mainline (lane 1), even when a short branch
+  // occupied lane 1 earlier. The fork connection only reaches the branch lane
+  // at the branch tip's own row, so the branch's occupied range must NOT be
+  // extended up to the fork's merge-commit row — otherwise the later branch
+  // is pushed to lane 2 and an empty lane appears between it and the main.
+  //
+  // Graph:
+  //   m3 → mergeS ──→ base ──→ m2 → m1 → root
+  //          │   ↘                 │   ↗
+  //          │     s1              lb1 → lb2
+  const BRANCH_AFTER_FORK = [
+    { sha: 'm3', parents: ['mergeS'], msg: 'main: 3' },
+    { sha: 'mergeS', parents: ['base', 's1'], msg: 'merge: short' },
+    { sha: 's1', parents: ['base'], msg: 'short: work 1' },
+    { sha: 'base', parents: ['m2', 'lb1'], msg: 'merge: long' },
+    { sha: 'lb1', parents: ['lb2'], msg: 'long: work 1' },
+    { sha: 'lb2', parents: ['m2'], msg: 'long: work 2' },
+    { sha: 'm2', parents: ['m1'], msg: 'main: 2' },
+    { sha: 'm1', parents: ['root'], msg: 'main: 1' },
+    { sha: 'root', parents: [], msg: 'root' },
+  ]
+
+  it('long branch forked off the mainline sits on lane 1 (adjacent), not lane 2', () => {
+    const { nodes } = getConnections(BRANCH_AFTER_FORK)
+    // Short branch (s1) is above the fork, long branch (lb1/lb2) below it.
+    // Both share lane 1: the long branch must NOT be pushed to lane 2.
+    expect(nodes[2].lane).toBe(1) // s1
+    expect(nodes[4].lane).toBe(1) // lb1
+    expect(nodes[5].lane).toBe(1) // lb2
+    expect(nodes[3].lane).toBe(0) // base (merge commit) on mainline
+    expect(nodes[6].lane).toBe(0) // m2 on mainline
+  })
+
+  it('uses only 2 lanes (no empty lane between main and the long branch)', () => {
+    const { laneCount } = getConnections(BRANCH_AFTER_FORK)
+    expect(laneCount).toBe(2)
+  })
+})
+
 describe('branchNames on nodes', () => {
   it('attaches branch names to nodes by walking first-parent chain from branch refs', () => {
     const { nodes } = getConnections(SINGLE_MERGE) as any

--- a/web/src/components/chat/ChatInputBar.vue
+++ b/web/src/components/chat/ChatInputBar.vue
@@ -65,11 +65,10 @@
       </Transition>
       <!-- Attachment tags (horizontal scrollable cards — only quote + attached file refs) -->
       <div v-if="quoteData || attachedFiles.length > 0" class="chat-attachment-tags">
-        <!-- Quote selection card -->
+        <!-- Quote selection card (same size as file cards, accent-colored) -->
         <span v-if="quoteData" class="chat-file-attachment attachment-quote" :title="quoteData.filePath" @click="$emit('quote-click')">
-          <MessageSquare :size="14" :stroke-width="1.5" class="attachment-quote-icon" />
-          <span class="attachment-filename">{{ truncateQuoteText(quoteData.text, 20) }}</span>
-          <span v-if="quoteData.startLine" class="attachment-filesize">L{{ quoteData.startLine }}</span>
+          <Code2 :size="14" :stroke-width="1.5" class="attachment-quote-icon" />
+          <span class="attachment-filename">{{ quoteFileName }}{{ quoteLineRange }}</span>
           <button class="attachment-close-btn" @click.stop="$emit('remove-quote')" :title="t('common.remove')">×</button>
         </span>
         <!-- Attached file reference cards (shared component) -->
@@ -241,7 +240,7 @@
 <script setup>
 import { ref, computed, nextTick, watch, onBeforeUnmount, onMounted, defineAsyncComponent } from 'vue'
 import { useI18n } from 'vue-i18n'
-import { MessageSquare, List, Plus, Search, Archive, Volume2, Upload, Paperclip, XCircle, Inbox, Send, Square, Zap, Loader2, Compass, Activity, MessagesSquare, RotateCcw, ClipboardPaste, Minimize2 } from 'lucide-vue-next'
+import { Code2, List, Plus, Search, Archive, Volume2, Upload, Paperclip, XCircle, Inbox, Send, Square, Zap, Loader2, Compass, Activity, MessagesSquare, RotateCcw, ClipboardPaste, Minimize2 } from 'lucide-vue-next'
 import { highlightText } from '@/utils/searchUtils.ts'
 import { computeRecentReferencedFiles } from '@/utils/chatInputUtils.ts'
 import ProviderIcon from '@/components/common/ProviderIcon.vue'
@@ -672,11 +671,18 @@ async function handleArchive() {
   }
 }
 
-function truncateQuoteText(text, maxLen) {
-  if (!text) return ''
-  const oneLine = text.replace(/\n/g, ' ')
-  return oneLine.length > maxLen ? oneLine.slice(0, maxLen) + '...' : oneLine
-}
+const quoteFileName = computed(() => {
+  if (!props.quoteData?.filePath) return ''
+  return props.quoteData.filePath.split('/').pop() || props.quoteData.filePath
+})
+
+const quoteLineRange = computed(() => {
+  if (!props.quoteData?.startLine) return ''
+  const s = props.quoteData.startLine
+  const e = props.quoteData.endLine
+  if (e && e !== s) return `:${s}-${e}`
+  return `:${s}`
+})
 
 function autoResizeTextarea() {
   const el = textareaRef.value
@@ -1530,7 +1536,7 @@ defineExpose({
   background: color-mix(in srgb, var(--accent-color, #0066cc) 18%, transparent);
 }
 
-/* Quote card */
+/* Quote card — accent-colored, same size as file cards */
 .chat-attachment-tags .attachment-quote {
   background: color-mix(in srgb, var(--accent-color, #4f9cf7) 8%, transparent);
   border: 1px dashed var(--accent-color, #4f9cf7);
@@ -1540,10 +1546,6 @@ defineExpose({
 
 .chat-attachment-tags .attachment-quote .attachment-filename {
   color: var(--accent-color, #4f9cf7);
-}
-
-.chat-attachment-tags .attachment-quote .attachment-filesize {
-  color: color-mix(in srgb, var(--accent-color, #4f9cf7) 60%, transparent);
 }
 
 .chat-attachment-tags .attachment-quote:hover {

--- a/web/src/components/chat/ChatMessageItem.vue
+++ b/web/src/components/chat/ChatMessageItem.vue
@@ -704,11 +704,13 @@ function handleCopyMessage() {
 .chat-message.user a {
     word-break: break-all;
     overflow-wrap: break-word;
-    color: #b8daff;
+    color: white;
+    text-decoration: underline;
+    text-underline-offset: 2px;
 }
 
 .chat-message.user a:hover {
-    color: #9dc5f0;
+    color: rgba(255, 255, 255, 0.85);
 }
 
 .chat-message.user img {

--- a/web/src/components/chat/ChatMessageItem.vue
+++ b/web/src/components/chat/ChatMessageItem.vue
@@ -232,18 +232,52 @@ function handleCopyMessage() {
 
 /* Image thumbnail style */
 .chat-message .chat-img {
-  cursor: pointer;
   vertical-align: middle;
 }
 
-.chat-message .lightbox-img {
+/* Lightbox image wrapper — positions the expand icon overlay */
+.chat-message .lightbox-img-wrap {
+  position: relative;
+  display: inline-block;
+}
+
+.chat-message .lightbox-img-wrap .lightbox-img {
   cursor: pointer;
   transition: transform 0.15s, box-shadow 0.15s;
 }
 
-.chat-message .lightbox-img:hover {
+.chat-message .lightbox-img-wrap:hover .lightbox-img {
   transform: scale(1.02);
   box-shadow: 0 4px 12px rgba(0, 0, 0, 0.15);
+}
+
+/* Expand icon — top-right corner, visible on hover (PC mode) */
+.chat-message .lightbox-img-wrap .lightbox-expand-icon {
+  display: none;
+  position: absolute;
+  top: 4px;
+  right: 4px;
+  width: 24px;
+  height: 24px;
+  border-radius: 4px;
+  background: rgba(0, 0, 0, 0.5);
+  color: #fff;
+  cursor: pointer;
+  z-index: 2;
+  pointer-events: auto;
+}
+
+.chat-message .lightbox-img-wrap:hover .lightbox-expand-icon {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+/* Use a simple "+" character as the expand icon (no SVG dependency in HTML strings) */
+.chat-message .lightbox-img-wrap .lightbox-expand-icon::after {
+  content: '⤢';
+  font-size: 14px;
+  line-height: 1;
 }
 
 /* ── Message content wrapper ── */
@@ -902,11 +936,35 @@ function handleCopyMessage() {
   transition: transform 0.15s, box-shadow 0.15s;
   background: var(--bg-secondary);
   padding: 8px;
+  position: relative;
 }
 
 .chat-message .mermaid:hover {
   transform: scale(1.02);
   box-shadow: 0 4px 12px rgba(0, 0, 0, 0.15);
+}
+
+/* Mermaid expand icon — top-right corner, visible on hover (PC mode) */
+.chat-message .mermaid::after {
+  content: '⤢';
+  display: none;
+  position: absolute;
+  top: 4px;
+  right: 4px;
+  width: 24px;
+  height: 24px;
+  border-radius: 4px;
+  background: rgba(0, 0, 0, 0.5);
+  color: #fff;
+  font-size: 14px;
+  line-height: 24px;
+  text-align: center;
+  cursor: pointer;
+  z-index: 2;
+}
+
+.chat-message .mermaid:hover::after {
+  display: block;
 }
 
 .chat-message .mermaid svg {

--- a/web/src/components/chat/ChatPanelContent.vue
+++ b/web/src/components/chat/ChatPanelContent.vue
@@ -92,7 +92,7 @@
       @add-attached="addAttachedFile"
       @remove-attached="removeAttachedFile"
       @remove-attached-by-path="removeAttachedFileByPath"
-      @remove-quote="setQuoteData(null)"
+      @remove-quote="setQuoteData(null); resetQuotePin()"
       @quote-click="handleQuoteClick"
       @open-session-tab="identity.openSessionTab"
       @open-session-search="$emit('open-session-search')"
@@ -173,6 +173,8 @@ import { useNotification } from '@/composables/useNotification.ts'
 import { applySummaryUpdate } from '@/utils/chatSessionUtils.ts'
 import { useFileUpload } from '@/composables/useFileUpload.ts'
 import { useChatContext } from '@/composables/useChatContext.ts'
+import { buildQuoteMessage } from '@/utils/quoteQuestionUtils.ts'
+import { resetQuotePin } from '@/composables/useQuoteQuestion.ts'
 import { dedupeFiles } from '@/utils/fileAttachmentUtils.ts'
 import { refreshCurrentFile } from '@/composables/useFileRefresh.ts'
 import { playNotificationSound } from '@/composables/useNotificationSound.ts'
@@ -627,7 +629,20 @@ function persistSessionUpdate(fields) {
 }
 
 async function sendMessage(text) {
-    const inputText = text !== undefined ? text : (inputBarRef.value?.inputText?.trim() || '')
+    let inputText = text !== undefined ? text : (inputBarRef.value?.inputText?.trim() || '')
+
+    // Embed quote context into message body (wide-screen sends via ChatInputBar
+    // don't go through QuoteQuestionBar.sendMessage, so we must embed here).
+    if (quoteData.value) {
+      const q = quoteData.value
+      if (q.filePath) {
+        addAttachedFile(q.filePath, false, q.startLine, q.endLine)
+      }
+      // Always embed the quoted code block — even without typed text,
+      // the AI needs the code context from the quote.
+      inputText = buildQuoteMessage(inputText || '', q.text, q.filePath, q.language, q.startLine, q.endLine)
+    }
+
     const hasFiles = pendingFiles.value.length > 0 || attachedFiles.value.length > 0 || quoteData.value
 
     if ((!inputText && !hasFiles) || inputDisabled.value) return
@@ -644,6 +659,7 @@ async function sendMessage(text) {
       const queueId = `pending-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`
       // Clear input state synchronously so user sees immediate feedback
       clearAll()
+      resetQuotePin()
       inputBarRef.value?.clearInput()
       clearPendingFiles()
       // Push a pending user message directly into messages.value
@@ -680,6 +696,7 @@ async function sendMessage(text) {
 
     // Clear input state before async request
     clearAll()
+    resetQuotePin()
     inputBarRef.value?.clearInput()
     clearPendingFiles()
 

--- a/web/src/components/common/BottomSheet.vue
+++ b/web/src/components/common/BottomSheet.vue
@@ -47,7 +47,7 @@ const props = defineProps({
   auto: Boolean,     // 自适应模式，高度按内容需要，最大全屏
   noHeader: Boolean, // 隐藏Header（含手柄）
   handleOnly: Boolean, // 仅显示拖拽手柄，无标题栏
-  wide: Boolean, // 大屏模式放宽面板宽度（默认 560px → 820px）
+  wide: Boolean, // 宽屏模式放宽面板宽度（默认 560px → 820px）
   transparentOverlay: Boolean, // 透明遮罩（可点击关闭但可见底层内容）
   fullscreen: Boolean, // 全屏模式，覆盖 app header，用于无 header 的页面（如终端）
   closeGuard: Boolean, // 阻止一切关闭操作（overlay点击/header点击/返回手势），用于内部有原生选择器等场景
@@ -366,7 +366,7 @@ defineExpose({
   z-index: 1200;
 }
 
-/* Big-screen (≥1024px): constrain bottom-sheet width and center it.
+/* Wide-screen (≥1024px): constrain bottom-sheet width and center it.
    Keep narrow screens full-width. */
 @media (min-width: 1024px) {
   .bs-panel {

--- a/web/src/components/file/FileManagerContent.vue
+++ b/web/src/components/file/FileManagerContent.vue
@@ -1045,8 +1045,9 @@ function handleItemClick(e) {
     const action = item.dataset.action
     const path = item.dataset.path
 
-    // Multi-select mode: toggle selection on click
+    // Multi-select mode: toggle selection on click (also track last item for Space key)
     if (multiSelect.active) {
+        selectedPath.value = path
         toggleSelect(path)
         return
     }
@@ -1314,8 +1315,8 @@ function handleKeydown(e) {
         return
     }
 
-    // Delete — delete
-    if (e.key === 'Delete') {
+    // Delete — delete (Shift+Delete handled separately as force delete)
+    if (e.key === 'Delete' && !e.shiftKey) {
         if (multiSelect.active && multiSelect.selected.size > 0) {
             e.preventDefault()
             doBatchDelete()
@@ -1336,6 +1337,162 @@ function handleKeydown(e) {
         toggleSelectAll()
         return
     }
+
+    // ── Additional file-manager shortcuts ──
+
+    // Enter — open the currently selected entry (dir → navigate in, file → preview)
+    if (e.key === 'Enter') {
+        // Don't hijack Enter when an interactive element (button/link) is focused
+        if (selectedPath.value && !e.target.closest?.('button, a, select')) {
+            const entry = visibleEntries.value.find(x => itemPath(x.name) === selectedPath.value)
+            if (entry) {
+                e.preventDefault()
+                if (entry.type === 'dir') emit('navigateDir', selectedPath.value)
+                else emit('selectFile', selectedPath.value)
+            }
+        }
+        return
+    }
+
+    // Alt+↑ — parent directory
+    if (e.altKey && e.key === 'ArrowUp') {
+        e.preventDefault()
+        emit('navigateBack')
+        return
+    }
+
+    // F2 — rename the selected entry (falls back to the currently open file)
+    if (e.key === 'F2') {
+        const path = selectedPath.value || props.currentFile?.path
+        if (path) {
+            e.preventDefault()
+            emit('rename', { path, name: path.split('/').pop() || path })
+        }
+        return
+    }
+
+    // Ctrl+R / F5 — refresh
+    if ((isCtrl && e.key === 'r') || e.key === 'F5') {
+        e.preventDefault()
+        emit('refresh')
+        return
+    }
+
+    // Ctrl+Shift+H — toggle hidden files
+    if (isCtrl && e.shiftKey && e.key.toLowerCase() === 'h') {
+        e.preventDefault()
+        emit('toggleHidden')
+        return
+    }
+
+    // Ctrl+Shift+M — toggle multi-select mode
+    if (isCtrl && e.shiftKey && e.key.toLowerCase() === 'm') {
+        e.preventDefault()
+        if (multiSelect.active) exitMultiSelect()
+        else enterMultiSelect()
+        return
+    }
+
+    // Space — toggle the selected item while in multi-select mode
+    if (e.key === ' ' && multiSelect.active && selectedPath.value) {
+        e.preventDefault()
+        toggleSelect(selectedPath.value)
+        return
+    }
+
+    // Escape — exit multi-select mode
+    if (e.key === 'Escape' && multiSelect.active) {
+        e.preventDefault()
+        exitMultiSelect()
+        return
+    }
+
+    // ↑/↓/Home/End — move the highlighted selection (Windows Explorer / Finder style)
+    if (e.key === 'ArrowDown' || e.key === 'ArrowUp' || e.key === 'Home' || e.key === 'End') {
+        e.preventDefault()
+        const delta = e.key === 'ArrowDown' ? 1 : e.key === 'ArrowUp' ? -1 : 0
+        moveSelection(delta, e.key === 'Home', e.key === 'End')
+        // Shift+Arrow extends multi-select to the moved item
+        if (e.shiftKey && multiSelect.active && selectedPath.value) {
+            if (!multiSelect.selected.has(selectedPath.value)) toggleSelect(selectedPath.value)
+        }
+        return
+    }
+
+    // Backspace — parent directory
+    if (e.key === 'Backspace') {
+        e.preventDefault()
+        emit('navigateBack')
+        return
+    }
+
+    // Ctrl+N — new file; Ctrl+Shift+N — new folder
+    if (isCtrl && e.key === 'n') {
+        e.preventDefault()
+        if (e.shiftKey) doNewFolder()
+        else doNewFile()
+        return
+    }
+
+    // Ctrl+1 — list view; Ctrl+2 — grid view
+    if (isCtrl && e.key === '1') {
+        e.preventDefault()
+        viewMode.value = 'list'
+        return
+    }
+    if (isCtrl && e.key === '2') {
+        e.preventDefault()
+        viewMode.value = 'grid'
+        return
+    }
+
+    // Shift+Delete — force delete without confirmation (permanent)
+    if (e.shiftKey && e.key === 'Delete') {
+        e.preventDefault()
+        if (multiSelect.active && multiSelect.selected.size > 0) {
+            emit('batchDelete', [...multiSelect.selected])
+            exitMultiSelect()
+        } else if (selectedPath.value) {
+            emit('delete', selectedPath.value)
+        } else if (props.currentFile) {
+            emit('delete', props.currentFile.path)
+        }
+        return
+    }
+}
+
+/** Move the highlighted selection by delta (or to the start/end), scrolling it into view. */
+function moveSelection(delta, toStart = false, toEnd = false) {
+    const entries = visibleEntries.value
+    if (entries.length === 0) return
+    let idx
+    if (toStart) idx = 0
+    else if (toEnd) idx = entries.length - 1
+    else {
+        const cur = entries.findIndex(x => itemPath(x.name) === selectedPath.value)
+        idx = cur === -1 ? (delta > 0 ? 0 : entries.length - 1) : Math.min(entries.length - 1, Math.max(0, cur + delta))
+    }
+    const path = itemPath(entries[idx].name)
+    selectedPath.value = path
+    scrollSelectedIntoView(path)
+}
+
+/** Scroll the given entry into view within the active list/grid container. */
+function scrollSelectedIntoView(path) {
+    nextTick(() => {
+        const container = viewMode.value === 'grid' ? fileGridRef.value : fileListRef.value
+        if (!container) return
+        const items = container.querySelectorAll('[data-path]')
+        for (const it of items) {
+            if (it.getAttribute('data-path') === path) {
+                // jsdom (tests) may not implement scrollIntoView — guard it
+                if (typeof it.scrollIntoView === 'function') {
+                    it.scrollIntoView({ block: 'nearest' })
+                }
+                break
+            }
+        }
+    })
 }
 
 // Build a clipboard entry from the currently viewed/selected file

--- a/web/src/components/file/FileManagerContent.vue
+++ b/web/src/components/file/FileManagerContent.vue
@@ -184,7 +184,7 @@
         <div
           v-long-press="(e) => onLongPress(entry, e)"
           class="file-item"
-          :draggable="isBigScreen"
+          :draggable="isWideScreen"
           @dragstart="onItemDragStart(entry, $event)"
           :class="{
             'dir-item': entry.type === 'dir',
@@ -246,7 +246,7 @@
       <div v-for="entry in visibleEntries" :key="entry.name"
         v-long-press="(e) => onLongPress(entry, e)"
         class="grid-item"
-        :draggable="isBigScreen"
+        :draggable="isWideScreen"
         @dragstart="onItemDragStart(entry, $event)"
         :class="{
           'grid-dir': entry.type === 'dir',
@@ -401,7 +401,7 @@ import { useTerminalStatus } from '@/composables/useTerminalStatus.ts'
 import { useFeatureBackHandler, PRIORITY_PAGE } from '@/composables/useEdgeSwipeBack'
 import { useFileUpload } from '@/composables/useFileUpload.ts'
 import { useChatContext } from '@/composables/useChatContext.ts'
-import { useBigScreenLayout } from '@/composables/useBigScreenLayout'
+import { useWideScreenLayout } from '@/composables/useWideScreenLayout'
 import { setAttachDragData, hasAttachDragData } from '@/utils/attachDrag'
 import { downloadFileByPath } from '@/utils/download.ts'
 import { useFileNavStack } from '@/composables/useFileNavStack'
@@ -465,7 +465,7 @@ async function onDrop(e) {
 
 /** Start an internal drag of a file/dir so it can be dropped onto the chat column. */
 function onItemDragStart(entry, e) {
-  if (!isBigScreen.value) return
+  if (!isWideScreen.value) return
   const path = itemPath(entry.name)
   setAttachDragData(e.dataTransfer, path, entry.type === 'dir')
   e.dataTransfer.effectAllowed = 'copy'
@@ -519,7 +519,7 @@ const dialog = useDialog()
 const { addAttachedFile, hasAttachedFile, removeAttachedFileByPath } = useChatContext()
 const { terminalRuntimeEnabled } = useTerminalStatus()
 const isTerminalDisabled = computed(() => terminalRuntimeEnabled.value !== true)
-const { isBigScreen } = useBigScreenLayout()
+const { isWideScreen } = useWideScreenLayout()
 
 const activeTab = inject('activeTab', ref(''))
 
@@ -1259,7 +1259,7 @@ function doDelete() {
 function handleKeydown(e) {
     // Only active when browse tab is focused
     if (activeTab.value !== 'browse') return
-    // Focus-aware: in big-screen mode also require the left pane to be focused
+    // Focus-aware: in wide-screen mode also require the left pane to be focused
     if (props.keyboardActive === false) return
     // Skip in Android app mode
     if (isAppMode.value) return

--- a/web/src/components/file/MarkdownPreview.vue
+++ b/web/src/components/file/MarkdownPreview.vue
@@ -214,7 +214,7 @@ function fixLocalImagePaths(html: string): string {
     // Add lightbox-img class to all <img> tags for lightbox activation
     result = result.replace(/<img(\s+[^>]*?)>/gi, (_match: string, attrs: string) => {
       const clean = attrs.replace(/\s*class="[^"]*"/i, '')
-      return `<img${clean} class="lightbox-img">`
+      return `<span class="lightbox-img-wrap"><img${clean} class="lightbox-img"><span class="lightbox-expand-icon"></span></span>`
     })
     return result
 }
@@ -385,5 +385,75 @@ defineExpose({
     width: 20px;
     height: auto;
     z-index: 2;
+}
+
+/* Lightbox image wrapper — positions the expand icon overlay */
+.markdown-body .lightbox-img-wrap {
+  position: relative;
+  display: inline-block;
+}
+
+.markdown-body .lightbox-img-wrap .lightbox-img {
+  cursor: pointer;
+  transition: transform 0.15s, box-shadow 0.15s;
+}
+
+.markdown-body .lightbox-img-wrap:hover .lightbox-img {
+  transform: scale(1.02);
+  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.15);
+}
+
+.markdown-body .lightbox-img-wrap .lightbox-expand-icon {
+  display: none;
+  position: absolute;
+  top: 4px;
+  right: 4px;
+  width: 24px;
+  height: 24px;
+  border-radius: 4px;
+  background: rgba(0, 0, 0, 0.5);
+  color: #fff;
+  cursor: pointer;
+  z-index: 2;
+  pointer-events: auto;
+}
+
+.markdown-body .lightbox-img-wrap:hover .lightbox-expand-icon {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.markdown-body .lightbox-img-wrap .lightbox-expand-icon::after {
+  content: '⤢';
+  font-size: 14px;
+  line-height: 1;
+}
+
+/* Mermaid expand icon — top-right corner, visible on hover (PC mode) */
+.markdown-body .mermaid {
+  position: relative;
+}
+
+.markdown-body .mermaid::after {
+  content: '⤢';
+  display: none;
+  position: absolute;
+  top: 4px;
+  right: 4px;
+  width: 24px;
+  height: 24px;
+  border-radius: 4px;
+  background: rgba(0, 0, 0, 0.5);
+  color: #fff;
+  font-size: 14px;
+  line-height: 24px;
+  text-align: center;
+  cursor: pointer;
+  z-index: 2;
+}
+
+.markdown-body .mermaid:hover::after {
+  display: block;
 }
 </style>

--- a/web/src/components/file/__tests__/FileManagerContent.test.ts
+++ b/web/src/components/file/__tests__/FileManagerContent.test.ts
@@ -646,6 +646,218 @@ describe('FileManagerContent — keyboard shortcuts', () => {
     expect(wrapper.vm.multiSelectState.active).toBe(true)
   })
 
+  it('Alt+ArrowUp emits navigateBack (parent directory)', async () => {
+    const wrapper = mountContent()
+    await nextTick()
+
+    document.dispatchEvent(new KeyboardEvent('keydown', { key: 'ArrowUp', altKey: true, bubbles: true }))
+    await nextTick()
+
+    expect(wrapper.emitted('navigateBack')).toBeTruthy()
+  })
+
+  it('F2 emits rename for the current file', async () => {
+    const wrapper = mountContent({ currentFile: { path: 'test.ts', name: 'test.ts' } })
+    await nextTick()
+
+    document.dispatchEvent(new KeyboardEvent('keydown', { key: 'F2', bubbles: true }))
+    await nextTick()
+
+    expect(wrapper.emitted('rename')).toBeTruthy()
+    expect(wrapper.emitted('rename')![0]).toEqual([{ path: 'test.ts', name: 'test.ts' }])
+  })
+
+  it('Ctrl+R emits refresh', async () => {
+    const wrapper = mountContent()
+    await nextTick()
+
+    document.dispatchEvent(new KeyboardEvent('keydown', { key: 'r', ctrlKey: true, bubbles: true }))
+    await nextTick()
+
+    expect(wrapper.emitted('refresh')).toBeTruthy()
+  })
+
+  it('Ctrl+Shift+H emits toggleHidden', async () => {
+    const wrapper = mountContent()
+    await nextTick()
+
+    document.dispatchEvent(new KeyboardEvent('keydown', { key: 'h', ctrlKey: true, shiftKey: true, bubbles: true }))
+    await nextTick()
+
+    expect(wrapper.emitted('toggleHidden')).toBeTruthy()
+  })
+
+  it('Ctrl+Shift+M toggles multi-select mode', async () => {
+    const wrapper = mountContent()
+    await nextTick()
+
+    document.dispatchEvent(new KeyboardEvent('keydown', { key: 'm', ctrlKey: true, shiftKey: true, bubbles: true }))
+    await nextTick()
+
+    expect(wrapper.vm.multiSelectState.active).toBe(true)
+  })
+
+  it('Escape exits multi-select mode', async () => {
+    const wrapper = mountContent()
+    await nextTick()
+
+    document.dispatchEvent(new KeyboardEvent('keydown', { key: 'a', ctrlKey: true, bubbles: true }))
+    await nextTick()
+    expect(wrapper.vm.multiSelectState.active).toBe(true)
+
+    document.dispatchEvent(new KeyboardEvent('keydown', { key: 'Escape', bubbles: true }))
+    await nextTick()
+    expect(wrapper.vm.multiSelectState.active).toBe(false)
+  })
+
+  it('Enter opens the selected entry (file → selectFile)', async () => {
+    const wrapper = mountContent()
+    await nextTick()
+
+    // Select test.ts by clicking it (also emits selectFile once)
+    await wrapper.find('.file-item[data-path="test.ts"]').trigger('click')
+    await nextTick()
+
+    document.dispatchEvent(new KeyboardEvent('keydown', { key: 'Enter', bubbles: true }))
+    await nextTick()
+
+    const selects = wrapper.emitted('selectFile')
+    expect(selects).toBeTruthy()
+    expect(selects!.length).toBeGreaterThanOrEqual(2)
+  })
+
+  it('Enter on a focused button is not hijacked', async () => {
+    const wrapper = mountContent()
+    await nextTick()
+
+    // Click the item to select it, then simulate Enter while a button is the target
+    await wrapper.find('.file-item[data-path="test.ts"]').trigger('click')
+    await nextTick()
+    const selectsBefore = wrapper.emitted('selectFile')?.length ?? 0
+
+    const btn = document.createElement('button')
+    document.body.appendChild(btn)
+    // Dispatch on the button so e.target is the button (real focused-button scenario)
+    btn.dispatchEvent(new KeyboardEvent('keydown', { key: 'Enter', bubbles: true }))
+    await nextTick()
+
+    expect((wrapper.emitted('selectFile')?.length ?? 0)).toBe(selectsBefore)
+
+    document.body.removeChild(btn)
+  })
+
+  it('Space toggles the selected item in multi-select mode', async () => {
+    const wrapper = mountContent()
+    await nextTick()
+
+    // Enter multi-select via Ctrl+Shift+M, then click test.ts to select it
+    document.dispatchEvent(new KeyboardEvent('keydown', { key: 'm', ctrlKey: true, shiftKey: true, bubbles: true }))
+    await nextTick()
+    await wrapper.find('.file-item[data-path="test.ts"]').trigger('click')
+    await nextTick()
+    expect(wrapper.vm.multiSelectState.selected.size).toBe(1)
+
+    document.dispatchEvent(new KeyboardEvent('keydown', { key: ' ', bubbles: true }))
+    await nextTick()
+    expect(wrapper.vm.multiSelectState.selected.size).toBe(0)
+  })
+
+  it('ArrowDown moves the highlighted selection to the next entry', async () => {
+    const wrapper = mountContent()
+    await nextTick()
+
+    // Click the first entry (src) to select it
+    await wrapper.find('.file-item[data-path="src"]').trigger('click')
+    await nextTick()
+    expect(wrapper.find('.file-item[data-path="src"]').classes()).toContain('active')
+
+    document.dispatchEvent(new KeyboardEvent('keydown', { key: 'ArrowDown', bubbles: true }))
+    await nextTick()
+
+    expect(wrapper.find('.file-item[data-path="src"]').classes()).not.toContain('active')
+    expect(wrapper.find('.file-item[data-path="test.ts"]').classes()).toContain('active')
+  })
+
+  it('End moves the highlighted selection to the last entry', async () => {
+    const wrapper = mountContent()
+    await nextTick()
+
+    await wrapper.find('.file-item[data-path="src"]').trigger('click')
+    await nextTick()
+
+    document.dispatchEvent(new KeyboardEvent('keydown', { key: 'End', bubbles: true }))
+    await nextTick()
+
+    expect(wrapper.find('.file-item[data-path="readme.md"]').classes()).toContain('active')
+  })
+
+  it('Backspace emits navigateBack (parent directory)', async () => {
+    const wrapper = mountContent()
+    await nextTick()
+
+    document.dispatchEvent(new KeyboardEvent('keydown', { key: 'Backspace', bubbles: true }))
+    await nextTick()
+
+    expect(wrapper.emitted('navigateBack')).toBeTruthy()
+  })
+
+  it('Ctrl+1 / Ctrl+2 switch list/grid view', async () => {
+    const wrapper = mountContent()
+    await nextTick()
+
+    document.dispatchEvent(new KeyboardEvent('keydown', { key: '2', ctrlKey: true, bubbles: true }))
+    await nextTick()
+    expect(wrapper.find('.file-grid').exists()).toBe(true)
+
+    document.dispatchEvent(new KeyboardEvent('keydown', { key: '1', ctrlKey: true, bubbles: true }))
+    await nextTick()
+    expect(wrapper.find('.file-list').exists()).toBe(true)
+  })
+
+  it('Shift+ArrowDown extends multi-select to the next entry', async () => {
+    const wrapper = mountContent()
+    await nextTick()
+
+    document.dispatchEvent(new KeyboardEvent('keydown', { key: 'm', ctrlKey: true, shiftKey: true, bubbles: true }))
+    await nextTick()
+    await wrapper.find('.file-item[data-path="test.ts"]').trigger('click')
+    await nextTick()
+    expect(wrapper.vm.multiSelectState.selected.size).toBe(1)
+
+    document.dispatchEvent(new KeyboardEvent('keydown', { key: 'ArrowDown', shiftKey: true, bubbles: true }))
+    await nextTick()
+    expect(wrapper.vm.multiSelectState.selected.size).toBe(2)
+  })
+
+  it('Shift+Delete force-deletes the multi-selection without confirm', async () => {
+    const wrapper = mountContent()
+    await nextTick()
+
+    document.dispatchEvent(new KeyboardEvent('keydown', { key: 'a', ctrlKey: true, bubbles: true }))
+    await nextTick()
+
+    document.dispatchEvent(new KeyboardEvent('keydown', { key: 'Delete', shiftKey: true, bubbles: true }))
+    await nextTick()
+
+    expect(wrapper.emitted('batchDelete')).toBeTruthy()
+    // 3 sample entries all selected → all force-deleted
+    expect(wrapper.emitted('batchDelete')![0][0]).toHaveLength(3)
+  })
+
+  it('ignores shortcuts while a text field holds focus (e.g. the chat input)', async () => {
+    const wrapper = mountContent({ currentFile: { path: 'test.ts', name: 'test.ts' } })
+    await nextTick()
+
+    // Focus is in a textarea (chat input on the right) — Ctrl+C must NOT copy a file
+    const ta = document.createElement('textarea')
+    document.body.appendChild(ta)
+    ta.dispatchEvent(new KeyboardEvent('keydown', { key: 'c', ctrlKey: true, bubbles: true }))
+    await nextTick()
+
+    expect(mockToastShow).not.toHaveBeenCalled()
+    document.body.removeChild(ta)
+  })
+
   describe('doShareExternal', () => {
     const mockShareFile = vi.fn()
     const origAndroidNative = (window as any).AndroidNative

--- a/web/src/components/media/Lightbox.vue
+++ b/web/src/components/media/Lightbox.vue
@@ -653,7 +653,15 @@ onMounted(() => {
         const isMermaidClick = !!e.target.closest('.mermaid')
         if (!isExpandIcon && !isMermaidClick && e.pointerType !== 'touch') return
 
-        const img = e.target.closest('.lightbox-img')
+        // When clicking the expand icon, find the image from the wrapper
+        // (the icon is a sibling of the img, not a child)
+        let img
+        if (isExpandIcon) {
+            const wrap = e.target.closest('.lightbox-img-wrap')
+            img = wrap ? wrap.querySelector('.lightbox-img') : null
+        } else {
+            img = e.target.closest('.lightbox-img')
+        }
         if (img) {
             e.preventDefault()
             // Check if the image is inside a markdown body — collect sibling images for navigation

--- a/web/src/components/media/Lightbox.vue
+++ b/web/src/components/media/Lightbox.vue
@@ -644,9 +644,15 @@ onMounted(() => {
     document.addEventListener('mousemove', handleMouseMove)
     document.addEventListener('mouseup', handleMouseUp)
     // Listen for clicks on images and mermaid diagrams to open lightbox
-    // Only activate on touch — skip mouse clicks for PC mode
     document.addEventListener('click', (e) => {
-        if (e.pointerType !== 'touch') return
+        // Touch mode: direct click on .lightbox-img or .mermaid opens lightbox
+        // PC mode: click on .lightbox-expand-icon (hover overlay) opens lightbox;
+        //   mermaid diagrams always respond to click (they have ::after expand icon
+        //   as a visual hint, but ::after pseudo-elements aren't real DOM targets).
+        const isExpandIcon = !!e.target.closest('.lightbox-expand-icon')
+        const isMermaidClick = !!e.target.closest('.mermaid')
+        if (!isExpandIcon && !isMermaidClick && e.pointerType !== 'touch') return
+
         const img = e.target.closest('.lightbox-img')
         if (img) {
             e.preventDefault()

--- a/web/src/components/task/TaskOverviewTab.vue
+++ b/web/src/components/task/TaskOverviewTab.vue
@@ -188,7 +188,7 @@ watch(
     // Add lightbox-img class to all <img> tags for lightbox activation
     const finalHtml = html.replace(/<img(\s+[^>]*?)>/gi, (_match, attrs) => {
       const clean = attrs.replace(/\s*class="[^"]*"/i, '')
-      return `<img${clean} class="lightbox-img">`
+      return `<span class="lightbox-img-wrap"><img${clean} class="lightbox-img"><span class="lightbox-expand-icon"></span></span>`
     })
 
     renderedPrompt.value = finalHtml

--- a/web/src/components/terminal/TerminalPanelContent.vue
+++ b/web/src/components/terminal/TerminalPanelContent.vue
@@ -74,7 +74,7 @@
     </div>
 
     <!-- Virtual key toolbar -->
-    <div class="terminal-toolbar">
+    <div class="terminal-toolbar" v-show="!isPC">
       <!-- Symbol bar (toggleable, above main toolbar) -->
       <Transition name="symbol-bar">
         <div v-if="showSymbolBar" class="symbol-bar">
@@ -188,6 +188,7 @@ import { shouldPreventTerminalContextMenu, useTerminalGestures } from '@/composa
 import { useToast } from '@/composables/useToast'
 import { useQuickCommands } from '@/composables/useQuickCommands'
 import { useAppMode } from '@/composables/useAppMode'
+import { usePlatformDetect } from '@/composables/usePlatformDetect'
 import { useKeyConfig } from '@/composables/useKeyConfig'
 import { useDialog } from '@/composables/useDialog'
 import { store } from '@/stores/app'
@@ -463,6 +464,7 @@ watch(activeTabId, () => {
 
 // Volume keys (Android)
 const { isAppMode } = useAppMode()
+const { isPC } = usePlatformDetect()
 
 function enableVolumeKeys() {
   if (!isAppMode.value) return

--- a/web/src/composables/__tests__/useConnectionOverlay.test.ts
+++ b/web/src/composables/__tests__/useConnectionOverlay.test.ts
@@ -121,4 +121,53 @@ describe('useConnectionOverlay', () => {
         restartingOverlayRef.value = false
         expect(overlay.mode.value).toBeNull()
     })
+
+    it('resets timer on foreground event so overlay does not flash immediately', async () => {
+        hasConnectedOnceRef.value = true
+        const overlay = make()
+        // Disconnect triggers the 5s timer
+        wsStatusRef.value = 'disconnected'
+        await nextTick()
+        // Advance 4s — timer has 1s remaining
+        await vi.advanceTimersByTimeAsync(RECONNECT_OVERLAY_DELAY_MS - 1000)
+        expect(overlay.mode.value).toBeNull()
+        // Foreground event resets the timer from zero
+        window.dispatchEvent(new CustomEvent('clawbench-foreground'))
+        await nextTick()
+        // The old 1s remainder is gone — overlay still hidden
+        await vi.advanceTimersByTimeAsync(1500)
+        expect(overlay.mode.value).toBeNull()
+        // Only after the full fresh 5s does the overlay appear
+        await vi.advanceTimersByTimeAsync(RECONNECT_OVERLAY_DELAY_MS - 1500 + 100)
+        expect(overlay.mode.value).toBe('reconnect')
+    })
+
+    it('foreground event clears an already-visible reconnect overlay', async () => {
+        hasConnectedOnceRef.value = true
+        const overlay = make()
+        wsStatusRef.value = 'disconnected'
+        await nextTick()
+        // Let the timer expire — overlay is showing
+        await vi.advanceTimersByTimeAsync(RECONNECT_OVERLAY_DELAY_MS + 100)
+        expect(overlay.mode.value).toBe('reconnect')
+        // Foreground resets: overlay hidden, fresh 5s timer started
+        window.dispatchEvent(new CustomEvent('clawbench-foreground'))
+        await nextTick()
+        expect(overlay.mode.value).toBeNull()
+        // Overlay re-appears only after another full 5s
+        await vi.advanceTimersByTimeAsync(RECONNECT_OVERLAY_DELAY_MS + 100)
+        expect(overlay.mode.value).toBe('reconnect')
+    })
+
+    it('foreground event does nothing when WS is connected', async () => {
+        hasConnectedOnceRef.value = true
+        const overlay = make()
+        expect(overlay.mode.value).toBeNull()
+        window.dispatchEvent(new CustomEvent('clawbench-foreground'))
+        await nextTick()
+        expect(overlay.mode.value).toBeNull()
+        // Advance time — no timer was started, overlay stays hidden
+        await vi.advanceTimersByTimeAsync(RECONNECT_OVERLAY_DELAY_MS + 100)
+        expect(overlay.mode.value).toBeNull()
+    })
 })

--- a/web/src/composables/__tests__/usePlatformDetect.test.ts
+++ b/web/src/composables/__tests__/usePlatformDetect.test.ts
@@ -1,0 +1,133 @@
+import { describe, expect, it, beforeEach, vi } from 'vitest'
+import { _setIsPCForTest, _resetPlatformForTest, usePlatformDetect, isAndroidUA, isIOSUA, isIPadOSUA } from '@/composables/usePlatformDetect'
+
+// Mock useAppMode to control isAppMode in tests
+vi.mock('@/composables/useAppMode', () => ({
+  useAppMode: () => ({ isAppMode: { value: false } }),
+}))
+
+beforeEach(() => {
+  _resetPlatformForTest()
+})
+
+describe('UA detection constants', () => {
+  it('isAndroidUA detects Android browser UA', () => {
+    // jsdom default UA contains no "Android"
+    expect(isAndroidUA).toBe(false)
+  })
+
+  it('isIOSUA detects iOS UA', () => {
+    // jsdom default UA contains no "iPhone/iPad/iPod"
+    expect(isIOSUA).toBe(false)
+  })
+
+  it('isIPadOSUA detects iPadOS desktop-mode UA', () => {
+    // jsdom UA contains "Macintosh" but maxTouchPoints defaults to 0
+    expect(isIPadOSUA).toBe(false)
+  })
+})
+
+describe('usePlatformDetect', () => {
+  it('returns isPC = true for desktop browser (jsdom default UA)', () => {
+    const { isPC } = usePlatformDetect()
+    expect(isPC.value).toBe(true)
+  })
+
+  it('_setIsPCForTest overrides isPC value', () => {
+    _setIsPCForTest(false)
+    const { isPC } = usePlatformDetect()
+    expect(isPC.value).toBe(false)
+
+    _setIsPCForTest(true)
+    expect(isPC.value).toBe(true)
+  })
+
+  it('_resetPlatformForTest resets to uninitialized state', () => {
+    const { isPC } = usePlatformDetect()
+    expect(isPC.value).toBe(true)
+    _resetPlatformForTest()
+    expect(isPC.value).toBe(false)
+  })
+})
+
+describe('isPC logic', () => {
+  it('isPC = false when isAppMode is true (Android native app)', async () => {
+    vi.doMock('@/composables/useAppMode', () => ({
+      useAppMode: () => ({ isAppMode: { value: true } }),
+    }))
+    vi.resetModules()
+    const mod = await import('@/composables/usePlatformDetect')
+    // Note: module-level UA constants are already computed with jsdom UA,
+    // so isAndroidUA/isIOSUA/isIPadOSUA are all false. Only isAppMode blocks isPC.
+    const { isPC } = mod.usePlatformDetect()
+    expect(isPC.value).toBe(false)
+  })
+
+  it('isPC = false for Android browser UA', async () => {
+    const androidUA = 'Mozilla/5.0 (Linux; Android 13; Pixel 7) AppleWebKit/537.36 Chrome/120.0.0.0 Mobile Safari/537.36'
+    Object.defineProperty(navigator, 'userAgent', { configurable: true, value: androidUA })
+    vi.resetModules()
+    const mod = await import('@/composables/usePlatformDetect')
+    expect(mod.isAndroidUA).toBe(true)
+    expect(mod.isIOSUA).toBe(false)
+    expect(mod.isIPadOSUA).toBe(false)
+    const { isPC } = mod.usePlatformDetect()
+    expect(isPC.value).toBe(false)
+  })
+
+  it('isPC = false for iOS Safari UA', async () => {
+    const iosUA = 'Mozilla/5.0 (iPhone; CPU iPhone OS 17_0 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/17.0 Mobile/15E148 Safari/604.1'
+    Object.defineProperty(navigator, 'userAgent', { configurable: true, value: iosUA })
+    vi.resetModules()
+    const mod = await import('@/composables/usePlatformDetect')
+    expect(mod.isAndroidUA).toBe(false)
+    expect(mod.isIOSUA).toBe(true)
+    expect(mod.isIPadOSUA).toBe(false)
+    const { isPC } = mod.usePlatformDetect()
+    expect(isPC.value).toBe(false)
+  })
+
+  it('isPC = false for iPadOS 13+ desktop-mode UA with maxTouchPoints > 0', async () => {
+    const ipadUA = 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/17.0 Safari/605.1.15'
+    Object.defineProperty(navigator, 'userAgent', { configurable: true, value: ipadUA })
+    Object.defineProperty(navigator, 'maxTouchPoints', { configurable: true, value: 5 })
+    vi.resetModules()
+    const mod = await import('@/composables/usePlatformDetect')
+    expect(mod.isAndroidUA).toBe(false)
+    expect(mod.isIOSUA).toBe(false)
+    expect(mod.isIPadOSUA).toBe(true)
+    const { isPC } = mod.usePlatformDetect()
+    expect(isPC.value).toBe(false)
+  })
+
+  it('isPC = true for real Mac desktop UA (Macintosh + maxTouchPoints = 0)', async () => {
+    const macUA = 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36'
+    Object.defineProperty(navigator, 'userAgent', { configurable: true, value: macUA })
+    Object.defineProperty(navigator, 'maxTouchPoints', { configurable: true, value: 0 })
+    vi.doMock('@/composables/useAppMode', () => ({
+      useAppMode: () => ({ isAppMode: { value: false } }),
+    }))
+    vi.resetModules()
+    const mod = await import('@/composables/usePlatformDetect')
+    expect(mod.isAndroidUA).toBe(false)
+    expect(mod.isIOSUA).toBe(false)
+    expect(mod.isIPadOSUA).toBe(false)
+    const { isPC } = mod.usePlatformDetect()
+    expect(isPC.value).toBe(true)
+  })
+
+  it('isPC = true for Windows desktop UA', async () => {
+    const winUA = 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36'
+    Object.defineProperty(navigator, 'userAgent', { configurable: true, value: winUA })
+    vi.doMock('@/composables/useAppMode', () => ({
+      useAppMode: () => ({ isAppMode: { value: false } }),
+    }))
+    vi.resetModules()
+    const mod = await import('@/composables/usePlatformDetect')
+    expect(mod.isAndroidUA).toBe(false)
+    expect(mod.isIOSUA).toBe(false)
+    expect(mod.isIPadOSUA).toBe(false)
+    const { isPC } = mod.usePlatformDetect()
+    expect(isPC.value).toBe(true)
+  })
+})

--- a/web/src/composables/__tests__/useTabDrawer.test.ts
+++ b/web/src/composables/__tests__/useTabDrawer.test.ts
@@ -1,14 +1,14 @@
 import { describe, expect, it, beforeEach } from 'vitest'
 import { nextTick } from 'vue'
 import { useTabDrawer, onTabSwitch, resetTabDrawerState } from '@/composables/useTabDrawer'
-import { _setBigScreenForTest, resetBigScreenState as resetBigScreen, switchLeftTab } from '@/composables/useBigScreenLayout'
+import { _setWideScreenForTest, resetWideScreenState as resetWideScreen, switchLeftTab } from '@/composables/useWideScreenLayout'
 
 beforeEach(() => {
   resetTabDrawerState()
-  // Narrow-mode default: jsdom's innerWidth (1024) makes useBigScreenLayout's
-  // physical-width detection init to big-screen — force it off so the plain
+  // Narrow-mode default: jsdom's innerWidth (1024) makes useWideScreenLayout's
+  // physical-width detection init to wide-screen — force it off so the plain
   // drawer tests exercise narrow behavior.
-  _setBigScreenForTest(false)
+  _setWideScreenForTest(false)
 })
 
 describe('useTabDrawer', () => {
@@ -134,14 +134,14 @@ describe('useTabDrawer', () => {
   })
 })
 
-describe('useTabDrawer big-screen awareness', () => {
+describe('useTabDrawer wide-screen awareness', () => {
   beforeEach(() => {
-    resetBigScreen()
-    _setBigScreenForTest(false)
+    resetWideScreen()
+    _setWideScreenForTest(false)
   })
 
-  it('big-screen: chat and leftTab drawers both open simultaneously', () => {
-    _setBigScreenForTest(true)
+  it('wide-screen: chat and leftTab drawers both open simultaneously', () => {
+    _setWideScreenForTest(true)
     switchLeftTab('browse')
     const chatDrawer = useTabDrawer('chat')
     const browseDrawer = useTabDrawer('browse')
@@ -156,8 +156,8 @@ describe('useTabDrawer big-screen awareness', () => {
     expect(chatDrawer.effectiveOpen.value).toBe(true)
   })
 
-  it('big-screen: autoRestore:false closes when leftTab switches away', async () => {
-    _setBigScreenForTest(true)
+  it('wide-screen: autoRestore:false closes when leftTab switches away', async () => {
+    _setWideScreenForTest(true)
     switchLeftTab('browse')
     const drawer = useTabDrawer('browse', { autoRestore: false })
     drawer.open()

--- a/web/src/composables/__tests__/useWideScreenLayout.test.ts
+++ b/web/src/composables/__tests__/useWideScreenLayout.test.ts
@@ -25,27 +25,35 @@ beforeEach(() => {
 
 describe('computeIsWideScreen', () => {
   it('desktop: CSS width ≥1024 → wide screen', () => {
-    expect(computeIsWideScreen(1280, 800, 1)).toBe(true)
-    expect(computeIsWideScreen(1024, 768, 1)).toBe(true)
+    expect(computeIsWideScreen(1280, 1280, 800, 1)).toBe(true)
+    expect(computeIsWideScreen(1024, 1024, 768, 1)).toBe(true)
   })
 
   it('high-DPR tablet landscape (CSS <1024) → wide screen via physical width', () => {
     // 2400 physical px at DPR 2.5 → CSS 960 (the user's tablet case)
-    expect(computeIsWideScreen(960, 600, 2.5)).toBe(true)
+    expect(computeIsWideScreen(960, 960, 600, 2.5)).toBe(true)
   })
 
   it('high-DPR phone portrait → NOT wide screen (landscape gate)', () => {
     // 430×3 = 1290 physical ≥1280, but portrait
-    expect(computeIsWideScreen(430, 900, 3)).toBe(false)
+    expect(computeIsWideScreen(430, 430, 900, 3)).toBe(false)
   })
 
   it('high-DPR phone landscape → wide screen (wide physical viewport)', () => {
-    expect(computeIsWideScreen(844, 390, 3)).toBe(true)
+    expect(computeIsWideScreen(844, 844, 390, 3)).toBe(true)
   })
 
   it('small CSS width and small physical width → NOT wide screen', () => {
-    expect(computeIsWideScreen(800, 1280, 1)).toBe(false)
-    expect(computeIsWideScreen(360, 800, 2)).toBe(false) // 720 physical
+    expect(computeIsWideScreen(800, 800, 1280, 1)).toBe(false)
+    expect(computeIsWideScreen(360, 360, 800, 2)).toBe(false) // 720 physical
+  })
+
+  it('keyboard opening on portrait tablet does NOT trigger wide screen', () => {
+    // Portrait tablet: screen 960×1600, DPR 2.5 → physical width 2400 ≥ 1280
+    // Without keyboard: cssWidth(960) < cssHeight(1600) → not wide
+    // With keyboard: window.innerHeight shrinks to 900, but screen stays 960×1600
+    // The landscape check uses screen dimensions, so it stays portrait
+    expect(computeIsWideScreen(960, 960, 1600, 2.5)).toBe(false)
   })
 })
 
@@ -164,12 +172,16 @@ describe('useWideScreenLayout viewport wiring', () => {
     Object.defineProperty(window, 'innerWidth', { configurable: true, value: 960 })
     Object.defineProperty(window, 'innerHeight', { configurable: true, value: 600 })
     Object.defineProperty(window, 'devicePixelRatio', { configurable: true, value: 2.5 })
+    Object.defineProperty(window.screen, 'width', { configurable: true, value: 960 })
+    Object.defineProperty(window.screen, 'height', { configurable: true, value: 600 })
     const mod = await import('@/composables/useWideScreenLayout')
     expect(mod.getWideScreenState().isWideScreen.value).toBe(true)
 
     // Rotate to portrait → back to single column
     Object.defineProperty(window, 'innerWidth', { configurable: true, value: 600 })
     Object.defineProperty(window, 'innerHeight', { configurable: true, value: 960 })
+    Object.defineProperty(window.screen, 'width', { configurable: true, value: 600 })
+    Object.defineProperty(window.screen, 'height', { configurable: true, value: 960 })
     window.dispatchEvent(new Event('resize'))
     expect(mod.getWideScreenState().isWideScreen.value).toBe(false)
 
@@ -177,6 +189,25 @@ describe('useWideScreenLayout viewport wiring', () => {
     Object.defineProperty(window, 'innerWidth', { configurable: true, value: 430 })
     Object.defineProperty(window, 'innerHeight', { configurable: true, value: 900 })
     Object.defineProperty(window, 'devicePixelRatio', { configurable: true, value: 3 })
+    Object.defineProperty(window.screen, 'width', { configurable: true, value: 430 })
+    Object.defineProperty(window.screen, 'height', { configurable: true, value: 900 })
+    window.dispatchEvent(new Event('resize'))
+    expect(mod.getWideScreenState().isWideScreen.value).toBe(false)
+  })
+
+  it('keyboard opening on portrait tablet does NOT trigger wide screen', async () => {
+    vi.resetModules()
+    // Portrait tablet: screen 960×1600, DPR 2.5
+    Object.defineProperty(window, 'innerWidth', { configurable: true, value: 960 })
+    Object.defineProperty(window, 'innerHeight', { configurable: true, value: 1600 })
+    Object.defineProperty(window, 'devicePixelRatio', { configurable: true, value: 2.5 })
+    Object.defineProperty(window.screen, 'width', { configurable: true, value: 960 })
+    Object.defineProperty(window.screen, 'height', { configurable: true, value: 1600 })
+    const mod = await import('@/composables/useWideScreenLayout')
+    expect(mod.getWideScreenState().isWideScreen.value).toBe(false)
+
+    // Keyboard opens: window.innerHeight shrinks, but screen stays the same
+    Object.defineProperty(window, 'innerHeight', { configurable: true, value: 900 })
     window.dispatchEvent(new Event('resize'))
     expect(mod.getWideScreenState().isWideScreen.value).toBe(false)
   })

--- a/web/src/composables/__tests__/useWideScreenLayout.test.ts
+++ b/web/src/composables/__tests__/useWideScreenLayout.test.ts
@@ -1,81 +1,81 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import {
-  useBigScreenLayout,
-  getBigScreenState,
+  useWideScreenLayout,
+  getWideScreenState,
   switchLeftTab,
   setSplitRatio,
-  resetBigScreenState,
-  registerBigScreenCallbacks,
-  _setBigScreenForTest,
+  resetWideScreenState,
+  registerWideScreenCallbacks,
+  _setWideScreenForTest,
   _resetForTest,
   resolveLeftTabOnEnter,
   resolveActivePaneOnEnter,
   setActivePane,
-  computeIsBigScreen,
-  BIG_SCREEN_DOCK_TABS,
-  LEFT_TAB_KEY,
-  SPLIT_RATIO_KEY,
-} from '@/composables/useBigScreenLayout'
+  computeIsWideScreen,
+  WIDE_SCREEN_DOCK_TABS,
+  WIDE_SCREEN_LEFT_TAB_KEY,
+  WIDE_SCREEN_SPLIT_RATIO_KEY,
+} from '@/composables/useWideScreenLayout'
 
 beforeEach(() => {
   _resetForTest()
-  resetBigScreenState()
+  resetWideScreenState()
   localStorage.clear()
 })
 
-describe('computeIsBigScreen', () => {
-  it('desktop: CSS width ≥1024 → big screen', () => {
-    expect(computeIsBigScreen(1280, 800, 1)).toBe(true)
-    expect(computeIsBigScreen(1024, 768, 1)).toBe(true)
+describe('computeIsWideScreen', () => {
+  it('desktop: CSS width ≥1024 → wide screen', () => {
+    expect(computeIsWideScreen(1280, 800, 1)).toBe(true)
+    expect(computeIsWideScreen(1024, 768, 1)).toBe(true)
   })
 
-  it('high-DPR tablet landscape (CSS <1024) → big screen via physical width', () => {
+  it('high-DPR tablet landscape (CSS <1024) → wide screen via physical width', () => {
     // 2400 physical px at DPR 2.5 → CSS 960 (the user's tablet case)
-    expect(computeIsBigScreen(960, 600, 2.5)).toBe(true)
+    expect(computeIsWideScreen(960, 600, 2.5)).toBe(true)
   })
 
-  it('high-DPR phone portrait → NOT big screen (landscape gate)', () => {
+  it('high-DPR phone portrait → NOT wide screen (landscape gate)', () => {
     // 430×3 = 1290 physical ≥1280, but portrait
-    expect(computeIsBigScreen(430, 900, 3)).toBe(false)
+    expect(computeIsWideScreen(430, 900, 3)).toBe(false)
   })
 
-  it('high-DPR phone landscape → big screen (wide physical viewport)', () => {
-    expect(computeIsBigScreen(844, 390, 3)).toBe(true)
+  it('high-DPR phone landscape → wide screen (wide physical viewport)', () => {
+    expect(computeIsWideScreen(844, 390, 3)).toBe(true)
   })
 
-  it('small CSS width and small physical width → NOT big screen', () => {
-    expect(computeIsBigScreen(800, 1280, 1)).toBe(false)
-    expect(computeIsBigScreen(360, 800, 2)).toBe(false) // 720 physical
+  it('small CSS width and small physical width → NOT wide screen', () => {
+    expect(computeIsWideScreen(800, 1280, 1)).toBe(false)
+    expect(computeIsWideScreen(360, 800, 2)).toBe(false) // 720 physical
   })
 })
 
-describe('useBigScreenLayout', () => {
-  it('initializes big-screen from the viewport and does not throw', () => {
+describe('useWideScreenLayout', () => {
+  it('initializes wide-screen from the viewport and does not throw', () => {
     Object.defineProperty(window, 'innerWidth', { configurable: true, value: 800 })
     Object.defineProperty(window, 'innerHeight', { configurable: true, value: 1280 })
     Object.defineProperty(window, 'devicePixelRatio', { configurable: true, value: 1 })
     _resetForTest()
-    const { isBigScreen } = useBigScreenLayout()
-    expect(isBigScreen.value).toBe(false)
+    const { isWideScreen } = useWideScreenLayout()
+    expect(isWideScreen.value).toBe(false)
   })
 
   it('leftTab defaults to browse and is clamped to allowed tabs', () => {
-    const { leftTab } = useBigScreenLayout()
+    const { leftTab } = useWideScreenLayout()
     expect(leftTab.value).toBe('browse')
-    expect(BIG_SCREEN_DOCK_TABS).toContain(leftTab.value)
+    expect(WIDE_SCREEN_DOCK_TABS).toContain(leftTab.value)
   })
 
   it('switchLeftTab ignores invalid tabs and persists valid ones', () => {
     switchLeftTab('terminal')
-    expect(localStorage.getItem(LEFT_TAB_KEY)).toBe('terminal')
+    expect(localStorage.getItem(WIDE_SCREEN_LEFT_TAB_KEY)).toBe('terminal')
     switchLeftTab('not-a-tab' as never)
-    expect(localStorage.getItem(LEFT_TAB_KEY)).toBe('terminal')
+    expect(localStorage.getItem(WIDE_SCREEN_LEFT_TAB_KEY)).toBe('terminal')
   })
 
   it('switchLeftTab runs registered side-effects and activeTab setter, but only on change', () => {
     const sideEffects = vi.fn()
     const setActiveTab = vi.fn()
-    registerBigScreenCallbacks({ sideEffects, setActiveTab })
+    registerWideScreenCallbacks({ sideEffects, setActiveTab })
 
     switchLeftTab('tasks')
     expect(setActiveTab).toHaveBeenCalledWith('tasks')
@@ -87,28 +87,28 @@ describe('useBigScreenLayout', () => {
 
   it('setSplitRatio normalizes and persists', () => {
     setSplitRatio(1.9)
-    expect(Number(localStorage.getItem(SPLIT_RATIO_KEY))).toBe(1)
+    expect(Number(localStorage.getItem(WIDE_SCREEN_SPLIT_RATIO_KEY))).toBe(1)
     setSplitRatio(0.35)
-    expect(Number(localStorage.getItem(SPLIT_RATIO_KEY))).toBeCloseTo(0.35)
+    expect(Number(localStorage.getItem(WIDE_SCREEN_SPLIT_RATIO_KEY))).toBeCloseTo(0.35)
   })
 
   it('restores persisted leftTab on init', () => {
-    localStorage.setItem(LEFT_TAB_KEY, 'settings')
+    localStorage.setItem(WIDE_SCREEN_LEFT_TAB_KEY, 'settings')
     _resetForTest()
-    const { leftTab } = useBigScreenLayout()
+    const { leftTab } = useWideScreenLayout()
     expect(leftTab.value).toBe('settings')
   })
 
   it('fresh init with no persisted ratio keeps splitRatio at 0.5', () => {
-    const { splitRatio } = useBigScreenLayout()
+    const { splitRatio } = useWideScreenLayout()
     expect(splitRatio.value).toBe(0.5)
   })
 
-  it('big-screen mode makes getBigScreenState expose chat + leftTab as active tabs', () => {
-    const { isBigScreen, leftTab } = getBigScreenState()
-    _setBigScreenForTest(true)
+  it('wide-screen mode makes getWideScreenState expose chat + leftTab as active tabs', () => {
+    const { isWideScreen, leftTab } = getWideScreenState()
+    _setWideScreenForTest(true)
     switchLeftTab('terminal')
-    expect(isBigScreen.value).toBe(true)
+    expect(isWideScreen.value).toBe(true)
     expect(leftTab.value).toBe('terminal')
   })
 })
@@ -137,7 +137,7 @@ describe('activePane focus tracking', () => {
   })
 
   it('setActivePane updates the shared activePane ref', () => {
-    const { activePane } = useBigScreenLayout()
+    const { activePane } = useWideScreenLayout()
     expect(activePane.value).toBe('right')
     setActivePane('left')
     expect(activePane.value).toBe('left')
@@ -145,39 +145,39 @@ describe('activePane focus tracking', () => {
     expect(activePane.value).toBe('right')
   })
 
-  it('resetBigScreenState resets activePane to right', () => {
+  it('resetWideScreenState resets activePane to right', () => {
     setActivePane('left')
-    resetBigScreenState()
-    const { activePane } = useBigScreenLayout()
+    resetWideScreenState()
+    const { activePane } = useWideScreenLayout()
     expect(activePane.value).toBe('right')
   })
 })
 
-describe('useBigScreenLayout viewport wiring', () => {
+describe('useWideScreenLayout viewport wiring', () => {
   afterEach(() => {
     vi.unstubAllGlobals()
   })
 
   it('activates for a high-DPR landscape tablet and reacts to resize/rotation', async () => {
     vi.resetModules()
-    // 960 CSS × 2.5 = 2400 physical px, landscape → big screen
+    // 960 CSS × 2.5 = 2400 physical px, landscape → wide screen
     Object.defineProperty(window, 'innerWidth', { configurable: true, value: 960 })
     Object.defineProperty(window, 'innerHeight', { configurable: true, value: 600 })
     Object.defineProperty(window, 'devicePixelRatio', { configurable: true, value: 2.5 })
-    const mod = await import('@/composables/useBigScreenLayout')
-    expect(mod.getBigScreenState().isBigScreen.value).toBe(true)
+    const mod = await import('@/composables/useWideScreenLayout')
+    expect(mod.getWideScreenState().isWideScreen.value).toBe(true)
 
     // Rotate to portrait → back to single column
     Object.defineProperty(window, 'innerWidth', { configurable: true, value: 600 })
     Object.defineProperty(window, 'innerHeight', { configurable: true, value: 960 })
     window.dispatchEvent(new Event('resize'))
-    expect(mod.getBigScreenState().isBigScreen.value).toBe(false)
+    expect(mod.getWideScreenState().isWideScreen.value).toBe(false)
 
     // Phone portrait, high DPR → stays single column
     Object.defineProperty(window, 'innerWidth', { configurable: true, value: 430 })
     Object.defineProperty(window, 'innerHeight', { configurable: true, value: 900 })
     Object.defineProperty(window, 'devicePixelRatio', { configurable: true, value: 3 })
     window.dispatchEvent(new Event('resize'))
-    expect(mod.getBigScreenState().isBigScreen.value).toBe(false)
+    expect(mod.getWideScreenState().isWideScreen.value).toBe(false)
   })
 })

--- a/web/src/composables/useConnectionOverlay.ts
+++ b/web/src/composables/useConnectionOverlay.ts
@@ -1,6 +1,7 @@
 import { ref, computed, watch, onUnmounted } from 'vue'
 import { useGlobalEvents } from './useGlobalEvents'
 import { useSettingsNavigation } from './useSettingsNavigation'
+import { appLog } from '@/utils/appLog'
 
 // Delay before showing the reconnect mask, so transient blips that recover
 // within this window never flash a fullscreen overlay.
@@ -18,6 +19,10 @@ export type ConnectionOverlayMode = 'restart' | 'reconnect' | null
  * - null        → overlay hidden.
  *
  * Restart takes priority over reconnect.
+ *
+ * When the app returns to foreground, the reconnect timer is reset so that
+ * the overlay won't flash immediately — the 5s grace period restarts from
+ * zero, giving the WS a fresh window to reconnect.
  */
 export function useConnectionOverlay() {
     const { wsStatus, hasConnectedOnce } = useGlobalEvents()
@@ -30,6 +35,20 @@ export function useConnectionOverlay() {
         if (reconnectTimer) {
             clearTimeout(reconnectTimer)
             reconnectTimer = null
+        }
+    }
+
+    /** Reset the reconnect timer so the 5s grace period restarts from zero. */
+    function resetTimer() {
+        clearTimer()
+        showReconnect.value = false
+        // If WS is not connected and we've connected before, restart the timer
+        if (wsStatus.value !== 'connected' && hasConnectedOnce.value) {
+            appLog.d('ConnectionOverlay', 'foreground reset: restarting reconnect timer')
+            reconnectTimer = setTimeout(() => {
+                showReconnect.value = true
+                reconnectTimer = null
+            }, RECONNECT_OVERLAY_DELAY_MS)
         }
     }
 
@@ -51,7 +70,18 @@ export function useConnectionOverlay() {
         { immediate: true },
     )
 
-    onUnmounted(clearTimer)
+    // On foreground: reset the timer so the overlay doesn't flash immediately
+    // after resuming from background (the old timer may have nearly expired
+    // during pauseTimers).
+    function onForeground() {
+        resetTimer()
+    }
+    window.addEventListener('clawbench-foreground', onForeground)
+
+    onUnmounted(() => {
+        clearTimer()
+        window.removeEventListener('clawbench-foreground', onForeground)
+    })
 
     const mode = computed<ConnectionOverlayMode>(() => {
         if (restartingOverlay.value) return 'restart'

--- a/web/src/composables/usePlatformDetect.ts
+++ b/web/src/composables/usePlatformDetect.ts
@@ -1,0 +1,57 @@
+import { ref } from 'vue'
+import { useAppMode } from './useAppMode'
+
+const ua = typeof navigator !== 'undefined' ? navigator.userAgent : ''
+
+/** Android UA (browser) — excludes Windows Phone spoofing */
+export const isAndroidUA = /Android/i.test(ua) && !/Windows Phone/i.test(ua)
+
+/** iOS UA (iPhone, iPad, iPod) — classic iOS UA string */
+export const isIOSUA = /iPhone|iPad|iPod/i.test(ua)
+
+/** iPadOS 13+ desktop-mode UA: sends "Macintosh" but has touch capability (maxTouchPoints > 0).
+ * Real Macs have maxTouchPoints = 0; iPads requesting desktop sites have maxTouchPoints > 0. */
+export const isIPadOSUA = /Macintosh/i.test(ua)
+  && typeof navigator !== 'undefined'
+  && navigator.maxTouchPoints > 0
+
+const isPC = ref(false)
+let platformInitialized = false
+
+/**
+ * Detects whether the device is a PC (desktop/laptop with physical keyboard).
+ *
+ * isPC = true when:
+ * - NOT Android UA (mobile phone/tablet browser)
+ * - NOT iOS UA (iPhone/iPad classic)
+ * - NOT iPadOS 13+ desktop-mode (touch-only device, no physical keyboard)
+ * - NOT Android App mode (native WebView)
+ *
+ * All conditions are static — UA doesn't change during a session and isAppMode
+ * is initialized once — so isPC is computed once at init, not a reactive computed.
+ *
+ * IMPORTANT: useAppMode() must be initialized (called at least once) before
+ * usePlatformDetect() reads isAppMode.value. Currently App.vue initializes
+ * useAppMode early, so this order dependency is satisfied. If usePlatformDetect()
+ * were called before useAppMode(), isAppMode.value would still be its default
+ * (false), which is correct (web mode is not PC-blocking, only native app mode is).
+ */
+export function usePlatformDetect() {
+  if (!platformInitialized) {
+    platformInitialized = true
+    const { isAppMode } = useAppMode()
+    isPC.value = !isAppMode.value && !isAndroidUA && !isIOSUA && !isIPadOSUA
+  }
+  return { isPC }
+}
+
+/** Test hook — force isPC value for unit tests. Sets platformInitialized=true so usePlatformDetect() won't overwrite. */
+export function _setIsPCForTest(val: boolean) {
+  isPC.value = val
+  platformInitialized = true
+}
+
+export function _resetPlatformForTest() {
+  platformInitialized = false
+  isPC.value = false
+}

--- a/web/src/composables/usePwaInstall.ts
+++ b/web/src/composables/usePwaInstall.ts
@@ -1,5 +1,6 @@
 import { ref, computed } from 'vue'
 import { useAppMode } from './useAppMode'
+import { isAndroidUA, isIOSUA } from './usePlatformDetect'
 import { appLog } from '@/utils/appLog'
 
 const TAG = 'PwaInstall'
@@ -11,11 +12,6 @@ interface BeforeInstallPromptEvent extends Event {
 // Module-level singleton — all consumers share the same deferred prompt & installed state
 const deferredPrompt = ref<BeforeInstallPromptEvent | null>(null)
 const installed = ref(false)
-
-// UA detection (only meaningful in web browser — not APP mode)
-const ua = typeof navigator !== 'undefined' ? navigator.userAgent : ''
-const isAndroidUA = /Android/i.test(ua) && !/Windows Phone/i.test(ua)
-const isIOSUA = /iPhone|iPad|iPod/i.test(ua)
 
 // Listen for beforeinstallprompt / appinstalled (once, module-level)
 if (typeof window !== 'undefined') {

--- a/web/src/composables/useQuoteQuestion.ts
+++ b/web/src/composables/useQuoteQuestion.ts
@@ -2,32 +2,16 @@ import { ref, onMounted, onUnmounted } from 'vue'
 import { useSessionIdentity } from '@/composables/useSessionIdentity.ts'
 import { useToast } from '@/composables/useToast.ts'
 import { gt } from '@/composables/useLocale'
-import { closestElement, getLineInfo, getFileInfo } from '@/utils/quoteQuestionUtils.ts'
+import { closestElement, getLineInfo, getFileInfo, buildQuoteMessage } from '@/utils/quoteQuestionUtils.ts'
 import { useChatContext } from '@/composables/useChatContext.ts'
 import type { QuoteData } from '@/composables/useChatContext.ts'
-
-function buildQuoteMessage(
-  userMessage: string,
-  text: string,
-  filePath: string,
-  language: string,
-  startLine: number,
-  endLine: number,
-): string {
-  const langPrefix = language ? `${language}:` : ':'
-  let lineSuffix = ''
-  if (startLine && endLine && startLine !== endLine) {
-    lineSuffix = `:${startLine}-${endLine}`
-  } else if (startLine) {
-    lineSuffix = `:${startLine}`
-  }
-  return `${userMessage.trim()}\n\n\`\`\`${langPrefix}${filePath}${lineSuffix}\n${text}\n\`\`\``
-}
+import { useWideScreenLayout } from '@/composables/useWideScreenLayout.ts'
 
 // Module-level singleton: bar visibility state shared across all consumers.
 // quoteData is stored in useChatContext (global singleton) so ChatInputBar
 // can render a quote chip in any tab.
 const { quoteData, setQuoteData, addAttachedFile, clearAll } = useChatContext()
+const { isWideScreen } = useWideScreenLayout()
 const barVisible = ref(false)
 const barPinned = ref(false)  // When pinned, selection loss won't auto-hide the bar
 const sheetOpen = ref(false)
@@ -39,7 +23,16 @@ function onSelectionChange() {
   debounceTimer = setTimeout(() => {
     const sel = window.getSelection()
     if (!sel || sel.isCollapsed || !sel.toString().trim()) {
-      // When the selection is gone, drop the quote (both modes) — unless the
+      // Wide-screen mode: auto-pin so the ChatInputBar quote tag survives
+      // focus switches (e.g. clicking the input textarea clears selection).
+      // There is no QuoteQuestionBar in wide-screen, so the quote tag in
+      // ChatInputBar is the only UI surface — losing it would be confusing.
+      if (isWideScreen.value && quoteData.value) {
+        barPinned.value = true
+        barVisible.value = false
+        return
+      }
+      // Narrow mode: when the selection is gone, drop the quote — unless the
       // user explicitly pinned it via "引用提问". A stale quote chip must not
       // linger in the chat input after the user deselects the text.
       if (!barPinned.value) {
@@ -71,11 +64,27 @@ function onSelectionChange() {
 
     setQuoteData({ text, filePath, language, startLine, endLine })
     barVisible.value = true
+    // Wide-screen: auto-pin so the quote tag persists when user focuses input
+    if (isWideScreen.value) {
+      barPinned.value = true
+    }
   }, 150)
 }
 
 // Global listener management
 let listenerCount = 0
+
+/** Reset the bar pinned state (for use when quoteData is cleared externally). */
+export function resetQuotePin() {
+  barPinned.value = false
+}
+
+/** Restore bar visibility when transitioning from wide-screen to narrow. */
+export function restoreBarVisibility() {
+  if (quoteData.value && barPinned.value) {
+    barVisible.value = true
+  }
+}
 
 export function useQuoteQuestion() {
   const toast = useToast()
@@ -121,6 +130,9 @@ export function useQuoteQuestion() {
     setTimeout(() => {
       setQuoteData(data)
       barVisible.value = true
+      if (isWideScreen.value) {
+        barPinned.value = true
+      }
     }, 400)
   }
 

--- a/web/src/composables/useQuoteQuestion.ts
+++ b/web/src/composables/useQuoteQuestion.ts
@@ -159,6 +159,12 @@ export function useQuoteQuestion() {
     const animFrom = sendBtn?.getBoundingClientRect() ?? null
     const animTo = dockChatBtn?.getBoundingClientRect() ?? null
 
+    // Clear quoteData BEFORE sending — ChatPanelContent.sendMessage also checks
+    // quoteData and would double-embed the quote if it's still set.
+    clearAll()
+    barVisible.value = false
+    barPinned.value = false
+
     // Delegate to session identity singleton — it routes to ChatPanel's
     // sendMessage if registered, otherwise falls back to a direct API call.
     try {
@@ -176,11 +182,6 @@ export function useQuoteQuestion() {
     } catch (err: unknown) {
       toast.show(gt('quoteBar.sendFailed', { error: (err as Error).message }), { icon: '⚠️', type: 'error' })
     }
-
-    // Clear all chat context (attachedFiles + quoteData) and close the bar.
-    clearAll()
-    barVisible.value = false
-    barPinned.value = false
   }
 
   return {

--- a/web/src/composables/useTabDrawer.ts
+++ b/web/src/composables/useTabDrawer.ts
@@ -1,8 +1,8 @@
 import { ref, computed, watch, onUnmounted, getCurrentInstance, type Ref, type ComputedRef, readonly } from 'vue'
 import { appLog } from '@/utils/appLog'
-import { getBigScreenState } from './useBigScreenLayout'
+import { getWideScreenState } from './useWideScreenLayout'
 
-const { isBigScreen, leftTab } = getBigScreenState()
+const { isWideScreen, leftTab } = getWideScreenState()
 
 /**
  * Tab-drawer declarative binding registry.
@@ -114,18 +114,18 @@ export function useTabDrawer(tabId: string, openRefOrOptions?: Ref<boolean> | Ta
 
   const isTabActive = () =>
     currentTab.value === tabId ||
-    (isBigScreen.value && (tabId === 'chat' || tabId === leftTab.value))
+    (isWideScreen.value && (tabId === 'chat' || tabId === leftTab.value))
 
   const effectiveOpen = computed(() => isTabActive() && openRef.value)
 
   // For autoRestore: false, close the drawer when its tab is no longer active
-  // (narrow: currentTab changed; big-screen: leftTab changed away)
+  // (narrow: currentTab changed; wide-screen: leftTab changed away)
   if (!autoRestore) {
     const closeIfInactive = () => {
       if (!openRef.value) return
       if (!isTabActive()) openRef.value = false
     }
-    watch(() => [currentTab.value, isBigScreen.value, leftTab.value], closeIfInactive)
+    watch(() => [currentTab.value, isWideScreen.value, leftTab.value], closeIfInactive)
   }
 
   return {

--- a/web/src/composables/useWideScreenLayout.ts
+++ b/web/src/composables/useWideScreenLayout.ts
@@ -1,31 +1,31 @@
 import { ref } from 'vue'
 import { normalizeRatio } from '@/utils/splitRatio'
 
-export const BIG_SCREEN_MIN_WIDTH = 1024
-// Physical (device-pixel) width threshold for the big-screen layout. CSS width
+export const WIDE_SCREEN_MIN_WIDTH = 1024
+// Physical (device-pixel) width threshold for the wide-screen layout. CSS width
 // alone can miss high-resolution tablets whose devicePixelRatio shrinks the CSS
 // viewport below 1024 (e.g. 2400 physical px at DPR 2.5 → 960 CSS px).
-export const BIG_SCREEN_MIN_PHYSICAL_WIDTH = 1280
-export const LEFT_TAB_KEY = 'clawbench-bigscreen-left-tab'
-export const SPLIT_RATIO_KEY = 'clawbench-bigscreen-split-ratio'
-export const BIG_SCREEN_DOCK_TABS = ['browse', 'history', 'proxy', 'terminal', 'tasks', 'settings']
+export const WIDE_SCREEN_MIN_PHYSICAL_WIDTH = 1280
+export const WIDE_SCREEN_LEFT_TAB_KEY = 'clawbench-widescreen-left-tab'
+export const WIDE_SCREEN_SPLIT_RATIO_KEY = 'clawbench-widescreen-split-ratio'
+export const WIDE_SCREEN_DOCK_TABS = ['browse', 'history', 'proxy', 'terminal', 'tasks', 'settings']
 
 /**
- * Big-screen detection. Active when the CSS viewport is ≥1024px (desktop), or
+ * Wide-screen detection. Active when the CSS viewport is ≥1024px (desktop), or
  * when the device's physical width (CSS width × devicePixelRatio) is ≥1280px
  * AND the viewport is landscape. The landscape gate keeps high-DPR phones in
  * portrait (e.g. 430×3 = 1290) from accidentally splitting.
  */
-export function computeIsBigScreen(cssWidth: number, cssHeight: number, devicePixelRatio: number): boolean {
+export function computeIsWideScreen(cssWidth: number, cssHeight: number, devicePixelRatio: number): boolean {
   const physicalWidth = cssWidth * (devicePixelRatio || 1)
-  return cssWidth >= BIG_SCREEN_MIN_WIDTH
-    || (physicalWidth >= BIG_SCREEN_MIN_PHYSICAL_WIDTH && cssWidth > cssHeight)
+  return cssWidth >= WIDE_SCREEN_MIN_WIDTH
+    || (physicalWidth >= WIDE_SCREEN_MIN_PHYSICAL_WIDTH && cssWidth > cssHeight)
 }
 
-const isBigScreen = ref(false)
+const isWideScreen = ref(false)
 const leftTab = ref<string>('browse')
 const splitRatio = ref(0.5)
-/** Big-screen focus tracking: which pane the user is currently working in. */
+/** Wide-screen focus tracking: which pane the user is currently working in. */
 const activePane = ref<'left' | 'right'>('right')
 let initialized = false
 let sideEffects: ((tab: string) => void) | null = null
@@ -33,20 +33,20 @@ let setActiveTab: ((tab: string) => void) | null = null
 
 function readPersistedLeftTab(): string {
   try {
-    const v = localStorage.getItem(LEFT_TAB_KEY)
-    if (v && BIG_SCREEN_DOCK_TABS.includes(v)) return v
+    const v = localStorage.getItem(WIDE_SCREEN_LEFT_TAB_KEY)
+    if (v && WIDE_SCREEN_DOCK_TABS.includes(v)) return v
   } catch {
     // localStorage may throw in restricted environments — fall through to default
   }
   return 'browse'
 }
 
-function initBigScreen() {
+function initWideScreen() {
   if (initialized) return
   initialized = true
   leftTab.value = readPersistedLeftTab()
   try {
-    const stored = localStorage.getItem(SPLIT_RATIO_KEY)
+    const stored = localStorage.getItem(WIDE_SCREEN_SPLIT_RATIO_KEY)
     if (stored !== null) {
       const raw = Number(stored)
       if (Number.isFinite(raw)) splitRatio.value = normalizeRatio(raw)
@@ -56,7 +56,7 @@ function initBigScreen() {
   }
   if (typeof window !== 'undefined') {
     const recompute = () => {
-      isBigScreen.value = computeIsBigScreen(
+      isWideScreen.value = computeIsWideScreen(
         window.innerWidth,
         window.innerHeight,
         window.devicePixelRatio || 1,
@@ -66,7 +66,7 @@ function initBigScreen() {
     // Viewport resize covers rotation, window resize and browser-zoom DPR changes.
     window.addEventListener('resize', recompute)
     if (typeof window.matchMedia === 'function') {
-      const mql = window.matchMedia(`(min-width: ${BIG_SCREEN_MIN_WIDTH}px)`)
+      const mql = window.matchMedia(`(min-width: ${WIDE_SCREEN_MIN_WIDTH}px)`)
       const onChange = () => recompute()
       if (typeof mql.addEventListener === 'function') {
         mql.addEventListener('change', onChange)
@@ -77,16 +77,16 @@ function initBigScreen() {
   }
 }
 
-/** Returns the shared big-screen state refs (initializes once). */
-export function useBigScreenLayout() {
-  initBigScreen()
-  return { isBigScreen, leftTab, splitRatio, activePane }
+/** Returns the shared wide-screen state refs (initializes once). */
+export function useWideScreenLayout() {
+  initWideScreen()
+  return { isWideScreen, leftTab, splitRatio, activePane }
 }
 
 /** Ref access for useTabDrawer (init once, return only the refs it needs). */
-export function getBigScreenState() {
-  initBigScreen()
-  return { isBigScreen, leftTab }
+export function getWideScreenState() {
+  initWideScreen()
+  return { isWideScreen, leftTab }
 }
 
 /** Record which pane the user is currently working in (drives focus-aware shortcuts). */
@@ -95,25 +95,25 @@ export function setActivePane(pane: 'left' | 'right') {
 }
 
 /**
- * Focus continuity on entering big-screen: if the user was on chat, the right
+ * Focus continuity on entering wide-screen: if the user was on chat, the right
  * pane (chat) is focused; otherwise they were in a left-column tab.
  */
 export function resolveActivePaneOnEnter(currentActiveTab: string): 'left' | 'right' {
   return currentActiveTab === 'chat' ? 'right' : 'left'
 }
 
-export function registerBigScreenCallbacks(opts: { sideEffects?: (tab: string) => void; setActiveTab?: (tab: string) => void }) {
+export function registerWideScreenCallbacks(opts: { sideEffects?: (tab: string) => void; setActiveTab?: (tab: string) => void }) {
   sideEffects = opts.sideEffects ?? null
   setActiveTab = opts.setActiveTab ?? null
 }
 
-/** Switch the big-screen left column tab. Writes activeTab + side-effects via callbacks; does NOT call onTabSwitch. */
+/** Switch the wide-screen left column tab. Writes activeTab + side-effects via callbacks; does NOT call onTabSwitch. */
 export function switchLeftTab(tab: string) {
-  if (!BIG_SCREEN_DOCK_TABS.includes(tab)) return
+  if (!WIDE_SCREEN_DOCK_TABS.includes(tab)) return
   if (leftTab.value === tab) return
   leftTab.value = tab
   try {
-    localStorage.setItem(LEFT_TAB_KEY, tab)
+    localStorage.setItem(WIDE_SCREEN_LEFT_TAB_KEY, tab)
   } catch {
     // ignore
   }
@@ -122,39 +122,39 @@ export function switchLeftTab(tab: string) {
 }
 
 /**
- * Q1A continuity rule: entering big-screen mode adopts the current narrow-mode
+ * Q1A continuity rule: entering wide-screen mode adopts the current narrow-mode
  * tab as the left column tab when it is a non-chat tab; otherwise keeps the
  * persisted/default leftTab.
  */
 export function resolveLeftTabOnEnter(currentActiveTab: string, persistedLeftTab: string): string {
-  if (currentActiveTab !== 'chat' && BIG_SCREEN_DOCK_TABS.includes(currentActiveTab)) return currentActiveTab
-  return BIG_SCREEN_DOCK_TABS.includes(persistedLeftTab) ? persistedLeftTab : 'browse'
+  if (currentActiveTab !== 'chat' && WIDE_SCREEN_DOCK_TABS.includes(currentActiveTab)) return currentActiveTab
+  return WIDE_SCREEN_DOCK_TABS.includes(persistedLeftTab) ? persistedLeftTab : 'browse'
 }
 
 /** Normalize + persist the split ratio (persistence owned here, not in SplitView). */
 export function setSplitRatio(ratio: number) {
   splitRatio.value = normalizeRatio(ratio)
   try {
-    localStorage.setItem(SPLIT_RATIO_KEY, String(splitRatio.value))
+    localStorage.setItem(WIDE_SCREEN_SPLIT_RATIO_KEY, String(splitRatio.value))
   } catch {
     // ignore
   }
 }
 
-export function resetBigScreenState() {
+export function resetWideScreenState() {
   leftTab.value = 'browse'
   splitRatio.value = 0.5
-  isBigScreen.value = false
+  isWideScreen.value = false
   activePane.value = 'right'
   sideEffects = null
   setActiveTab = null
 }
 
 /** Test hooks — do not use in production code. */
-export function _setBigScreenForTest(val: boolean) {
-  isBigScreen.value = val
+export function _setWideScreenForTest(val: boolean) {
+  isWideScreen.value = val
 }
 export function _resetForTest() {
   initialized = false
-  resetBigScreenState()
+  resetWideScreenState()
 }

--- a/web/src/composables/useWideScreenLayout.ts
+++ b/web/src/composables/useWideScreenLayout.ts
@@ -13,13 +13,14 @@ export const WIDE_SCREEN_DOCK_TABS = ['browse', 'history', 'proxy', 'terminal', 
 /**
  * Wide-screen detection. Active when the CSS viewport is ≥1024px (desktop), or
  * when the device's physical width (CSS width × devicePixelRatio) is ≥1280px
- * AND the viewport is landscape. The landscape gate keeps high-DPR phones in
- * portrait (e.g. 430×3 = 1290) from accidentally splitting.
+ * AND the screen is landscape. Uses screen.width/screen.height (not window
+ * inner dimensions) for the landscape check so that soft-keyboard resizing on
+ * Android adjustResize cannot flip a portrait tablet into wide-screen mode.
  */
-export function computeIsWideScreen(cssWidth: number, cssHeight: number, devicePixelRatio: number): boolean {
+export function computeIsWideScreen(cssWidth: number, screenWidth: number, screenHeight: number, devicePixelRatio: number): boolean {
   const physicalWidth = cssWidth * (devicePixelRatio || 1)
   return cssWidth >= WIDE_SCREEN_MIN_WIDTH
-    || (physicalWidth >= WIDE_SCREEN_MIN_PHYSICAL_WIDTH && cssWidth > cssHeight)
+    || (physicalWidth >= WIDE_SCREEN_MIN_PHYSICAL_WIDTH && screenWidth > screenHeight)
 }
 
 const isWideScreen = ref(false)
@@ -58,7 +59,8 @@ function initWideScreen() {
     const recompute = () => {
       isWideScreen.value = computeIsWideScreen(
         window.innerWidth,
-        window.innerHeight,
+        window.screen.width,
+        window.screen.height,
         window.devicePixelRatio || 1,
       )
     }

--- a/web/src/stores/__tests__/app.test.ts
+++ b/web/src/stores/__tests__/app.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it, vi, beforeEach, afterEach } from 'vitest'
-import { loadBrowseDir } from '@/stores/app.ts'
+import { loadBrowseDir, loadOpenFile, clearOpenFile } from '@/stores/app.ts'
 import { store } from '@/stores/app.ts'
 import { apiGet } from '@/utils/api'
 
@@ -167,5 +167,58 @@ describe('loadFiles DirectoryNotFound → parent navigation', () => {
     expect(store.state.dirLoading).toBe(false)
     // apiGet should have been called at least 11 times (initial + 10 recursive)
     expect(vi.mocked(apiGet).mock.calls.length).toBeGreaterThanOrEqual(10)
+  })
+})
+
+describe('saveOpenFile / loadOpenFile / clearOpenFile', () => {
+  const OPEN_FILE_PREFIX = 'clawbench-open-file:'
+
+  beforeEach(() => {
+    localStorage.clear()
+    store.state.projectRoot = ''
+    store.state.currentFile = null
+  })
+
+  it('loadOpenFile returns empty string when no projectRoot', () => {
+    store.state.projectRoot = ''
+    expect(loadOpenFile()).toBe('')
+  })
+
+  it('loadOpenFile returns saved file path for the current project', () => {
+    store.state.projectRoot = '/home/user/myproject'
+    localStorage.setItem(OPEN_FILE_PREFIX + '/home/user/myproject', 'src/main.go')
+    expect(loadOpenFile()).toBe('src/main.go')
+  })
+
+  it('loadOpenFile returns empty string when no saved file exists', () => {
+    store.state.projectRoot = '/home/user/newproject'
+    expect(loadOpenFile()).toBe('')
+  })
+
+  it('clearOpenFile removes the persisted file for the current project', () => {
+    store.state.projectRoot = '/home/user/myproject'
+    localStorage.setItem(OPEN_FILE_PREFIX + '/home/user/myproject', 'src/main.go')
+    clearOpenFile()
+    expect(localStorage.getItem(OPEN_FILE_PREFIX + '/home/user/myproject')).toBeNull()
+  })
+
+  it('clearOpenFile does nothing when projectRoot is empty', () => {
+    store.state.projectRoot = ''
+    localStorage.setItem(OPEN_FILE_PREFIX + '/home/user/other', 'other.go')
+    clearOpenFile()
+    // Should not affect other keys
+    expect(localStorage.getItem(OPEN_FILE_PREFIX + '/home/user/other')).toBe('other.go')
+  })
+
+  it('different projects have independent open files', () => {
+    store.state.projectRoot = '/project/a'
+    localStorage.setItem(OPEN_FILE_PREFIX + '/project/a', 'file-a.ts')
+    store.state.projectRoot = '/project/b'
+    localStorage.setItem(OPEN_FILE_PREFIX + '/project/b', 'file-b.ts')
+
+    store.state.projectRoot = '/project/a'
+    expect(loadOpenFile()).toBe('file-a.ts')
+    store.state.projectRoot = '/project/b'
+    expect(loadOpenFile()).toBe('file-b.ts')
   })
 })

--- a/web/src/stores/app.ts
+++ b/web/src/stores/app.ts
@@ -10,6 +10,35 @@ import { useFileNavStack } from '@/composables/useFileNavStack'
 
 const TAG = 'Store'
 
+// ── Open file persistence (per-project) ──
+const OPEN_FILE_PREFIX = 'clawbench-open-file:'
+
+function saveOpenFile(): void {
+    if (!state.projectRoot) return
+    try {
+        const path = state.currentFile?.path
+        if (path) {
+            localStorage.setItem(OPEN_FILE_PREFIX + state.projectRoot, path)
+        } else {
+            localStorage.removeItem(OPEN_FILE_PREFIX + state.projectRoot)
+        }
+    } catch { /* ignore */ }
+}
+
+export function loadOpenFile(): string {
+    if (!state.projectRoot) return ''
+    try {
+        return localStorage.getItem(OPEN_FILE_PREFIX + state.projectRoot) || ''
+    } catch { return '' }
+}
+
+export function clearOpenFile(): void {
+    if (!state.projectRoot) return
+    try {
+        localStorage.removeItem(OPEN_FILE_PREFIX + state.projectRoot)
+    } catch { /* ignore */ }
+}
+
 // ── Browse directory persistence (per-project) ──
 const BROWSE_DIR_PREFIX = 'clawbench-browse-dir:'
 
@@ -341,27 +370,27 @@ async function selectFile(path: string, isImageFile = false, isAudioFile = false
     if (isPdf) {
         const fileName = baseName(path)
         state.currentFile = { name: fileName, path, content: null, isPdf: true }
-        return true
+        saveOpenFile(); return true
     }
     if (isImage) {
         const fileName = baseName(path)
         state.currentFile = { name: fileName, path, content: null, isImage: true }
-        return true
+        saveOpenFile(); return true
     }
     if (isAudio) {
         const fileName = baseName(path)
         state.currentFile = { name: fileName, path, content: null, isAudio: true }
-        return true
+        saveOpenFile(); return true
     }
     if (isVideo) {
         const fileName = baseName(path)
         state.currentFile = { name: fileName, path, content: null, isVideo: true }
-        return true
+        saveOpenFile(); return true
     }
     if (isOffice) {
         const fileName = baseName(path)
         state.currentFile = { name: fileName, path, content: null, isOffice: true }
-        return true
+        saveOpenFile(); return true
     }
 
     try {
@@ -391,7 +420,7 @@ async function selectFile(path: string, isImageFile = false, isAudioFile = false
                 const fileName = baseName(path)
                 const sizeInfo = state.dirEntries.find(e => e.name === fileName)
                 state.currentFile = { name: fileName, path, content: null, tooLarge: true, size: sizeInfo?.size }
-                return true
+                saveOpenFile(); return true
             }
             throw new Error(err.error || 'Failed')
         }
@@ -415,7 +444,7 @@ async function selectFile(path: string, isImageFile = false, isAudioFile = false
         } else {
             state.currentFile = data
         }
-        return true
+        saveOpenFile(); return true
     } catch (err: unknown) {
         // Don't replace currentFile — keep the previously opened file visible.
         useToast().show((err as Error).message, { type: 'error', icon: '⚠️' })
@@ -450,6 +479,7 @@ async function deleteFile(filePath: string): Promise<void> {
     }
     if (state.currentFile?.path === filePath) {
         state.currentFile = null
+        clearOpenFile()
         useFileNavStack().removePath(filePath)
     }
     appLog.d(TAG, '[deleteFile] refreshing, currentDir:', state.currentDir, 'loadFilesSeq:', loadFilesSeq)
@@ -473,6 +503,7 @@ async function deleteFiles(paths: string[]): Promise<void> {
     if (state.currentFile && paths.includes(state.currentFile.path)) {
         useFileNavStack().removePath(state.currentFile.path)
         state.currentFile = null
+        clearOpenFile()
     }
     await Promise.all([loadFiles(state.currentDir), loadGitBranch()])
     appLog.d(TAG, '[deleteFiles] done, dirEntries count:', state.dirEntries.length)

--- a/web/src/utils/__tests__/quoteQuestionUtils.test.ts
+++ b/web/src/utils/__tests__/quoteQuestionUtils.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest'
-import { closestElement, getFileInfo, getLineInfo } from '@/utils/quoteQuestionUtils'
+import { closestElement, getFileInfo, getLineInfo, buildQuoteMessage } from '@/utils/quoteQuestionUtils'
 
 // --- closestElement ---
 
@@ -290,5 +290,38 @@ describe('getFileInfo', () => {
     office.appendChild(md)
     // .markdown-body is checked before .office-preview-body
     expect(getFileInfo(container)).toEqual({ filePath: '/from-markdown.md', language: '' })
+  })
+})
+
+// --- buildQuoteMessage ---
+describe('buildQuoteMessage', () => {
+  it('embeds quoted code with language and line range', () => {
+    const result = buildQuoteMessage('explain this', 'func main()', '/cmd/main.go', 'go', 10, 25)
+    expect(result).toBe('explain this\n\n```go:/cmd/main.go:10-25\nfunc main()\n```')
+  })
+
+  it('embeds quoted code with single line number', () => {
+    const result = buildQuoteMessage('what is this?', 'return nil', '/internal/handler.go', 'go', 42, 42)
+    expect(result).toBe('what is this?\n\n```go:/internal/handler.go:42\nreturn nil\n```')
+  })
+
+  it('embeds quoted code without line numbers', () => {
+    const result = buildQuoteMessage('explain', 'some text', '/README.md', '', 0, 0)
+    expect(result).toBe('explain\n\n' + '```' + ':/README.md\nsome text\n' + '```')
+  })
+
+  it('uses empty language prefix when language is empty', () => {
+    const result = buildQuoteMessage('question', 'plain text', '/notes.txt', '', 5, 5)
+    expect(result).toBe('question\n\n' + '```' + ':/notes.txt:5\nplain text\n' + '```')
+  })
+
+  it('trims user message whitespace', () => {
+    const result = buildQuoteMessage('  explain this  ', 'code', '/f.go', 'go', 1, 2)
+    expect(result).toBe('explain this\n\n```go:/f.go:1-2\ncode\n```')
+  })
+
+  it('embeds quoted code with language but no line numbers', () => {
+    const result = buildQuoteMessage('explain', 'some code', '/main.go', 'go', 0, 0)
+    expect(result).toBe('explain\n\n```go:/main.go\nsome code\n```')
   })
 })

--- a/web/src/utils/chatRenderUtils.ts
+++ b/web/src/utils/chatRenderUtils.ts
@@ -20,7 +20,7 @@ export function rewriteImageUrls(html: string, projectRoot: string): string {
       const src = srcMatch[1]
       // Skip absolute/external URLs
       if (/^(https?:|\/\/|^\/)/i.test(src)) {
-        return `<img${cleanAttrs} class="chat-img lightbox-img">`
+        return `<span class="lightbox-img-wrap"><img${cleanAttrs} class="chat-img lightbox-img"><span class="lightbox-expand-icon"></span></span>`
       }
       // Try to resolve as a project-local path
       if (projectRoot) {
@@ -37,7 +37,7 @@ export function rewriteImageUrls(html: string, projectRoot: string): string {
         }
       }
     }
-    return `<img${cleanAttrs} class="chat-img lightbox-img">`
+    return `<span class="lightbox-img-wrap"><img${cleanAttrs} class="chat-img lightbox-img"><span class="lightbox-expand-icon"></span></span>`
   })
 }
 

--- a/web/src/utils/exportHtml.ts
+++ b/web/src/utils/exportHtml.ts
@@ -651,8 +651,8 @@ export async function exportRenderedHtml(options: ExportOptions): Promise<Export
     const title = escapeHtml(fileName.replace(/\.md$/i, ''))
     const bodyContent = clone.outerHTML
 
-    // Use current app theme as default (avoids flash of wrong theme)
-    const currentAppTheme = document.documentElement.getAttribute('data-theme') || 'light'
+    // Use light theme as default for exported HTML
+    const currentAppTheme = 'light'
 
     // Theme toggle button (sun/moon icon)
     const themeToggleHtml = `<button id="theme-toggle" class="fab-btn" title="Toggle theme"><svg id="theme-icon-moon" width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M21 12.79A9 9 0 1 1 11.21 3 7 7 0 0 0 21 12.79z"/></svg><svg id="theme-icon-sun" width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" style="display:none"><circle cx="12" cy="12" r="5"/><line x1="12" y1="1" x2="12" y2="3"/><line x1="12" y1="21" x2="12" y2="23"/><line x1="4.22" y1="4.22" x2="5.64" y2="5.64"/><line x1="18.36" y1="18.36" x2="19.78" y2="19.78"/><line x1="1" y1="12" x2="3" y2="12"/><line x1="21" y1="12" x2="23" y2="12"/><line x1="4.22" y1="19.78" x2="5.64" y2="18.36"/><line x1="18.36" y1="5.64" x2="19.78" y2="4.22"/></svg></button>`

--- a/web/src/utils/exportHtml.ts
+++ b/web/src/utils/exportHtml.ts
@@ -154,7 +154,6 @@ function serializeCss(_markdownBodyEl: HTMLElement): string {
                     sel === ':root' ||
                     sel.startsWith('[data-theme') ||
                     sel.includes('.markdown-content') ||
-                    sel.includes('.diff-marker') ||
                     sel.includes('.hljs') ||
                     sel.includes('.katex') ||
                     sel.includes('.code-line') ||
@@ -207,7 +206,6 @@ function serializeCss(_markdownBodyEl: HTMLElement): string {
                     name.includes('line-flash') ||
                     name.includes('copy-flash') ||
                     name.includes('char-flash') ||
-                    name.includes('diff-marker') ||
                     name.includes('url-btn-spin')
                 ) {
                     rules.push(rule.cssText)
@@ -574,6 +572,12 @@ export async function exportRenderedHtml(options: ExportOptions): Promise<Export
         mathml.remove()
     }
 
+    // 1e. Remove diff markers — interactive UI elements (colored side-bar buttons)
+    //     that open the diff drawer in the app. Meaningless in a standalone export.
+    for (const marker of Array.from(clone.querySelectorAll('.diff-marker'))) {
+        marker.remove()
+    }
+
     // 1e. Note: <foreignObject> elements in Mermaid SVGs are kept as-is.
     //     Chrome may log "Unsafe attempt to load URL" warnings on file:// URLs,
     //     but this does NOT affect rendering — the content displays correctly.
@@ -597,6 +601,51 @@ export async function exportRenderedHtml(options: ExportOptions): Promise<Export
 
     // 6. Build code block interaction JS
     const codeBlockJs = buildCodeBlockJs()
+
+    // 7. Lightbox JS for exported HTML — opens full-screen image/SVG viewer
+    const lightboxJs = `
+(function() {
+    function openLightbox(content, isSvg) {
+        var overlay = document.createElement('div');
+        overlay.className = 'export-lightbox';
+        if (isSvg) {
+            var div = document.createElement('div');
+            div.innerHTML = content;
+            var svg = div.querySelector('svg');
+            if (svg) { svg.style.maxWidth = '95vw'; svg.style.maxHeight = '95vh'; }
+            overlay.appendChild(svg || div);
+        } else {
+            var img = document.createElement('img');
+            img.src = content;
+            overlay.appendChild(img);
+        }
+        var closeBtn = document.createElement('button');
+        closeBtn.className = 'lb-close-btn';
+        closeBtn.textContent = '\\u00d7';
+        closeBtn.onclick = function(e) { e.stopPropagation(); overlay.remove(); };
+        overlay.appendChild(closeBtn);
+        overlay.onclick = function(e) { if (e.target === overlay) overlay.remove(); };
+        document.addEventListener('keydown', function handler(e) {
+            if (e.key === 'Escape') { overlay.remove(); document.removeEventListener('keydown', handler); }
+        });
+        document.body.appendChild(overlay);
+    }
+    document.addEventListener('click', function(e) {
+        var expandIcon = e.target.closest('.lightbox-expand-icon');
+        if (expandIcon) {
+            var wrap = expandIcon.closest('.lightbox-img-wrap');
+            var img = wrap ? wrap.querySelector('.lightbox-img') : null;
+            if (img) { e.preventDefault(); openLightbox(img.src, false); }
+            return;
+        }
+        var mermaid = e.target.closest('.mermaid');
+        if (mermaid) {
+            var svg = mermaid.querySelector('svg');
+            if (svg) { e.preventDefault(); openLightbox(svg.outerHTML, true); }
+            return;
+        }
+    });
+})();`
 
     // 7. Assemble HTML
     const title = escapeHtml(fileName.replace(/\.md$/i, ''))
@@ -672,6 +721,23 @@ body { margin: 0; padding: 0; font-family: -apple-system, BlinkMacSystemFont, 'S
 
 /* ─── TOC + FAB buttons ─── */
 ${tocCss}
+
+/* ─── Lightbox expand icon (hover overlay on images/mermaid) ─── */
+.markdown-body .lightbox-img-wrap { position: relative; display: inline-block; }
+.markdown-body .lightbox-img-wrap .lightbox-img { cursor: pointer; transition: transform 0.15s, box-shadow 0.15s; }
+.markdown-body .lightbox-img-wrap:hover .lightbox-img { transform: scale(1.02); box-shadow: 0 4px 12px rgba(0,0,0,0.15); }
+.markdown-body .lightbox-img-wrap .lightbox-expand-icon { display: none; position: absolute; top: 4px; right: 4px; width: 24px; height: 24px; border-radius: 4px; background: rgba(0,0,0,0.5); color: #fff; cursor: pointer; z-index: 2; pointer-events: auto; }
+.markdown-body .lightbox-img-wrap:hover .lightbox-expand-icon { display: flex; align-items: center; justify-content: center; }
+.markdown-body .lightbox-img-wrap .lightbox-expand-icon::after { content: '\\2922'; font-size: 14px; line-height: 1; }
+.markdown-body .mermaid { position: relative; }
+.markdown-body .mermaid::after { content: '\\2922'; display: none; position: absolute; top: 4px; right: 4px; width: 24px; height: 24px; border-radius: 4px; background: rgba(0,0,0,0.5); color: #fff; font-size: 14px; line-height: 24px; text-align: center; cursor: pointer; z-index: 2; }
+.markdown-body .mermaid:hover::after { display: block; }
+
+/* ─── Lightbox overlay ─── */
+.export-lightbox { position: fixed; inset: 0; z-index: 9999; background: rgba(0,0,0,0.85); display: flex; align-items: center; justify-content: center; cursor: zoom-out; }
+.export-lightbox img, .export-lightbox svg { max-width: 95vw; max-height: 95vh; object-fit: contain; }
+.export-lightbox .lb-close-btn { position: absolute; top: 16px; right: 16px; width: 36px; height: 36px; border-radius: 50%; border: none; background: rgba(255,255,255,0.2); color: #fff; font-size: 20px; cursor: pointer; display: flex; align-items: center; justify-content: center; }
+.export-lightbox .lb-close-btn:hover { background: rgba(255,255,255,0.4); }
 </style>
 </head>
 <body>
@@ -683,6 +749,7 @@ ${bodyContent}
 ${themeToggleJs}
 ${tocJs}
 ${codeBlockJs}
+${lightboxJs}
 </script>
 </body>
 </html>`

--- a/web/src/utils/gitGraph.ts
+++ b/web/src/utils/gitGraph.ts
@@ -193,19 +193,21 @@ export function computeGraphData(commits: GitCommit[], rowHeight: number, previo
         const parentRow = shaToRow.get(pSha)
         const parentLane = shaToLane.get(pSha)
         if (rowLane !== parentLane) {
-          // Extend child lane to include parent row
-          if (!laneFirstRow.has(rowLane) || parentRow < laneFirstRow.get(rowLane)) {
-            laneFirstRow.set(rowLane, parentRow)
-          }
-          if (!laneLastRow.has(rowLane) || parentRow > laneLastRow.get(rowLane)) {
-            laneLastRow.set(rowLane, parentRow)
-          }
-          // Extend parent lane to include child row
-          if (!laneFirstRow.has(parentLane) || row < laneFirstRow.get(parentLane)) {
-            laneFirstRow.set(parentLane, row)
-          }
-          if (!laneLastRow.has(parentLane) || row > laneLastRow.get(parentLane)) {
-            laneLastRow.set(parentLane, row)
+          // For a merge-in (first-parent on another lane) the connection is
+          // drawn as a vertical line on the child lane running down to the
+          // parent row, so extend the child lane to include it. Fork curves
+          // (non-first parents) stay between the two lanes and only reach
+          // the parent lane at the parent node's own row, so they extend
+          // neither lane. Extending a lane beyond its real occupied rows
+          // would push a later branch to a farther lane and leave an empty
+          // lane between it and the mainline.
+          if (pi === 0) {
+            if (!laneFirstRow.has(rowLane) || parentRow < laneFirstRow.get(rowLane)) {
+              laneFirstRow.set(rowLane, parentRow)
+            }
+            if (!laneLastRow.has(rowLane) || parentRow > laneLastRow.get(rowLane)) {
+              laneLastRow.set(rowLane, parentRow)
+            }
           }
         }
       }

--- a/web/src/utils/quoteQuestionUtils.ts
+++ b/web/src/utils/quoteQuestionUtils.ts
@@ -68,3 +68,26 @@ export function truncateQuoteText(text: string, maxLen = 150): string {
 export function canSendInput(inputText: string): boolean {
   return inputText.trim().length > 0
 }
+
+/**
+ * Build a message that embeds quoted code as a fenced code block.
+ * The code block includes language prefix, file path, and optional line range
+ * so the AI can identify the source context precisely.
+ */
+export function buildQuoteMessage(
+  userMessage: string,
+  text: string,
+  filePath: string,
+  language: string,
+  startLine: number,
+  endLine: number,
+): string {
+  const langPrefix = language ? `${language}:` : ':'
+  let lineSuffix = ''
+  if (startLine && endLine && startLine !== endLine) {
+    lineSuffix = `:${startLine}-${endLine}`
+  } else if (startLine) {
+    lineSuffix = `:${startLine}`
+  }
+  return `${userMessage.trim()}\n\n\`\`\`${langPrefix}${filePath}${lineSuffix}\n${text}\n\`\`\``
+}


### PR DESCRIPTION
## Summary

- **goconst**: Replace string literal `"tool_use"` with existing `eventTypeToolUse` constant in `session_command.go` and `session_executor.go`
- **gocyclo**: Extract `extractMessageParts()` from `BuildForkContext()` to reduce cyclomatic complexity from 17 to ≤15
- **gofumpt**: Fix formatting in `chat.go`, `session_command.go`, `session_command_test.go`
- **test**: Add 5 unit tests for `extractMessageParts` (text blocks, empty text, tool_use, skip thinking/warning, empty blocks)

## Test

All pre-push checks pass: Go lint, Go test, Go build, Frontend typecheck, Frontend build.