### PR TITLE
feat(chat): 增加流式响应计时与多段引用提问

### DIFF
--- a/web/src/App.vue
+++ b/web/src/App.vue
@@ -260,11 +260,11 @@
         @close="detailsDrawer.close()"
       />
 
-      <!-- Quote question floating bar (narrow mode only; wide-screen uses ChatInputBar quote tag) -->
+      <!-- Quote question floating bar (shared by narrow and wide layouts) -->
       <QuoteQuestionBar
-        v-if="!isWideScreen"
         :visible="quoteQuestion.visible.value"
         :quoteData="quoteQuestion.quoteData.value"
+        @add="quoteQuestion.addToConversation($event)"
         @send="quoteQuestion.sendMessage($event)"
         @close="quoteQuestion.closeSheet()"
         @pin="quoteQuestion.pinBar()"
@@ -431,7 +431,7 @@ import HeaderMarquee from './components/common/HeaderMarquee.vue'
 import AgentIcon from './components/common/AgentIcon.vue'
 import SettingsPage from './components/settings/SettingsPage.vue'
 import TaskTab from '@/components/task/TaskTab.vue'
-import { useQuoteQuestion, restoreBarVisibility } from './composables/useQuoteQuestion.ts'
+import { useQuoteQuestion } from './composables/useQuoteQuestion.ts'
 import { useTaskTab, registerSwitchTab, onTaskEvent } from '@/composables/useTaskTab.ts'
 import { useTabDrawer, onTabSwitch, resetTabDrawerState } from '@/composables/useTabDrawer.ts'
 import { resetAgents, useAgents } from '@/composables/useAgents'
@@ -1515,10 +1515,6 @@ watch(isWideScreen, (val) => {
     document.documentElement.style.setProperty('--dock-height', '0px')
   } else {
     onTabSwitch(activeTab.value)
-    // Restore QuoteQuestionBar visibility if a pinned quote exists
-    // (wide-screen auto-pin sets barVisible=false because the floating bar
-    // is hidden there; switching to narrow needs the bar back).
-    restoreBarVisibility()
     // Bottom dock visible again — re-measure (ResizeObserver may miss the
     // display:none → visible transition, see the keyboard safety-net comment).
     nextTick(() => {

--- a/web/src/components/__tests__/chatInputBar.test.ts
+++ b/web/src/components/__tests__/chatInputBar.test.ts
@@ -520,6 +520,43 @@ describe('ChatInputBar — quick-send touch events', () => {
 })
 
 describe('ChatInputBar — quoteData chip', () => {
+  it('renders multiple staged quote chips in order', async () => {
+    const wrapper = mountInputBar({
+      quotes: [
+        { id: 'q1', text: 'one', filePath: '/a.ts', language: 'ts', startLine: 1, endLine: 2, note: '' },
+        { id: 'q2', text: 'two', filePath: '/b.ts', language: 'ts', startLine: 8, endLine: 8, note: 'check this' },
+      ],
+    })
+    await nextTick()
+
+    const chips = wrapper.findAll('.attachment-quote')
+    expect(chips).toHaveLength(2)
+    expect(chips[0].text()).toContain('a.ts:1-2')
+    expect(chips[1].text()).toContain('b.ts:8')
+    expect(chips[1].attributes('title')).toBe('check this')
+  })
+
+  it('removes and navigates a specific staged quote', async () => {
+    const quote = { id: 'q2', text: 'two', filePath: '/b.ts', language: 'ts', startLine: 8, endLine: 8, note: '' }
+    const wrapper = mountInputBar({ quotes: [quote] })
+    await nextTick()
+
+    await wrapper.find('.attachment-quote').trigger('click')
+    await wrapper.find('.attachment-close-btn').trigger('click')
+
+    expect(wrapper.emitted('quote-click')![0]).toEqual([quote])
+    expect(wrapper.emitted('remove-quote')![0]).toEqual(['q2'])
+  })
+
+  it('sends staged quotes without requiring input text', async () => {
+    const wrapper = mountInputBar({
+      quotes: [{ id: 'q1', text: 'one', filePath: '/a.ts', language: 'ts', startLine: 1, endLine: 1, note: '' }],
+    })
+    expect(wrapper.vm.hasInputContent).toBeTruthy()
+    await wrapper.find('.chat-send-btn').trigger('click')
+    expect(wrapper.emitted('send')![0]).toEqual([''])
+  })
+
   it('shows quote chip when quoteData prop is provided', async () => {
     const wrapper = mountInputBar({
       quoteData: { text: 'selected code', filePath: '/foo.ts', language: 'typescript', startLine: 10, endLine: 20 },

--- a/web/src/components/__tests__/quoteQuestionBar.test.ts
+++ b/web/src/components/__tests__/quoteQuestionBar.test.ts
@@ -14,6 +14,7 @@ const i18n = createI18n({
         chat: 'Chat',
         clear: 'Clear',
         placeholder: 'Ask...',
+        addToChat: 'Add to chat',
         send: 'Send',
         newSession: 'New Session',
         aiChat: 'AI Chat',
@@ -127,6 +128,7 @@ describe('QuoteQuestionBar component', () => {
         stubs: {
           MessageSquare: true,
           XCircle: true,
+          Plus: true,
           Send: true,
         },
       },
@@ -171,6 +173,30 @@ describe('QuoteQuestionBar component', () => {
     await vm.expand()
     // canSend is computed from inputText
     expect(vm.canSend).toBe(false)
+  })
+
+  it('allows adding the quote with empty text', async () => {
+    const wrapper = mountBar()
+    const vm = wrapper.vm as any
+    await vm.expand()
+
+    vm.handleAdd()
+
+    expect(wrapper.emitted('add')![0]).toEqual([''])
+    expect(vm.expanded).toBe(false)
+  })
+
+  it('emits entered text as the quote note when adding', async () => {
+    const wrapper = mountBar()
+    const vm = wrapper.vm as any
+    await vm.expand()
+    vm.inputText = 'note for this quote'
+    await nextTick()
+
+    vm.handleAdd()
+
+    expect(wrapper.emitted('add')![0]).toEqual(['note for this quote'])
+    expect(vm.inputText).toBe('')
   })
 
   it('send button is enabled when input has text', async () => {

--- a/web/src/components/chat/ChatInputBar.vue
+++ b/web/src/components/chat/ChatInputBar.vue
@@ -64,12 +64,12 @@
         </div>
       </Transition>
       <!-- Attachment tags (horizontal scrollable cards — quote + pending uploads + attached file refs) -->
-      <div v-if="quoteData || attachedFiles.length > 0 || pendingFiles.length > 0" class="chat-attachment-tags">
-        <!-- Quote selection card (same size as file cards, accent-colored) -->
-        <span v-if="quoteData" class="chat-file-attachment attachment-quote" :title="quoteData.filePath" @click="$emit('quote-click')">
+      <div v-if="quoteItems.length > 0 || attachedFiles.length > 0 || pendingFiles.length > 0" class="chat-attachment-tags">
+        <!-- Staged quote cards (same size as file cards, accent-colored) -->
+        <span v-for="(quote, quoteIndex) in quoteItems" :key="quote.id || quoteIndex" class="chat-file-attachment attachment-quote" :title="quote.note || quote.filePath" @click="$emit('quote-click', quote)">
           <Code2 :size="14" :stroke-width="1.5" class="attachment-quote-icon" />
-          <span class="attachment-filename">{{ quoteFileName }}{{ quoteLineRange }}</span>
-          <button class="attachment-close-btn" @click.stop="$emit('remove-quote')" :title="t('common.remove')">×</button>
+          <span class="attachment-filename">{{ quoteFileName(quote) }}{{ quoteLineRange(quote) }}</span>
+          <button class="attachment-close-btn" @click.stop="$emit('remove-quote', quote.id)" :title="t('common.remove')">×</button>
         </span>
         <!-- Attached file reference cards (shared component, includes pending uploads with local Blob preview) -->
         <AttachmentTags :files="attachedFiles" :pending-files="pendingFiles" @file-click="$emit('file-tag-click', $event)" @remove="handleRemoveAttached" @remove-pending="removeFile" />
@@ -407,6 +407,8 @@ const props = defineProps({
   currentFile: Object,
   currentDir: String,
   attachedFiles: Array,
+  quotes: { type: Array, default: () => [] },
+  // Backward-compatible single quote prop for isolated consumers/tests.
   quoteData: Object,
   messages: Array,
   autoSpeechEnabled: Boolean,
@@ -662,7 +664,11 @@ watch(() => props.currentSessionId, (newId, oldId) => {
   // autoResizeTextarea is called automatically by the inputText watcher
 })
 
-const hasInputContent = computed(() => inputText.value.trim() || props.attachedFiles.length > 0 || props.quoteData)
+const quoteItems = computed(() => props.quotes.length > 0
+  ? props.quotes
+  : props.quoteData ? [props.quoteData] : [])
+
+const hasInputContent = computed(() => inputText.value.trim() || props.attachedFiles.length > 0 || quoteItems.value.length > 0)
 
 // Extract recently referenced files from message history
 const recentReferencedFiles = computed(() => {
@@ -688,18 +694,18 @@ async function handleArchive() {
   }
 }
 
-const quoteFileName = computed(() => {
-  if (!props.quoteData?.filePath) return ''
-  return props.quoteData.filePath.split('/').pop() || props.quoteData.filePath
-})
+function quoteFileName(quote) {
+  if (!quote?.filePath) return ''
+  return quote.filePath.split('/').pop() || quote.filePath
+}
 
-const quoteLineRange = computed(() => {
-  if (!props.quoteData?.startLine) return ''
-  const s = props.quoteData.startLine
-  const e = props.quoteData.endLine
+function quoteLineRange(quote) {
+  if (!quote?.startLine) return ''
+  const s = quote.startLine
+  const e = quote.endLine
   if (e && e !== s) return `:${s}-${e}`
   return `:${s}`
-})
+}
 
 function autoResizeTextarea() {
   const el = textareaRef.value
@@ -969,7 +975,7 @@ async function toggleAttachMenu() {
 function handleSendClick() {
   if (inputText.value.trim()) {
     emit('send', inputText.value.trim())
-  } else if (props.attachedFiles.length > 0) {
+  } else if (props.attachedFiles.length > 0 || quoteItems.value.length > 0) {
     emit('send', '')
   } else {
     toggleQuickMenu()

--- a/web/src/components/chat/ChatMessageItem.vue
+++ b/web/src/components/chat/ChatMessageItem.vue
@@ -15,6 +15,7 @@
         :blockTasks="blockTasks"
         :blockAskQuestions="blockAskQuestions"
         :streaming="msg.streaming"
+        :startedAt="msg.createdAt"
         :cancelled="msg.cancelled"
         :summary="msg.summary"
         :summaryCards="msg.summaryCards"

--- a/web/src/components/chat/ChatPanelContent.vue
+++ b/web/src/components/chat/ChatPanelContent.vue
@@ -75,7 +75,7 @@
       :currentFile="currentFile"
       :currentDir="currentDir"
       :attachedFiles="attachedFiles"
-      :quoteData="quoteData"
+      :quotes="stagedQuotes"
       :messages="renderedMessages"
       :autoSpeechEnabled="autoSpeech.enabled.value"
       :currentSessionId="identity.currentSessionId.value"
@@ -92,7 +92,7 @@
       @add-attached="addAttachedFile"
       @remove-attached="removeAttachedFile"
       @remove-attached-by-path="removeAttachedFileByPath"
-      @remove-quote="setQuoteData(null); resetQuotePin()"
+      @remove-quote="removeStagedQuote($event)"
       @quote-click="handleQuoteClick"
       @open-session-tab="identity.openSessionTab"
       @open-session-search="$emit('open-session-search')"
@@ -184,7 +184,7 @@ import { useNotification } from '@/composables/useNotification.ts'
 import { applySummaryUpdate, shouldShowSummary } from '@/utils/chatSessionUtils.ts'
 import { useFileUpload } from '@/composables/useFileUpload.ts'
 import { useChatContext } from '@/composables/useChatContext.ts'
-import { buildQuoteMessage } from '@/utils/quoteQuestionUtils.ts'
+import { buildMultiQuoteMessage } from '@/utils/quoteQuestionUtils.ts'
 import { resetQuotePin } from '@/composables/useQuoteQuestion.ts'
 import { dedupeFiles } from '@/utils/fileAttachmentUtils.ts'
 import { enqueueAndMaybeStart } from '@/utils/chatQueueSend.ts'
@@ -262,8 +262,7 @@ async function handleFileTagClick(filePath) {
     }
 }
 
-function handleQuoteClick() {
-    const q = quoteData.value
+function handleQuoteClick(q) {
     if (q?.filePath) {
         store.selectFile(q.filePath).then(() => {
             switchTab('view')
@@ -456,7 +455,7 @@ const stream = useChatStream({
 })
 
 const { pendingFiles, attachedFiles, addAttachedFile, removeAttachedFile, cleanupPreviewUrls, clearPendingFiles } = useFileUpload()
-const { quoteData, setQuoteData, clearAll, removeAttachedFileByPath } = useChatContext()
+const { stagedQuotes, removeStagedQuote, clearAll, removeAttachedFileByPath } = useChatContext()
 
 const manager = useSessionManager({
   messages,
@@ -665,19 +664,16 @@ function persistSessionUpdate(fields) {
 async function sendMessage(text) {
     let inputText = text !== undefined ? text : (inputBarRef.value?.inputText?.trim() || '')
 
-    // Embed quote context into message body (wide-screen sends via ChatInputBar
-    // don't go through QuoteQuestionBar.sendMessage, so we must embed here).
-    if (quoteData.value) {
-      const q = quoteData.value
-      if (q.filePath) {
+    const quotes = [...stagedQuotes.value]
+    if (quotes.length > 0) {
+      for (const q of quotes) {
+        if (!q.filePath) continue
         addAttachedFile(q.filePath, false, q.startLine, q.endLine)
       }
-      // Always embed the quoted code block — even without typed text,
-      // the AI needs the code context from the quote.
-      inputText = buildQuoteMessage(inputText || '', q.text, q.filePath, q.language, q.startLine, q.endLine)
+      inputText = buildMultiQuoteMessage(inputText || '', quotes)
     }
 
-     const hasFiles = pendingFiles.value.length > 0 || attachedFiles.value.length > 0 || quoteData.value
+     const hasFiles = pendingFiles.value.length > 0 || attachedFiles.value.length > 0 || quotes.length > 0
 
      if ((!inputText && !hasFiles) || inputDisabled.value) return
 

--- a/web/src/components/chat/ContentBlocks.vue
+++ b/web/src/components/chat/ContentBlocks.vue
@@ -184,7 +184,10 @@
     </template>
     </template>
     <!-- Loading dots while AI is still streaming (not when cancelled, and not when showing summary) -->
-    <div v-if="streaming && !cancelled && !(showingSummary && summary)" class="placeholder-dots"><span></span><span></span><span></span></div>
+    <div v-if="streaming && !cancelled && !(showingSummary && summary)" class="streaming-status">
+      <div class="placeholder-dots"><span></span><span></span><span></span></div>
+      <span class="streaming-elapsed" role="timer">{{ elapsedLabel }}</span>
+    </div>
 
   </div>
 </template>
@@ -303,6 +306,7 @@ const props = defineProps({
   blockTasks: { type: Object, default: () => ({}) },
   blockAskQuestions: { type: Object, default: () => ({}) },
   streaming: { type: Boolean, default: false },
+  startedAt: { type: String, default: '' },
   cancelled: { type: Boolean, default: false },
   summary: { type: String, default: null },
   summaryCards: { type: Object, default: null },
@@ -322,6 +326,43 @@ const props = defineProps({
 })
 
 const emit = defineEmits(['toggle-tool', 'show-tool-detail', 'task-card-click', 'send-message', 'render-flush', 'resume-session'])
+
+const elapsedSeconds = ref(0)
+let elapsedTimer = null
+let fallbackStartedAt = Date.now()
+
+function updateElapsed() {
+  const parsedStartedAt = Date.parse(props.startedAt)
+  const startedAt = Number.isFinite(parsedStartedAt) ? parsedStartedAt : fallbackStartedAt
+  elapsedSeconds.value = Math.max(0, Math.floor((Date.now() - startedAt) / 1000))
+}
+
+function stopElapsedTimer() {
+  if (elapsedTimer) {
+    clearInterval(elapsedTimer)
+    elapsedTimer = null
+  }
+}
+
+watch([() => props.streaming, () => props.startedAt], ([streaming]) => {
+  stopElapsedTimer()
+  if (!streaming) return
+  fallbackStartedAt = Date.now()
+  updateElapsed()
+  elapsedTimer = setInterval(updateElapsed, 1000)
+}, { immediate: true })
+
+const elapsedLabel = computed(() => {
+  if (elapsedSeconds.value < 60) return `${elapsedSeconds.value}s`
+  const minutes = Math.floor(elapsedSeconds.value / 60)
+  const seconds = String(elapsedSeconds.value % 60).padStart(2, '0')
+  if (minutes >= 60) {
+    const hours = Math.floor(minutes / 60)
+    const remainingMinutes = String(minutes % 60).padStart(2, '0')
+    return `${hours}h ${remainingMinutes}m ${seconds}s`
+  }
+  return `${minutes}m ${seconds}s`
+})
 
 // Key helper: use msgId if available, otherwise msgIndex
 function key(bi) {
@@ -723,6 +764,7 @@ watch(() => props.active, (active) => {
 })
 
 onUnmounted(() => {
+  stopElapsedTimer()
   if (_throttleTimer) { clearTimeout(_throttleTimer); _throttleTimer = null }
   _collapseTimers.forEach(t => clearTimeout(t))
   _collapseTimers = []
@@ -730,6 +772,19 @@ onUnmounted(() => {
 </script>
 
 <style scoped>
+.streaming-status {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.streaming-elapsed {
+  color: var(--text-muted, #999);
+  font-size: 11px;
+  font-variant-numeric: tabular-nums;
+  line-height: 1;
+}
+
 .placeholder-dots {
   display: flex;
   gap: 4px;

--- a/web/src/components/chat/__tests__/ContentBlocks.test.ts
+++ b/web/src/components/chat/__tests__/ContentBlocks.test.ts
@@ -96,9 +96,10 @@ const i18n = createI18n({
 })
 
 const LucideStub = { template: '<span class="lucide-stub" />' }
+const mountedWrappers: ReturnType<typeof mount>[] = []
 
 function mountBlocks(props: Record<string, unknown> = {}) {
-  return mount(ContentBlocks, {
+  const wrapper = mount(ContentBlocks, {
     props: {
       blocks: [],
       msgId: 'msg-1',
@@ -123,7 +124,15 @@ function mountBlocks(props: Record<string, unknown> = {}) {
       },
     },
   })
+  mountedWrappers.push(wrapper)
+  return wrapper
 }
+
+afterEach(() => {
+  for (const wrapper of mountedWrappers.splice(0)) {
+    if (wrapper.exists()) wrapper.unmount()
+  }
+})
 
 describe('ContentBlocks', () => {
   // ── Text blocks ──
@@ -336,6 +345,35 @@ describe('ContentBlocks', () => {
         cancelled: false,
       })
       expect(wrapper.find('.placeholder-dots').exists()).toBe(true)
+    })
+
+    it('shows elapsed streaming time and updates it from the message start time', async () => {
+      vi.useFakeTimers()
+      vi.setSystemTime(new Date('2026-08-10T12:00:00.000Z'))
+      const wrapper = mountBlocks({
+        blocks: [],
+        streaming: true,
+        cancelled: false,
+        startedAt: '2026-08-10T11:59:58.000Z',
+      })
+
+      try {
+        expect(wrapper.find('.streaming-elapsed').text()).toBe('2s')
+
+        vi.advanceTimersByTime(63_000)
+        await nextTick()
+        expect(wrapper.find('.streaming-elapsed').text()).toBe('1m 05s')
+
+        vi.advanceTimersByTime(3_596_000)
+        await nextTick()
+        expect(wrapper.find('.streaming-elapsed').text()).toBe('1h 01m 01s')
+
+        await wrapper.setProps({ streaming: false })
+        expect(wrapper.find('.streaming-elapsed').exists()).toBe(false)
+      } finally {
+        wrapper.unmount()
+        vi.useRealTimers()
+      }
     })
 
     it('hides placeholder dots when not streaming', () => {

--- a/web/src/components/common/QuoteQuestionBar.vue
+++ b/web/src/components/common/QuoteQuestionBar.vue
@@ -36,6 +36,9 @@
               @keydown.enter.exact.prevent="handleSend"
               @input="autoResizeTextarea"
             />
+            <button class="qq-add-btn" @click="handleAdd" :title="t('quoteBar.addToChat')" :aria-label="t('quoteBar.addToChat')">
+              <Plus :size="14" />
+            </button>
             <button class="qq-send-btn" :class="{ disabled: !canSend }" @click="handleSend" :title="t('quoteBar.send')">
               <Send :size="14" />
             </button>
@@ -48,7 +51,7 @@
 </template>
 
 <script setup>
-import { MessageSquare, XCircle, Send } from 'lucide-vue-next'
+import { MessageSquare, XCircle, Plus, Send } from 'lucide-vue-next'
 import { ref, computed, watch, onMounted, onUnmounted, nextTick } from 'vue'
 import { useI18n } from 'vue-i18n'
 import { truncateQuoteText, canSendInput } from '@/utils/quoteQuestionUtils'
@@ -59,7 +62,7 @@ const props = defineProps({
   visible: Boolean,
   quoteData: Object,
 })
-const emit = defineEmits(['send', 'close', 'pin', 'unpin'])
+const emit = defineEmits(['add', 'send', 'close', 'pin', 'unpin'])
 
 const expanded = ref(false)
 const inputText = ref('')
@@ -127,6 +130,12 @@ watch(inputText, () => nextTick(() => autoResizeTextarea()))
 function handleSend() {
   if (!canSend.value) return
   emit('send', inputText.value)
+  expanded.value = false
+  inputText.value = ''
+}
+
+function handleAdd() {
+  emit('add', inputText.value)
   expanded.value = false
   inputText.value = ''
 }
@@ -304,6 +313,7 @@ defineExpose({ expanded, expand, inputText })
   background: color-mix(in srgb, var(--danger-color) 8%, transparent);
 }
 
+.qq-add-btn,
 .qq-send-btn {
   display: flex;
   align-items: center;
@@ -318,6 +328,16 @@ defineExpose({ expanded, expand, inputText })
   cursor: pointer;
   transition: background 0.15s, opacity 0.15s;
   flex-shrink: 0;
+}
+
+.qq-add-btn {
+  background: transparent;
+  color: var(--accent-color);
+  border: 1px solid color-mix(in srgb, var(--accent-color) 45%, var(--border-color));
+}
+
+.qq-add-btn:hover {
+  background: color-mix(in srgb, var(--accent-color) 10%, transparent);
 }
 
 .qq-send-btn:hover {

--- a/web/src/composables/__tests__/useChatContext.test.ts
+++ b/web/src/composables/__tests__/useChatContext.test.ts
@@ -121,6 +121,49 @@ describe('useChatContext', () => {
     })
   })
 
+  describe('stagedQuotes', () => {
+    const first = { text: 'const a = 1', filePath: '/a.ts', language: 'ts', startLine: 1, endLine: 1 }
+
+    it('keeps ordered selections with optional notes', () => {
+      ctx.addStagedQuote(first, 'first note')
+      ctx.addStagedQuote({ ...first, text: 'const b = 2', startLine: 2, endLine: 2 })
+
+      expect(ctx.stagedQuotes.value.map(item => ({ text: item.text, note: item.note }))).toEqual([
+        { text: 'const a = 1', note: 'first note' },
+        { text: 'const b = 2', note: '' },
+      ])
+    })
+
+    it('deduplicates an identical selection and updates a non-empty note', () => {
+      const original = ctx.addStagedQuote(first, 'old note')
+      const duplicate = ctx.addStagedQuote({ ...first }, 'new note')
+
+      expect(ctx.stagedQuotes.value).toHaveLength(1)
+      expect(duplicate.id).toBe(original.id)
+      expect(ctx.stagedQuotes.value[0].note).toBe('new note')
+    })
+
+    it('does not erase an existing note when duplicate note is empty', () => {
+      ctx.addStagedQuote(first, 'keep me')
+      ctx.addStagedQuote({ ...first }, '   ')
+      expect(ctx.stagedQuotes.value[0].note).toBe('keep me')
+    })
+
+    it('keeps partially overlapping ranges as separate selections', () => {
+      ctx.addStagedQuote({ ...first, startLine: 1, endLine: 5 })
+      ctx.addStagedQuote({ ...first, text: 'overlap', startLine: 4, endLine: 8 })
+      expect(ctx.stagedQuotes.value).toHaveLength(2)
+    })
+
+    it('removes one staged quote by id without affecting the others', () => {
+      const firstItem = ctx.addStagedQuote(first)
+      const secondItem = ctx.addStagedQuote({ ...first, text: 'second', startLine: 2, endLine: 2 })
+      ctx.removeStagedQuote(firstItem.id)
+
+      expect(ctx.stagedQuotes.value.map(item => item.id)).toEqual([secondItem.id])
+    })
+  })
+
   describe('clearAll', () => {
     it('clears both attachedFiles and quoteData', () => {
       ctx.addAttachedFile('/a.txt')
@@ -131,6 +174,7 @@ describe('useChatContext', () => {
 
       expect(ctx.attachedFiles.value).toHaveLength(0)
       expect(ctx.quoteData.value).toBeNull()
+      expect(ctx.stagedQuotes.value).toHaveLength(0)
     })
   })
 

--- a/web/src/composables/__tests__/useQuoteQuestion.test.ts
+++ b/web/src/composables/__tests__/useQuoteQuestion.test.ts
@@ -289,6 +289,60 @@ describe('useQuoteQuestion', () => {
         expect.objectContaining({ type: 'error' }),
       )
     })
+
+    it('sends staged quotes with notes together with the active selection', async () => {
+      const qq = useQuoteQuestion()
+      mockSendMessage.mockResolvedValue(undefined)
+      ctx.addStagedQuote(
+        { text: 'first()', filePath: '/first.ts', language: 'ts', startLine: 1, endLine: 2 },
+        'Review this first',
+      )
+      ctx.setQuoteData({ text: 'second()', filePath: '/second.ts', language: 'ts', startLine: 8, endLine: 8 })
+
+      await qq.sendMessage('Compare them')
+
+      expect(mockSendMessage).toHaveBeenCalledWith(
+        'Compare them\n\nReview this first\n\n```ts:/first.ts:1-2\nfirst()\n```\n\n```ts:/second.ts:8\nsecond()\n```',
+      )
+      expect(ctx.stagedQuotes.value).toHaveLength(0)
+    })
+
+    it('deduplicates the active selection against staged quotes', async () => {
+      const qq = useQuoteQuestion()
+      mockSendMessage.mockResolvedValue(undefined)
+      const quote = { text: 'same()', filePath: '/same.ts', language: 'ts', startLine: 4, endLine: 4 }
+      ctx.addStagedQuote(quote, 'Keep this note')
+      ctx.setQuoteData({ ...quote })
+
+      await qq.sendMessage('Explain')
+
+      expect(mockSendMessage).toHaveBeenCalledWith(
+        'Explain\n\nKeep this note\n\n```ts:/same.ts:4\nsame()\n```',
+      )
+    })
+  })
+
+  describe('addToConversation', () => {
+    it('stages an active quote without requiring text', () => {
+      const qq = useQuoteQuestion()
+      ctx.setQuoteData({ text: 'selected', filePath: '/a.ts', language: 'ts', startLine: 3, endLine: 4 })
+
+      qq.addToConversation('')
+
+      expect(ctx.stagedQuotes.value).toHaveLength(1)
+      expect(ctx.stagedQuotes.value[0].note).toBe('')
+      expect(ctx.quoteData.value).toBeNull()
+      expect(qq.visible.value).toBe(false)
+    })
+
+    it('stores entered text as the staged quote note', () => {
+      const qq = useQuoteQuestion()
+      ctx.setQuoteData({ text: 'selected', filePath: '/a.ts', language: 'ts', startLine: 3, endLine: 4 })
+
+      qq.addToConversation('  Why is this needed?  ')
+
+      expect(ctx.stagedQuotes.value[0].note).toBe('Why is this needed?')
+    })
   })
 
   describe('selectionchange listener', () => {

--- a/web/src/composables/useChatContext.ts
+++ b/web/src/composables/useChatContext.ts
@@ -9,6 +9,11 @@ export interface QuoteData {
   endLine: number
 }
 
+export interface StagedQuote extends QuoteData {
+  id: string
+  note: string
+}
+
 // ───────────────────────────────────────────────────────────
 // Module-level singleton state — shared across the whole app.
 // useChatContext unifies "context sent to chat" from any tab:
@@ -18,6 +23,8 @@ export interface QuoteData {
 
 const attachedFiles = ref<FileEntry[]>([])
 const quoteData = ref<QuoteData | null>(null)
+const stagedQuotes = ref<StagedQuote[]>([])
+let quoteId = 0
 
 function addAttachedFile(path: string, isDir: boolean = false, startLine?: number, endLine?: number) {
   if (!path) return
@@ -60,21 +67,59 @@ function setQuoteData(data: QuoteData | null) {
   quoteData.value = data
 }
 
+function sameQuote(a: QuoteData, b: QuoteData): boolean {
+  return a.filePath === b.filePath
+    && a.startLine === b.startLine
+    && a.endLine === b.endLine
+    && a.text === b.text
+}
+
+function addStagedQuote(data: QuoteData, note = ''): StagedQuote {
+  const normalizedNote = note.trim()
+  const existing = stagedQuotes.value.find(item => sameQuote(item, data))
+  if (existing) {
+    if (normalizedNote) existing.note = normalizedNote
+    return existing
+  }
+
+  const item: StagedQuote = {
+    ...data,
+    id: `quote-${Date.now()}-${++quoteId}`,
+    note: normalizedNote,
+  }
+  stagedQuotes.value.push(item)
+  return item
+}
+
+function removeStagedQuote(id: string) {
+  const index = stagedQuotes.value.findIndex(item => item.id === id)
+  if (index >= 0) stagedQuotes.value.splice(index, 1)
+}
+
+function clearQuotes() {
+  quoteData.value = null
+  stagedQuotes.value = []
+}
+
 function clearAll() {
   attachedFiles.value = []
-  quoteData.value = null
+  clearQuotes()
 }
 
 export function useChatContext() {
   return {
     attachedFiles,
     quoteData,
+    stagedQuotes,
     addAttachedFile,
     removeAttachedFile,
     removeAttachedFileByPath,
     toggleAttachedFile,
     hasAttachedFile,
     setQuoteData,
+    addStagedQuote,
+    removeStagedQuote,
+    clearQuotes,
     clearAll,
   }
 }

--- a/web/src/composables/useQuoteQuestion.ts
+++ b/web/src/composables/useQuoteQuestion.ts
@@ -2,16 +2,22 @@ import { ref, onMounted, onUnmounted } from 'vue'
 import { useSessionIdentity } from '@/composables/useSessionIdentity.ts'
 import { useToast } from '@/composables/useToast.ts'
 import { gt } from '@/composables/useLocale'
-import { closestElement, getLineInfo, getFileInfo, buildQuoteMessage } from '@/utils/quoteQuestionUtils.ts'
+import { closestElement, getLineInfo, getFileInfo, buildMultiQuoteMessage } from '@/utils/quoteQuestionUtils.ts'
 import { useChatContext } from '@/composables/useChatContext.ts'
 import type { QuoteData } from '@/composables/useChatContext.ts'
-import { useWideScreenLayout } from '@/composables/useWideScreenLayout.ts'
 
 // Module-level singleton: bar visibility state shared across all consumers.
-// quoteData is stored in useChatContext (global singleton) so ChatInputBar
-// can render a quote chip in any tab.
-const { quoteData, setQuoteData, addAttachedFile, clearAll } = useChatContext()
-const { isWideScreen } = useWideScreenLayout()
+// The active selection stays separate from staged quotes so dismissing a
+// selection never discards snippets the user already added to the chat draft.
+const {
+  quoteData,
+  stagedQuotes,
+  setQuoteData,
+  addStagedQuote,
+  addAttachedFile,
+  clearQuotes,
+  clearAll,
+} = useChatContext()
 const barVisible = ref(false)
 const barPinned = ref(false)  // When pinned, selection loss won't auto-hide the bar
 const sheetOpen = ref(false)
@@ -23,18 +29,7 @@ function onSelectionChange() {
   debounceTimer = setTimeout(() => {
     const sel = window.getSelection()
     if (!sel || sel.isCollapsed || !sel.toString().trim()) {
-      // Wide-screen mode: auto-pin so the ChatInputBar quote tag survives
-      // focus switches (e.g. clicking the input textarea clears selection).
-      // There is no QuoteQuestionBar in wide-screen, so the quote tag in
-      // ChatInputBar is the only UI surface — losing it would be confusing.
-      if (isWideScreen.value && quoteData.value) {
-        barPinned.value = true
-        barVisible.value = false
-        return
-      }
-      // Narrow mode: when the selection is gone, drop the quote — unless the
-      // user explicitly pinned it via "引用提问". A stale quote chip must not
-      // linger in the chat input after the user deselects the text.
+      // Drop only the active selection. Staged quotes remain in the chat draft.
       if (!barPinned.value) {
         barVisible.value = false
         setQuoteData(null)
@@ -70,10 +65,6 @@ function onSelectionChange() {
 
     setQuoteData({ text, filePath, language, startLine, endLine })
     barVisible.value = true
-    // Wide-screen: auto-pin so the quote tag persists when user focuses input
-    if (isWideScreen.value) {
-      barPinned.value = true
-    }
   }, 150)
 }
 
@@ -83,13 +74,6 @@ let listenerCount = 0
 /** Reset the bar pinned state (for use when quoteData is cleared externally). */
 export function resetQuotePin() {
   barPinned.value = false
-}
-
-/** Restore bar visibility when transitioning from wide-screen to narrow. */
-export function restoreBarVisibility() {
-  if (quoteData.value && barPinned.value) {
-    barVisible.value = true
-  }
 }
 
 export function useQuoteQuestion() {
@@ -111,7 +95,6 @@ export function useQuoteQuestion() {
   })
 
   function closeSheet() {
-    // Clear selection when closing
     const sel = window.getSelection()
     if (sel) sel.removeAllRanges()
     barVisible.value = false
@@ -148,26 +131,36 @@ export function useQuoteQuestion() {
     setTimeout(() => {
       setQuoteData(data)
       barVisible.value = true
-      if (isWideScreen.value) {
-        barPinned.value = true
-      }
     }, opts.delay ?? 400)
+  }
+
+  function addToConversation(note = '') {
+    if (!quoteData.value) return
+    addStagedQuote(quoteData.value, note)
+    const sel = window.getSelection()
+    if (sel) sel.removeAllRanges()
+    setQuoteData(null)
+    barVisible.value = false
+    barPinned.value = false
+    toast.show(gt('quoteBar.addedToChat'), { icon: '📎', type: 'success', duration: 1500 })
   }
 
   async function sendMessage(userMessage: string) {
     if (!quoteData.value || !userMessage.trim()) return
 
     const q = quoteData.value
+    // Reuse the staging dedupe rule so reselecting an already staged range
+    // does not include the same quote twice in an immediate send.
+    addStagedQuote(q)
+    const quotes = [...stagedQuotes.value]
 
-    // Add the quoted file (with line info) as an attached file — unified channel.
-    // addAttachedFile handles dedup: if file already attached without line info,
-    // it upgrades the entry with startLine/endLine.
-    if (q.filePath) {
-      addAttachedFile(q.filePath, false, q.startLine, q.endLine)
+    for (const quote of quotes) {
+      if (quote.filePath) {
+        addAttachedFile(quote.filePath, false, quote.startLine, quote.endLine)
+      }
     }
 
-    // Embed quoted code text in the message body as context for the AI
-    const message = buildQuoteMessage(userMessage, q.text, q.filePath, q.language, q.startLine, q.endLine)
+    const message = buildMultiQuoteMessage(userMessage, quotes)
 
     // Capture animation coordinates BEFORE any await — the bar's handleSend()
     // sets expanded=false synchronously right after emit('send'), so the
@@ -177,16 +170,21 @@ export function useQuoteQuestion() {
     const animFrom = sendBtn?.getBoundingClientRect() ?? null
     const animTo = dockChatBtn?.getBoundingClientRect() ?? null
 
-    // Clear quoteData BEFORE sending — ChatPanelContent.sendMessage also checks
-    // quoteData and would double-embed the quote if it's still set.
-    clearAll()
+    // Keep attached files long enough for ChatPanelContent to capture them, but
+    // clear quotes before delegating so they are not embedded a second time.
+    clearQuotes()
     barVisible.value = false
     barPinned.value = false
 
     // Delegate to session identity singleton — it routes to ChatPanel's
     // sendMessage if registered, otherwise falls back to a direct API call.
     try {
-      await sessionIdentity.sendMessage(message)
+      const sendPromise = sessionIdentity.sendMessage(message)
+      // The registered ChatPanel handler captures files synchronously before its
+      // first await. Clear this batch now so a later response cannot wipe the
+      // next set of quotes the user starts collecting while the request runs.
+      clearAll()
+      await sendPromise
       toast.show(gt('quoteBar.sentToSession'), { icon: '✅', type: 'success', duration: 2000 })
       // Dispatch animation event with pre-captured coordinates
       if (animFrom && animTo) {
@@ -212,6 +210,7 @@ export function useQuoteQuestion() {
     unpinBar,
     showBar,
     hideBar,
+    addToConversation,
     sendMessage,
   }
 }

--- a/web/src/i18n/locales/en.ts
+++ b/web/src/i18n/locales/en.ts
@@ -946,6 +946,8 @@ export default {
     chat: 'Chat',
     clear: 'Clear',
     placeholder: 'Type your question...',
+    addToChat: 'Add to chat',
+    addedToChat: 'Added to chat',
     send: 'Send',
     aiChat: 'AI Chat',
     newSession: 'New session',

--- a/web/src/i18n/locales/zh.ts
+++ b/web/src/i18n/locales/zh.ts
@@ -947,6 +947,8 @@ export default {
     chat: '对话',
     clear: '清空',
     placeholder: '输入你的问题...',
+    addToChat: '加入对话',
+    addedToChat: '已加入对话',
     send: '发送',
     aiChat: 'AI 对话',
     newSession: '新会话',

--- a/web/src/utils/__tests__/quoteQuestionUtils.test.ts
+++ b/web/src/utils/__tests__/quoteQuestionUtils.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest'
-import { closestElement, getFileInfo, getLineInfo, buildQuoteMessage } from '@/utils/quoteQuestionUtils'
+import { closestElement, getFileInfo, getLineInfo, buildQuoteMessage, buildMultiQuoteMessage } from '@/utils/quoteQuestionUtils'
 
 // --- closestElement ---
 
@@ -323,5 +323,33 @@ describe('buildQuoteMessage', () => {
   it('embeds quoted code with language but no line numbers', () => {
     const result = buildQuoteMessage('explain', 'some code', '/main.go', 'go', 0, 0)
     expect(result).toBe('explain\n\n```go:/main.go\nsome code\n```')
+  })
+})
+
+describe('buildMultiQuoteMessage', () => {
+  const quotes = [
+    { text: 'const a = 1', filePath: '/a.ts', language: 'ts', startLine: 1, endLine: 1, note: 'Check initialization' },
+    { text: 'return a', filePath: '/b.ts', language: 'ts', startLine: 8, endLine: 9, note: '' },
+  ]
+
+  it('places the overall question first and each note before its quote', () => {
+    expect(buildMultiQuoteMessage('Compare these', quotes)).toBe(
+      'Compare these\n\nCheck initialization\n\n```ts:/a.ts:1\nconst a = 1\n```\n\n```ts:/b.ts:8-9\nreturn a\n```',
+    )
+  })
+
+  it('allows quotes to be sent without an overall question', () => {
+    expect(buildMultiQuoteMessage('', [quotes[1]])).toBe('```ts:/b.ts:8-9\nreturn a\n```')
+  })
+
+  it('preserves quote order across selections from the same file', () => {
+    const sameFile = [
+      { ...quotes[0], note: '', startLine: 10, endLine: 12, text: 'first' },
+      { ...quotes[0], note: '', startLine: 30, endLine: 31, text: 'second' },
+    ]
+    const result = buildMultiQuoteMessage('', sameFile)
+    expect(result.indexOf('first')).toBeLessThan(result.indexOf('second'))
+    expect(result).toContain('```ts:/a.ts:10-12')
+    expect(result).toContain('```ts:/a.ts:30-31')
   })
 })

--- a/web/src/utils/quoteQuestionUtils.ts
+++ b/web/src/utils/quoteQuestionUtils.ts
@@ -91,3 +91,38 @@ export function buildQuoteMessage(
   }
   return `${userMessage.trim()}\n\n\`\`\`${langPrefix}${filePath}${lineSuffix}\n${text}\n\`\`\``
 }
+
+export interface QuoteMessageItem {
+  text: string
+  filePath: string
+  language: string
+  startLine: number
+  endLine: number
+  note?: string
+}
+
+function buildQuoteBlock(quote: QuoteMessageItem): string {
+  const langPrefix = quote.language ? `${quote.language}:` : ':'
+  let lineSuffix = ''
+  if (quote.startLine && quote.endLine && quote.startLine !== quote.endLine) {
+    lineSuffix = `:${quote.startLine}-${quote.endLine}`
+  } else if (quote.startLine) {
+    lineSuffix = `:${quote.startLine}`
+  }
+  return `\`\`\`${langPrefix}${quote.filePath}${lineSuffix}\n${quote.text}\n\`\`\``
+}
+
+/** Build one prompt from an optional overall question and ordered quoted selections. */
+export function buildMultiQuoteMessage(userMessage: string, quotes: QuoteMessageItem[]): string {
+  const parts: string[] = []
+  const prompt = userMessage.trim()
+  if (prompt) parts.push(prompt)
+
+  for (const quote of quotes) {
+    const note = quote.note?.trim()
+    if (note) parts.push(note)
+    parts.push(buildQuoteBlock(quote))
+  }
+
+  return parts.join('\n\n')
+}


### PR DESCRIPTION
## 变更概述

本 PR 改进聊天流式响应的状态反馈，并统一桌面与移动端的代码/文本引用提问流程。分支基于 `upstream/main` 创建，仅包含以下两条独立提交：

1. `feat(chat): show elapsed time while AI responds`
2. `feat(chat): 支持多段引用暂存与统一提问`

不包含 `fix(build): resolve Android JDK across platforms`。

## 流式响应计时

- 在 AI 仍在输出时，于加载动画旁显示已耗时。
- 优先使用消息 `createdAt` 作为起点；时间戳不可解析时回退到组件开始流式渲染的时刻。
- 按秒刷新，并格式化为 `Xs`、`Xm XXs` 或 `Xh XXm XXs`。
- 流式输出结束或组件卸载时清理定时器，避免后台更新与资源泄漏。

## 多段引用与统一提问

- 宽屏与窄屏统一使用引用浮动框，选择内容后可直接输入问题发送，也可将当前引用加入聊天草稿后继续选择。
- 支持按照添加顺序暂存多段引用；每段引用可关联备注，主输入框显示已暂存引用并支持定位和移除。
- 发送时将所有暂存片段合并为单条上下文消息，并为有文件路径的片段附加对应文件及行号。
- 以文件路径、起止行号和文本内容识别相同引用；重复添加不会产生重复上下文，新的备注会更新已有条目。
- 点击关闭、切换会话或发送完成后会清理恰当的引用状态，避免上一轮选区泄漏到后续输入；发送过程中保留附件直至聊天面板同步捕获。

## 测试

已执行以下相关前端测试：

```text
npm test -- --run 
  web/src/components/chat/__tests__/ContentBlocks.test.ts 
  web/src/components/__tests__/chatInputBar.test.ts 
  web/src/components/__tests__/quoteQuestionBar.test.ts 
  web/src/composables/__tests__/useChatContext.test.ts 
  web/src/composables/__tests__/useQuoteQuestion.test.ts 
  web/src/utils/__tests__/quoteQuestionUtils.test.ts
```

结果：6 个测试文件、213 项断言全部通过。测试运行会输出已有的 Vue 生命周期及 Vitest Promise leak 提示，但不影响测试结果。