### PR TITLE
fix(markdown): improve Android and CJK bold rendering

### DIFF
--- a/package.json
+++ b/package.json
@@ -90,5 +90,8 @@
     "vite": "^6.0.0",
     "vitest": "^4.1.8",
     "vue-tsc": "^2.2.12"
+  },
+  "overrides": {
+    "marked": "$marked"
   }
 }

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -175,8 +175,12 @@ export default defineConfig({
     },
   },
   resolve: {
+    // Force root marked@18. redoc (web/ transitive) installs marked@4, which
+    // fails to parse **bold `code`** followed by CJK punctuation (e.g. ，).
     alias: {
       '@': resolve(__dirname, 'web/src'),
+      marked: resolve(__dirname, 'node_modules/marked'),
     },
+    dedupe: ['marked'],
   },
 })

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -34,9 +34,13 @@ function staticAssetResolver(): import('vite').Plugin {
 export default defineConfig({
   plugins: [vue(), staticAssetResolver()],
   resolve: {
+    // Same as vite.config.ts: pin marked@18 so redoc's marked@4 is never used.
+    // marked@4 drops <strong> for **text `code`** + CJK punctuation (U+FF0C etc.).
     alias: {
       '@': resolve(__dirname, 'web/src'),
+      marked: resolve(__dirname, 'node_modules/marked'),
     },
+    dedupe: ['marked'],
   },
   publicDir: resolve(__dirname, 'assets'),
   server: {

--- a/web/css/markdown-common.css
+++ b/web/css/markdown-common.css
@@ -3,9 +3,12 @@
    Shared by: .markdown-body (file preview), .chat-message.assistant and .chat-message.user (chat), .table-row-value (table row modal)
    ========================================================================== */
 
-/* Strong / Bold — traditional font-weight bold;
- * Android WebView font-weight:700 often doesn't thicken glyphs, so add text-shadow
- * via [data-app-mode] (set by useAppMode) as visual compensation. */
+/* Strong / Bold — traditional font-weight bold + darker --text-bold.
+ * Mobile Chrome usually has a real/native bold cut, so weight alone is enough.
+ * Android WebView (esp. CJK at chat sizes) often synthesizes bold by fattening
+ * outlines, which can look lighter/softer than the browser. Compensate only in
+ * [data-app-mode] with a tiny zero-blur horizontal text-shadow (hard stroke, no
+ * glow) so weight matches browser darkness without softening vertical edges. */
 .markdown-body strong,
 .markdown-body b,
 .chat-message.assistant strong,
@@ -22,19 +25,24 @@
     color: #ffffff;
 }
 
-/* WebView bold compensation — text-shadow thickens glyphs where font-weight alone fails */
+/* WebView bold compensation — tiny horizontal zero-blur offsets thicken glyphs crisply.
+ * Avoid `0 0 1px` (blur radius) which looks soft/fuzzy on GPU-composited layers. */
 [data-app-mode] .markdown-body strong,
 [data-app-mode] .markdown-body b,
 [data-app-mode] .chat-message.assistant strong,
 [data-app-mode] .chat-message.assistant b,
 [data-app-mode] .table-row-value strong,
 [data-app-mode] .table-row-value b {
-    text-shadow: 0 0 1px currentColor;
+    text-shadow:
+        0.12px 0 0 currentColor,
+        -0.12px 0 0 currentColor;
 }
 
 [data-app-mode] .chat-message.user strong,
 [data-app-mode] .chat-message.user b {
-    text-shadow: 0 0 0.8px currentColor;
+    text-shadow:
+        0.1px 0 0 currentColor,
+        -0.1px 0 0 currentColor;
 }
 
 /* Links */

--- a/web/src/components/chat/__tests__/chatBoldStyle.test.ts
+++ b/web/src/components/chat/__tests__/chatBoldStyle.test.ts
@@ -1,0 +1,51 @@
+import { readFileSync } from 'node:fs'
+import { resolve } from 'node:path'
+import { describe, expect, it } from 'vitest'
+
+/**
+ * Android WebView chat bold must match mobile browser darkness/weight:
+ * - Keep font-weight: bold + --text-bold (darker than body text)
+ * - In app/WebView only, use tiny horizontal zero-blur text-shadow (hard stroke)
+ * - Never reintroduce soft blur shadows (`0 0 Npx`) or weight-600 overrides
+ *   that wash bold out lighter than Chrome.
+ */
+describe('chat bold style (Android WebView vs browser parity)', () => {
+  const markdownCss = readFileSync(
+    resolve(__dirname, '../../../../css/markdown-common.css'),
+    'utf8',
+  )
+  const messageItem = readFileSync(
+    resolve(__dirname, '../ChatMessageItem.vue'),
+    'utf8',
+  )
+
+  it('uses bold weight + --text-bold for assistant/markdown strong', () => {
+    expect(markdownCss).toMatch(
+      /\.chat-message\.assistant strong,[\s\S]*?font-weight:\s*bold;[\s\S]*?color:\s*var\(--text-bold\);/,
+    )
+  })
+
+  it('applies tiny horizontal zero-blur text-shadow only under data-app-mode', () => {
+    expect(markdownCss).toContain('[data-app-mode] .chat-message.assistant strong')
+    expect(markdownCss).toMatch(
+      /\[data-app-mode\][\s\S]*?text-shadow:\s*[\s\S]*?0\.12px 0 0 currentColor[\s\S]*?-0\.12px 0 0 currentColor/,
+    )
+    expect(markdownCss).not.toMatch(/text-shadow:[\s\S]*?0 0\.\d+px 0 currentColor/)
+    expect(markdownCss).not.toMatch(/text-shadow:[\s\S]*?0 -0\.\d+px 0 currentColor/)
+    // Soft glow (blur radius) looks fuzzy on GPU-composited WebView layers
+    expect(markdownCss).not.toMatch(/text-shadow:\s*0 0 1px currentColor/)
+    expect(markdownCss).not.toMatch(/text-shadow:\s*0 0 0\.8px currentColor/)
+  })
+
+  it('does not override chat strong with lighter weight or text-shadow:none in ChatMessageItem', () => {
+    // Guard against regressing to weight-600 / color-mix / text-shadow:none overrides
+    expect(messageItem).not.toMatch(/\.chat-message strong[\s\S]{0,80}font-weight:\s*600/)
+    expect(messageItem).not.toMatch(/:root\[data-app-mode\] \.chat-message strong[\s\S]{0,120}text-shadow:\s*none/)
+    expect(messageItem).not.toMatch(/color-mix\(in srgb, var\(--text-primary\)/)
+  })
+
+  it('keeps the Android GPU ghost will-change rule on chat messages', () => {
+    expect(messageItem).toContain(':root[data-app-mode] .chat-message')
+    expect(messageItem).toContain('will-change: transform')
+  })
+})

--- a/web/src/utils/__tests__/markedConfig.test.ts
+++ b/web/src/utils/__tests__/markedConfig.test.ts
@@ -97,4 +97,52 @@ describe('markedConfig', () => {
             expect(html).not.toContain('class="language-')
         })
     })
+
+    /**
+     * Regression: marked@4 (redoc transitive) drops <strong> when bold wraps
+     * inline code and is immediately followed by CJK punctuation.
+     * Must keep marked@18+ so chat/file preview renders bold correctly.
+     */
+    describe('bold + inline code + CJK punctuation (marked@4 regression)', () => {
+        it('keeps strong when **…`code`** is followed by fullwidth comma', () => {
+            const md = '5. **媒体缓存 bust 靠 query `t`**，依赖前端记得刷新 timestamp'
+            const html = marked.parse(md) as string
+            expect(html).toContain('<strong>')
+            expect(html).toContain('</strong>')
+            expect(html).toContain('<code>t</code>')
+            expect(html).toMatch(/<strong>[\s\S]*媒体缓存[\s\S]*<code>t<\/code>[\s\S]*<\/strong>/)
+            // Literal asterisks must not leak into rendered HTML
+            expect(html).not.toContain('**媒体')
+            expect(html).not.toContain('`t`**')
+        })
+
+        it('keeps strong for **text `code`** + various CJK punctuation', () => {
+            const puncts = ['，', '。', '；', '：', '）', '、', '！']
+            for (const p of puncts) {
+                const md = '**query `t`**' + p + 'x'
+                const html = marked.parse(md) as string
+                expect(html, `failed for punct ${JSON.stringify(p)}`).toContain('<strong>')
+                expect(html).toContain('<code>t</code>')
+                expect(html).not.toMatch(/\*\*query/)
+            }
+        })
+
+        it('keeps strong in multi-item list matching real chat content', () => {
+            const md = [
+                '1. **扩展名表多处维护**：`app.ts`',
+                "2. **绝对路径靠 `path.startsWith('/')` 判断**，Windows",
+                '3. **文件操作 handler 偏厚**：`file.go`',
+                '4. **`/api/files` 全量 Walk** 对大仓库危险，主路径用的是 `/api/dir`',
+                '5. **媒体缓存 bust 靠 query `t`**，依赖前端记得刷新 timestamp；watcher 路径走 `refreshCurrentFile`，列表缩略图（`file_thumb.go`）是否同步要另看',
+            ].join('\n')
+            const html = marked.parse(md) as string
+            const items = [...html.matchAll(/<li>[\s\S]*?<\/li>/g)].map((m) => m[0])
+            expect(items).toHaveLength(5)
+            for (let i = 0; i < 5; i++) {
+                expect(items[i], `item ${i + 1} missing <strong>`).toContain('<strong>')
+            }
+            expect(items[4]).toMatch(/<strong>[\s\S]*媒体缓存[\s\S]*<\/strong>/)
+            expect(items[4]).not.toContain('**媒体')
+        })
+    })
 })

--- a/web/src/utils/markedConfig.ts
+++ b/web/src/utils/markedConfig.ts
@@ -18,11 +18,13 @@ export function resetHeadingIds(): void {
 /**
  * Configure marked's custom renderer for code blocks and headings.
  *
- * CRITICAL: marked v4 passes positional args (code, lang) / (text, depth)
- * to renderer hooks, while marked v18+ passes a single token object
- * ({ text, lang }) / ({ text, depth }). The web/ sub-project may resolve
- * a different marked version than root (due to redoc's transitive dep),
- * so the renderer must handle both APIs.
+ * marked must be v18+ (pinned via vite/vitest alias + package overrides).
+ * marked@4 (historically pulled in by redoc) fails to parse
+ * `**text `code`**` followed by CJK punctuation (e.g. fullwidth comma)，
+ * leaving literal `**` instead of <strong>.
+ *
+ * Renderer hooks still accept both v4 positional args and v18 token objects
+ * for defense-in-depth if a stale nested marked ever sneaks back in.
  *
  * Call once at app startup (from main.ts).
  */


### PR DESCRIPTION
## Summary

This PR fixes two independent bold-rendering issues, with one complete feature per commit:

1. Make bold text in Android WebView as crisp and dark as mobile Chrome.
2. Keep bold spans intact when they contain inline code and are followed by CJK punctuation.

## Changes

### Android WebView bold rendering (`9c113771`)

- Keeps the existing semantic `font-weight: bold` and `--text-bold` color.
- Replaces the blurred WebView compensation (`0 0 1px`) with symmetric, zero-blur horizontal offsets.
- Uses `+/-0.12px` for assistant/Markdown/table content and `+/-0.1px` for user-message bold text.
- Applies compensation only under `[data-app-mode]`; normal mobile and desktop browsers continue to use native bold rendering.
- Adds a focused CSS regression test that prevents soft glow shadows, lighter weight overrides, or removal of the Android GPU compositing rule.

### marked@18 CJK bold parsing (`e036511e`)

- Pins transitive `marked` resolution to the root direct dependency through a package override.
- Aliases and deduplicates `marked` in both Vite and Vitest so `redoc`'s nested `marked@4` cannot be selected for application Markdown.
- Retains renderer compatibility with both positional and token-object callback forms as a defensive fallback.
- Adds regression coverage for bold text containing inline code followed by Chinese/Japanese punctuation, including a representative multi-item Markdown list.
- Verifies that rendered output contains `<strong>` and `<code>` without leaking literal `**` markers.

## Review guide

- Review the two commits independently; the CSS change does not depend on the parser change.
- For the Android change, compare the zero-blur horizontal offsets with the removed blurred shadow and confirm the selector remains app-mode-only.
- For the parser change, focus on the Vite/Vitest alias target and the root `marked` override. No renderer behavior changes outside dependency selection and regression documentation.
- This PR does not change Android native/build files, `build.sh`, chat retry behavior, ACP model refresh, or general `ContentBlocks` rendering.

## Verification

- Focused Vitest: 2 files / 17 tests passed
- `npm run typecheck`
- `npm run build`
- Commit-time ESLint hook
- `git diff --check upstream/main..HEAD`

The repository-wide pre-push wrapper still has the same unrelated baseline/tooling blockers seen on this upstream revision: it requests the nonexistent `golangci-lint v2.12.2` release, unchanged Go packages miss existing coverage floors, and the full Vitest coverage run can hang while terminating a worker. The focused checks above passed.
