### PR TITLE
fix(acp): 异步斜杠命令运行期间连接不被 idle sweep 回收

### DIFF
--- a/internal/ai/acp_client.go
+++ b/internal/ai/acp_client.go
@@ -173,6 +173,17 @@ func (c *ClawBenchACPClient) SessionUpdate(ctx context.Context, n acp.SessionNot
 		c.mu.Unlock()
 	}
 
+	// Keep the connection alive for async workflows (e.g. /deep-research):
+	// record this SessionUpdate as activity so the idle sweep doesn't close a
+	// connection that is still receiving events even after Prompt returns and
+	// the session is unregistered from sessionRoutes. This MUST be lock-free
+	// (atomic) — this callback runs on the ACP notification processing
+	// goroutine, and RPCs like NewSession hold conn.mu while waiting for queued
+	// notifications to be processed. Taking conn.mu here would deadlock.
+	if c.connRef != nil {
+		c.connRef.TouchSessionUpdate()
+	}
+
 	// During LoadSession replay, collect messages in buffer instead of
 	// routing to WS stream channels. The load handler reads them after
 	// the LoadSession RPC returns.
@@ -191,6 +202,8 @@ func (c *ClawBenchACPClient) SessionUpdate(ctx context.Context, n acp.SessionNot
 	if !ok {
 		// No active stream for this session — drop the update.
 		// This can happen after a session is cancelled or the prompt completes.
+		// The connection activity was already recorded above, so async
+		// workflows that continue sending events stay alive.
 		return nil
 	}
 

--- a/internal/ai/acp_client_test.go
+++ b/internal/ai/acp_client_test.go
@@ -133,6 +133,44 @@ func TestClawBenchACPClient_SessionUpdate_UnregisteredSession_DropsSilently(t *t
 	assert.NoError(t, err) // no error, just silently dropped
 }
 
+func TestClawBenchACPClient_SessionUpdate_TouchesConnRefForUnregisteredSession(t *testing.T) {
+	// Even for an unregistered session (async workflow after Prompt returns),
+	// SessionUpdate must record connection activity so the idle sweep does not
+	// close the connection while the workflow is still streaming events.
+	agent := &model.Agent{ID: "test-async-agent", Backend: "acp-stdio", AcpCommand: "echo"}
+	conn := newACPConn(agent, "session-async")
+
+	c := NewClawBenchACPClient()
+	c.connRef = conn
+
+	// Set lastUsed to an old time to verify TouchSessionUpdate advances it
+	old := time.Now().Add(-10 * time.Minute)
+	conn.mu.Lock()
+	conn.lastUsed = old
+	conn.mu.Unlock()
+
+	ctx := context.Background()
+	notif := acp.SessionNotification{
+		SessionId: acp.SessionId("unknown-sess"),
+		Update: acp.SessionUpdate{
+			AgentMessageChunk: &acp.SessionUpdateAgentMessageChunk{
+				Content: acp.ContentBlock{
+					Text: &acp.ContentBlockText{Text: "async progress"},
+				},
+			},
+		},
+	}
+
+	err := c.SessionUpdate(ctx, notif)
+	assert.NoError(t, err)
+
+	// The connection's lastActivityNano must be newer than the old lastUsed,
+	// proving TouchSessionUpdate was invoked for the unregistered session.
+	activity := conn.lastActivityNano()
+	assert.True(t, activity > old.UnixNano(),
+		"SessionUpdate should record activity on connRef for unregistered sessions")
+}
+
 func TestClawBenchACPClient_SessionUpdate_CachesCommands(t *testing.T) {
 	c := NewClawBenchACPClient()
 	ch := make(chan StreamEvent, 10)

--- a/internal/ai/acp_pool.go
+++ b/internal/ai/acp_pool.go
@@ -148,14 +148,14 @@ func (m *ACPConnManager) sweepOnce() {
 	now := time.Now()
 	for sid, conn := range m.conns {
 		conn.mu.Lock()
-		idle := now.Sub(conn.lastUsed)
+		lastActivity := conn.lastActivityNano()
 		alive := conn.alive
 		conn.mu.Unlock()
 
 		if !alive {
 			continue // already dead, will be respawned on next use
 		}
-		if idle < idleConnTimeout {
+		if now.Sub(time.Unix(0, lastActivity)) < idleConnTimeout {
 			continue // not idle enough yet
 		}
 		// Skip connections with actively running sessions
@@ -179,14 +179,14 @@ func (m *ACPConnManager) sweepOnce() {
 		// the initial scan (TOCTOU race). If it's no longer idle or the
 		// session started running, skip it.
 		conn.mu.Lock()
-		idle := time.Since(conn.lastUsed)
+		lastActivity := conn.lastActivityNano()
 		alive := conn.alive
 		conn.mu.Unlock()
 
 		if !alive {
 			continue // already dead
 		}
-		if idle < idleConnTimeout {
+		if time.Since(time.Unix(0, lastActivity)) < idleConnTimeout {
 			continue // recently used, no longer idle
 		}
 		if m.isSessionRunning != nil && m.isSessionRunning(sid) {
@@ -202,7 +202,7 @@ func (m *ACPConnManager) sweepOnce() {
 		m.mu.Unlock()
 
 		if ok {
-			slog.Info("acp: idle sweep closing connection", "clawbench_sid", sid, "idle_duration", idle)
+			slog.Info("acp: idle sweep closing connection", "clawbench_sid", sid, "idle_duration", time.Since(time.Unix(0, lastActivity)))
 			conn.close()
 		}
 	}
@@ -362,6 +362,28 @@ func (m *ACPConnManager) MarkIdle(clawbenchSID string) {
 		conn.lastUsed = time.Now()
 		conn.mu.Unlock()
 	}
+}
+
+// TouchSessionUpdate records the current time as the connection's most recent
+// SessionUpdate activity. It is lock-free (atomic store) so it can be called
+// from the ACP notification processing goroutine without risking a deadlock:
+// RPCs like NewSession hold c.mu while waiting for queued notifications to be
+// processed, so if this callback took c.mu it would block notification
+// processing and stall the RPC until timeout.
+func (c *ACPConn) TouchSessionUpdate() {
+	c.lastSessionUpdate.Store(time.Now().UnixNano())
+}
+
+// lastActivityNano returns the later of lastUsed and lastSessionUpdate as a
+// UnixNano timestamp, representing the last time the connection did any work
+// (either an explicit use or an incoming SessionUpdate from an async workflow).
+// Must be called without holding c.mu.
+func (c *ACPConn) lastActivityNano() int64 {
+	lastUsedNano := c.lastUsed.UnixNano()
+	if su := c.lastSessionUpdate.Load(); su > lastUsedNano {
+		return su
+	}
+	return lastUsedNano
 }
 
 // ACPCachedState holds the cached ACP state for a connection.
@@ -557,6 +579,15 @@ type ACPConn struct {
 	lastUsed  time.Time
 	alive     bool
 	startedAt time.Time // when the agent process was spawned
+
+	// lastSessionUpdate is the UnixNano timestamp of the most recent
+	// SessionUpdate event received from the agent, updated atomically (no
+	// lock) so the SessionUpdate callback can keep an async workflow's
+	// connection alive without blocking the ACP notification processing
+	// chain. A blocked notification chain would deadlock RPC calls like
+	// NewSession, which wait for queued notifications to be processed
+	// (see waitNotificationsUpTo in the ACP SDK).
+	lastSessionUpdate atomic.Int64
 
 	// cmdWaitOnce ensures cmd.Wait() is called exactly once; the result is
 	// cached in cmdWaitState for subsequent readers.

--- a/internal/ai/acp_pool_test.go
+++ b/internal/ai/acp_pool_test.go
@@ -130,6 +130,56 @@ func TestACPConnManager_MarkIdle_NonexistentConn(t *testing.T) {
 	})
 }
 
+// --- ACPConn.TouchSessionUpdate / lastActivityNano ---
+
+func TestACPConn_TouchSessionUpdate_UpdatesLastActivity(t *testing.T) {
+	conn := newACPConn(nil, "test-touch-sid")
+
+	// Set lastUsed to a known old time so lastActivityNano falls back to it
+	old := time.Now().Add(-10 * time.Minute)
+	conn.mu.Lock()
+	conn.lastUsed = old
+	conn.mu.Unlock()
+
+	// Before any SessionUpdate, lastActivityNano equals lastUsed
+	assert.Equal(t, old.UnixNano(), conn.lastActivityNano())
+
+	// TouchSessionUpdate records a newer activity timestamp
+	conn.TouchSessionUpdate()
+
+	after := conn.lastActivityNano()
+	assert.True(t, after > old.UnixNano(), "TouchSessionUpdate should advance lastActivityNano")
+}
+
+func TestACPConn_LastActivityNano_PrefersNewerSessionUpdate(t *testing.T) {
+	conn := newACPConn(nil, "test-activity-sid")
+
+	// lastUsed is fresh
+	now := time.Now()
+	conn.mu.Lock()
+	conn.lastUsed = now
+	conn.mu.Unlock()
+
+	// A newer SessionUpdate wins over lastUsed
+	conn.TouchSessionUpdate()
+
+	got := conn.lastActivityNano()
+	assert.True(t, got >= now.UnixNano(), "lastActivityNano should prefer the newer of lastUsed/lastSessionUpdate")
+}
+
+func TestACPConn_LastActivityNano_StaleSessionUpdateFallsBackToLastUsed(t *testing.T) {
+	conn := newACPConn(nil, "test-stale-sid")
+
+	// lastUsed is newer than the SessionUpdate timestamp
+	conn.mu.Lock()
+	conn.lastUsed = time.Now()
+	conn.mu.Unlock()
+	conn.lastSessionUpdate.Store(time.Now().Add(-30 * time.Minute).UnixNano())
+
+	got := conn.lastActivityNano()
+	assert.Equal(t, conn.lastUsed.UnixNano(), got, "lastActivityNano should fall back to lastUsed when SessionUpdate is stale")
+}
+
 // --- spawnLocked mutex release during cmd.Wait ---
 
 func TestACPConn_CancelTurn_DoesNotBlockOnDeadConn(t *testing.T) {


### PR DESCRIPTION
## 变更说明

### 问题
ACP 异步斜杠命令（如 `/deep-research`）调用后立即返回（`conn.Prompt` 数百毫秒完成），但工作流在后台继续运行。由于 ACP 会话基于 5 分钟闲置超时回收连接，超过 5 分钟的调研会被 idle sweep 杀死，无法通过 `/workflows` 查询进度。

### 根因
- Prompt 返回后 session 从 `sessionRoutes` 移除，后续 `SessionUpdate` 事件被丢弃，`lastUsed` 不再更新
- 最初尝试将 `lastUsed` 更新移到路由检查之前，但引入死锁：`SessionUpdate` 回调运行在 ACP notification 处理链上，而 `NewSession` 等 RPC 持有 `conn.mu` 等待 notification 处理完成（`waitNotificationsUpTo`），导致 RPC 30 秒超时

### 修复
- 新增 `ACPConn.lastSessionUpdate` 原子字段，`SessionUpdate` 回调通过**无锁原子操作**（`TouchSessionUpdate`）记录活跃时间，避免阻塞 notification 处理链
- idle sweep 使用 `lastActivityNano`（`lastUsed` 与 `lastSessionUpdate` 的较大值）判断连接是否空闲
- 异步工作流持续发送 `SessionUpdate` 事件时连接保持活跃，工作流结束后事件停止，连接在 5 分钟后正常回收

## 变更类型

- [x] Bug 修复
- [ ] 新功能
- [ ] 重构
- [ ] 文档变更
- [ ] 其他

## 关联 Issue

Fixes #354

## 测试

- [x] `go test ./internal/ai/...` 全部通过
- [x] 新增单元测试：`TouchSessionUpdate`、`lastActivityNano`、`SessionUpdate` 对未注册 session 仍记录连接活跃
- [x] `golangci-lint --new-from-rev` 0 issues
- [x] 实际验证：普通消息正常、`/deep-research` 运行 9 分钟连接保持存活、`/workflows` 正常查询进度

## 自检清单

- [x] 代码风格遵循项目规范（gofumpt）
- [x] 无敏感信息泄露
- [x] 变更相关测试已补充