### PR TITLE
fix(task): show streaming status when viewing running execution detail

### DIFF
--- a/web/src/components/task/TaskExecDetail.vue
+++ b/web/src/components/task/TaskExecDetail.vue
@@ -8,7 +8,7 @@
     <!-- Scrollable message content -->
     <div class="exec-detail-content" ref="contentRef" @click="handleContentClick" @mousedown="onTableMouseDown" @touchstart="onTableTouchStart">
       <!-- Summary / Original tab bar (hidden during live streaming) -->
-      <SummaryToggle v-if="hasSummary && !execStream.isStreaming.value" mode="tab" :showing-summary="activeTab === 'summary'" i18n-prefix="task.exec" @toggle="setTab(activeTab === 'summary' ? 'original' : 'summary')" />
+      <SummaryToggle v-if="hasSummary && !execStream.isStreaming.value && !isRunning" mode="tab" :showing-summary="activeTab === 'summary'" i18n-prefix="task.exec" @toggle="setTab(activeTab === 'summary' ? 'original' : 'summary')" />
       <ChatMessageItem
         v-if="activeMsgData"
         :msg="activeMsgData"
@@ -226,7 +226,10 @@ const msgData = computed(() => {
     blocks,
     metadata: props.execDetail.metadata || null,
     createdAt: props.execDetail.createdAt || '',
-    streaming: false,
+    // While the execution is still running, always mark the message as
+    // streaming so the "streaming status" indicator is shown. Otherwise a
+    // running task's partial DB content renders like a completed answer.
+    streaming: isRunning.value,
     cancelled: false,
   }
 })
@@ -280,7 +283,9 @@ const activeMsgData = computed(() => {
   }
   // When not streaming, use the DB content (refreshed by refreshExecDetail)
   // we always show whatever partial content is available rather than "connecting..."
-  if (activeTab.value === 'summary' && summaryMsgData.value) return summaryMsgData.value
+  // During a running execution a summary isn't final yet, so never present it
+  // as a completed answer.
+  if (activeTab.value === 'summary' && summaryMsgData.value && !isRunning.value) return summaryMsgData.value
   return msgData.value
 })
 

--- a/web/src/components/task/__tests__/TaskExecDetail.streaming.test.ts
+++ b/web/src/components/task/__tests__/TaskExecDetail.streaming.test.ts
@@ -1,0 +1,59 @@
+import { describe, expect, it } from 'vitest'
+
+/**
+ * Tests for the msgData streaming-flag logic in TaskExecDetail.vue.
+ *
+ * A running task execution must render with the "streaming status" indicator,
+ * NOT as a completed answer. The DB content is only partial while running, but
+ * it should still look like an in-progress generation.
+ */
+
+interface MsgDataInput {
+  content: string
+  status: string
+}
+
+interface MsgData {
+  streaming: boolean
+  cancelled: boolean
+  blocks: Array<Record<string, unknown>>
+}
+
+/**
+ * Pure-function equivalent of TaskExecDetail.vue's msgData computed,
+ * capturing the streaming-flag decision for a non-empty-content message.
+ */
+function buildMsgData(input: MsgDataInput, blocks: Array<Record<string, unknown>>): MsgData {
+  const isRunning = input.status === 'running'
+  return {
+    blocks,
+    streaming: isRunning,
+    cancelled: false,
+  }
+}
+
+describe('TaskExecDetail msgData streaming flag', () => {
+  it('marks a running execution as streaming so the status indicator shows', () => {
+    const msg = buildMsgData(
+      { content: '{"blocks":[{"type":"text","text":"partial"}]}', status: 'running' },
+      [{ type: 'text', text: 'partial' }],
+    )
+    expect(msg.streaming).toBe(true)
+  })
+
+  it('does NOT mark a completed execution as streaming', () => {
+    const msg = buildMsgData(
+      { content: '{"blocks":[{"type":"text","text":"final"}]}', status: 'completed' },
+      [{ type: 'text', text: 'final' }],
+    )
+    expect(msg.streaming).toBe(false)
+  })
+
+  it('marks a failed execution as not streaming', () => {
+    const msg = buildMsgData(
+      { content: '{"blocks":[]}', status: 'failed' },
+      [],
+    )
+    expect(msg.streaming).toBe(false)
+  })
+})


### PR DESCRIPTION
显示正在运行的任务执行详情时展示流式状态。

Changes:
- TaskExecDetail.vue: show streaming status indicator
- Test: TaskExecDetail.streaming.test.ts