### PR TITLE
fix: terminate ACP process tree on Windows via taskkill /T

### DIFF
--- a/internal/ai/acp_process_windows.go
+++ b/internal/ai/acp_process_windows.go
@@ -5,18 +5,23 @@ package ai
 import (
 	"os"
 	"os/exec"
+	"strconv"
 )
 
 // setProcessGroup is a no-op on Windows. POSIX process groups don't exist;
-// Job Objects would be needed for proper child cleanup. For now, Kill() on
-// the parent process is sufficient for most cases.
+// process-tree cleanup is handled by killProcessGroup via taskkill /T.
 func setProcessGroup(cmd *exec.Cmd) {
 	// Windows: no POSIX process groups
 }
 
-// killProcessGroup kills the process. On Windows, there are no POSIX process
-// groups, so we can only kill the parent. Child processes spawned by npx may
-// survive; cmd.Wait() should still complete once the parent exits.
+// killProcessGroup kills the process and its entire process tree.
+// ACP agents like Claude are spawned via npx (npx → node → claude); killing
+// only the npx parent leaves node and claude alive — leaking memory and
+// holding the stdout/stderr pipes open, which makes cmd.Wait() hang.
+// taskkill /T terminates the process and all its descendants recursively.
 func killProcessGroup(proc *os.Process) {
+	// /F force-terminates, /T kills the whole tree, /PID targets the process.
+	_ = exec.Command("taskkill", "/F", "/T", "/PID", strconv.Itoa(proc.Pid)).Run()
+	// Fallback: kill the parent directly if taskkill failed or already exited.
 	_ = proc.Kill()
 }


### PR DESCRIPTION
## Problem

Closing a chat session from the mobile/web UI (`ArchiveSession` / `DestroySession`) calls `CloseConn` → `killProcessGroup`, which on Windows only ran `proc.Kill()` on the **parent** process.

`proc.Kill()` (TerminateProcess) terminates a single process and does **not** follow children. ACP agents like Claude are spawned via `npx -y @agentclientprotocol/claude-agent-acp@latest`, i.e. a tree of `npx → node → claude`. Killing only `npx` leaves `node` and `claude` alive:

- each closed session leaks one live Claude process that keeps consuming memory (accumulates until OOM),
- the surviving children hold the stdout/stderr pipe write ends open, so `cmd.Wait()` in the `CloseConn` goroutine blocks indefinitely.

On Unix this works correctly (process-group kill via `setpgid` + `kill(-pid)`); the bug is Windows-specific.

## Fix

Use `taskkill /F /T` in `killProcessGroup` on Windows — it recursively terminates the process and all its descendants, matching the process-group semantics on Unix. `proc.Kill()` is kept as a fallback.

Verified on Windows: spawning a parent `cmd` with a child `ping`, then `taskkill /F /T` on the parent, kills the child as well.
