### PR TITLE
fix: ACP 会话恢复重试与新会话回退 + 终端键盘高度复位

### DIFF
--- a/internal/ai/acp_backend.go
+++ b/internal/ai/acp_backend.go
@@ -60,6 +60,35 @@ func (b *ACPBackend) ExecuteStream(ctx context.Context, req ChatRequest) (<-chan
 		conn, isNew, err := mgr.GetOrCreateConn(ctx, b.agent, req.SessionID, req.WorkDir)
 		slog.Info("acp: GetOrCreateConn done", "session_id", req.SessionID, "agent_id", b.agent.ID, "is_new", isNew, "elapsed", time.Since(connStart), "error", err)
 		if err != nil {
+			// The agent process may have just been killed (e.g. OOM/LMK), or a
+			// stale-alive race caused LoadSession to hit a dead connection.
+			// Retry once — a fresh respawn + LoadSession/ResumeSession usually
+			// restores the session, so we don't fail the user's turn on a
+			// transient disconnect.
+			if isACPPeerDisconnected(err) {
+				slog.Warn("acp: connection lost, retrying GetOrCreateConn once",
+					"session_id", req.SessionID, "agent_id", b.agent.ID, "error", err)
+				conn, isNew, err = mgr.GetOrCreateConn(ctx, b.agent, req.SessionID, req.WorkDir)
+			}
+			if err != nil && isACPPeerDisconnected(err) && shouldNewSessionFallback(req.AssistantMessageCount) {
+				// Session cannot be restored (process keeps dying / load keeps
+				// failing). Only fall back to a brand-new session when no
+				// conversation has happened yet (AssistantMessageCount==0) —
+				// rebuilding a session that already has history would lose it.
+				// In that case the error below is surfaced and the user retries,
+				// preserving the original session mapping.
+				slog.Error("acp: session recovery failed, starting new session",
+					"session_id", req.SessionID, "agent_id", b.agent.ID, "error", err)
+				if fb := mgr.NewSessionFallback(ctx, b.agent, req.SessionID, req.WorkDir); fb != nil {
+					conn, isNew, err = fb, true, nil
+					forwardACPEvent(ch, StreamEvent{
+						Type:    "warning",
+						Content: "ACP 会话无法恢复，已开启新会话（原有对话上下文已丢失）。", Reason: ReasonBackendExit,
+					})
+				}
+			}
+		}
+		if err != nil {
 			// ACP connection failed — surface the error directly.
 			// Do NOT fall back to CLI backend: the user chose ACP transport
 			// and silent fallback hides real problems (e.g., NewSession timeout).
@@ -210,6 +239,16 @@ func (b *ACPBackend) emitSessionAndCacheState(conn *ACPConn, isNew bool, ch chan
 	if planState := conn.GetCachedPlanState(); planState != nil {
 		forwardACPEvent(ch, StreamEvent{Type: "plan_update", Plan: planState})
 	}
+}
+
+// shouldNewSessionFallback reports whether a failed session recovery should
+// fall back to a brand-new session. We only do so when NO conversation has
+// happened yet (AssistantMessageCount == 0). If the session already has
+// assistant history, rebuilding it with a fresh ACP session would drop the
+// agent's memory of the prior conversation — so instead we surface the error
+// and let the user retry, preserving the original session mapping.
+func shouldNewSessionFallback(assistantMessageCount int) bool {
+	return assistantMessageCount == 0
 }
 
 // acpErrorText formats an ACP error for the UI warning banner, preserving both

--- a/internal/ai/acp_backend_test.go
+++ b/internal/ai/acp_backend_test.go
@@ -1,0 +1,22 @@
+package ai
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+// TestShouldNewSessionFallback verifies the rule that a failed session recovery
+// only falls back to a brand-new session when NO conversation has happened yet.
+// If the session already has assistant history, rebuilding would lose it, so we
+// must NOT fall back — the user retries to preserve the original session mapping.
+func TestShouldNewSessionFallback(t *testing.T) {
+	t.Run("no conversation yet falls back", func(t *testing.T) {
+		assert.True(t, shouldNewSessionFallback(0), "brand-new session (0 assistant messages) may fall back to a new session")
+	})
+
+	t.Run("existing conversation does not fall back", func(t *testing.T) {
+		assert.False(t, shouldNewSessionFallback(1), "session with assistant history must not be rebuilt (history loss)")
+		assert.False(t, shouldNewSessionFallback(5), "session with multiple turns must not be rebuilt (history loss)")
+	})
+}

--- a/internal/ai/acp_pool.go
+++ b/internal/ai/acp_pool.go
@@ -299,6 +299,45 @@ func (m *ACPConnManager) GetOrCreateConnForLoad(ctx context.Context, agent *mode
 	return conn, nil
 }
 
+// NewSessionFallback forces a brand-new ACP session on the given ClawBench
+// session's connection, ignoring any prior (unrecoverable) session mapping.
+// Used when LoadSession/ResumeSession recovery fails after the agent process
+// was killed (e.g. OOM/LMK) — the conversation continues in a fresh session
+// rather than hard-failing the request.
+//
+// It clears acpSID and loadTargetSID so ensureAliveWithSession creates a new
+// session instead of retrying the dead one. Returns the conn on success, or
+// nil if even a new session could not be established (the pool entry is
+// cleaned up so a later request starts fresh).
+func (m *ACPConnManager) NewSessionFallback(ctx context.Context, agent *model.Agent, clawbenchSID, cwd string) *ACPConn {
+	m.mu.Lock()
+	conn, ok := m.conns[clawbenchSID]
+	if !ok {
+		conn = newACPConn(agent, clawbenchSID)
+		m.conns[clawbenchSID] = conn
+	}
+	m.mu.Unlock()
+
+	// Drop the previous session mapping so ensureAliveWithSession goes down the
+	// NewSession branch instead of retrying the unrecoverable session.
+	conn.mu.Lock()
+	conn.acpSID = ""
+	conn.loadTargetSID = ""
+	conn.mu.Unlock()
+
+	if _, err := conn.ensureAliveWithSession(ctx, cwd); err != nil {
+		slog.Warn("acp: NewSessionFallback failed, cleaning up connection",
+			"clawbench_sid", clawbenchSID, "error", err)
+		m.mu.Lock()
+		if c, exists := m.conns[clawbenchSID]; exists && c == conn {
+			delete(m.conns, clawbenchSID)
+		}
+		m.mu.Unlock()
+		return nil
+	}
+	return conn
+}
+
 // GetConn returns the ACPConn for the given ClawBench session ID.
 // Returns nil if no connection exists.
 func (m *ACPConnManager) GetConn(clawbenchSID string) *ACPConn {

--- a/internal/ai/acp_pool_test.go
+++ b/internal/ai/acp_pool_test.go
@@ -974,6 +974,41 @@ func TestGetOrCreateConn_DoesNotPrePopulateAcpSID_WhenEmpty(t *testing.T) {
 	mgr.CloseConn(clawbenchSID)
 }
 
+// TestACPConnManager_NewSessionFallback_ClearsStaleSession verifies that when
+// LoadSession/ResumeSession recovery fails (agent process killed, e.g. OOM/LMK),
+// NewSessionFallback drops the unrecoverable session mapping so a brand-new
+// session is created instead of retrying the dead one. With "echo" (not a real
+// ACP agent) the new-session attempt fails and the pool entry is cleaned up.
+func TestACPConnManager_NewSessionFallback_ClearsStaleSession(t *testing.T) {
+	mgr := GetACPConnManager()
+	clawbenchSID := "session-fallback-test"
+	agent := &model.Agent{ID: "test-fallback", Backend: "acp-stdio", AcpCommand: "echo"}
+
+	// Simulate a connection whose session could not be restored after the
+	// agent process was killed: alive=false with a stale session mapping.
+	conn := NewACPConnForTest(agent, clawbenchSID)
+	conn.SetSessionMappingForTest(clawbenchSID, "dead-acp-session")
+	conn.loadTargetSID = "dead-acp-session"
+	mgr.SetConnForTest(clawbenchSID, conn)
+
+	result := mgr.NewSessionFallback(context.Background(), agent, clawbenchSID, "/tmp")
+	assert.Nil(t, result, "echo agent cannot establish a new session, fallback should fail closed")
+
+	// The stale mappings must be cleared even though the new-session attempt failed.
+	conn.mu.Lock()
+	acpSID := conn.acpSID
+	loadTarget := conn.loadTargetSID
+	conn.mu.Unlock()
+	assert.Empty(t, acpSID, "stale acpSID should be cleared before new-session attempt")
+	assert.Empty(t, loadTarget, "stale loadTargetSID should be cleared")
+
+	// Failed fallback must not leave a stale (half-dead) conn in the pool.
+	mgr.mu.Lock()
+	_, exists := mgr.conns[clawbenchSID]
+	mgr.mu.Unlock()
+	assert.False(t, exists, "failed fallback should be cleaned up from conns map")
+}
+
 func TestWaitForLoadSessionDone(t *testing.T) {
 	agent := &model.Agent{ID: "a", Backend: "claude"}
 	conn := newACPConn(agent, "sid")

--- a/web/src/composables/__tests__/useTerminalViewport.test.ts
+++ b/web/src/composables/__tests__/useTerminalViewport.test.ts
@@ -2,16 +2,22 @@ import { describe, expect, it, vi, beforeEach, afterEach } from 'vitest'
 import { ref, nextTick } from 'vue'
 import { useTerminalViewport } from '@/composables/useTerminalViewport'
 
+// Shared refs for the mocked module — exposed so tests can assert on the
+// module-level singleton state that App.vue reads (not just the local ref).
+const mockShared = vi.hoisted(() => {
+  // eslint-disable-next-line @typescript-eslint/no-var-requires
+  const { ref } = require('vue') as typeof import('vue')
+  return { keyboardHeight: ref(0), isAdjustResize: ref(false) }
+})
+
 // Mock useTerminalKeyboard to avoid module-level side effects
-const mockIsAdjustResize = ref(false)
 vi.mock('@/composables/useTerminalKeyboard', () => {
-  const keyboardHeight = ref(0)
   return {
     useTerminalKeyboard: () => ({
-      keyboardHeight,
-      setKeyboardHeight: (h: number) => { keyboardHeight.value = h },
-      isAdjustResize: mockIsAdjustResize,
-      setAdjustResize: (v: boolean) => { mockIsAdjustResize.value = v },
+      keyboardHeight: mockShared.keyboardHeight,
+      setKeyboardHeight: (h: number) => { mockShared.keyboardHeight.value = h },
+      isAdjustResize: mockShared.isAdjustResize,
+      setAdjustResize: (v: boolean) => { mockShared.isAdjustResize.value = v },
       fullScreenHeight: 800,
     }),
   }
@@ -58,7 +64,8 @@ describe('useTerminalViewport', () => {
     document.body.appendChild(container)
 
     // Reset mock state
-    mockIsAdjustResize.value = false
+    mockShared.isAdjustResize.value = false
+    mockShared.keyboardHeight.value = 0
     mockIsPC.value = false
 
     // Save originals
@@ -125,6 +132,38 @@ describe('useTerminalViewport', () => {
     expect(viewport.keyboardHeight.value).toBe(200)
 
     viewport.stopWatching()
+  })
+
+  it('resets the shared keyboard height to 0 on stopWatching', () => {
+    const terminal = ref(null)
+    const containerRef = ref<HTMLElement | null>(container)
+    const viewport = useTerminalViewport(terminal, containerRef)
+
+    // Keyboard open — shared singleton must reflect it (App.vue reads this)
+    Object.defineProperty(window, 'visualViewport', {
+      value: {
+        height: 600,
+        offsetTop: 0,
+        addEventListener: vi.fn(),
+        removeEventListener: vi.fn(),
+      },
+      writable: true,
+      configurable: true,
+    })
+    Object.defineProperty(window, 'innerHeight', {
+      value: 800,
+      writable: true,
+      configurable: true,
+    })
+
+    viewport.startWatching()
+    expect(mockShared.keyboardHeight.value).toBe(200)
+
+    // Deactivating the terminal (closing/switching away from the tab page) must
+    // clear the shared keyboard state. Otherwise the dock stays hidden even
+    // though the terminal is no longer active.
+    viewport.stopWatching()
+    expect(mockShared.keyboardHeight.value).toBe(0)
   })
 
   it('detects keyboard from Android adjustResize (innerHeight shrinks)', () => {
@@ -423,11 +462,11 @@ describe('useTerminalViewport', () => {
     })
 
     viewport.startWatching()
-    expect(mockIsAdjustResize.value).toBe(true)
+    expect(mockShared.isAdjustResize.value).toBe(true)
 
     viewport.stopWatching()
     // Reset on stop
-    expect(mockIsAdjustResize.value).toBe(false)
+    expect(mockShared.isAdjustResize.value).toBe(false)
   })
 
   it('keeps keyboard height at 0 on PC even when innerHeight shrinks (window resize)', () => {
@@ -460,7 +499,7 @@ describe('useTerminalViewport', () => {
 
     expect(viewport.viewportHeight.value).toBe(500)
     expect(viewport.keyboardHeight.value).toBe(0)
-    expect(mockIsAdjustResize.value).toBe(false)
+    expect(mockShared.isAdjustResize.value).toBe(false)
 
     viewport.stopWatching()
   })
@@ -488,7 +527,7 @@ describe('useTerminalViewport', () => {
     })
 
     viewport.startWatching()
-    expect(mockIsAdjustResize.value).toBe(false)
+    expect(mockShared.isAdjustResize.value).toBe(false)
     // keyboardHeight from visualViewport: 800 - 550 - 0 = 250
     expect(viewport.keyboardHeight.value).toBe(250)
 

--- a/web/src/composables/useTerminalViewport.ts
+++ b/web/src/composables/useTerminalViewport.ts
@@ -117,6 +117,12 @@ export function useTerminalViewport(terminal: Ref<Terminal | null>, containerRef
 
     // Reset adjustResize flag when keyboard closes
     setAdjustResize(false)
+
+    // Clear the shared keyboard height when the terminal view deactivates.
+    // The module-level singleton otherwise retains its last value forever, so
+    // anyKeyboardActive in App.vue would keep the Dock hidden even after the
+    // terminal tab page is closed / navigated away from.
+    setSharedKeyboardHeight(0)
   }
 
   return {


### PR DESCRIPTION
## Summary
- **fix(acp)**: 连接建立失败（进程被杀/OOM/LMK 或 stale-alive 竞态）时重试一次 GetOrCreateConn；恢复仍失败且会话尚无对话（AssistantMessageCount==0）时回退到全新 ACP 会话，避免用户轮次直接失败。
- **fix(terminal)**: `stopWatching` 时复位共享键盘高度，关闭/离开终端页后 Dock 恢复正常显示。

## Tests
- Go: `TestShouldNewSessionFallback`、`TestACPConnManager_NewSessionFallback_ClearsStaleSession`（单元测试）
- Frontend: `useTerminalViewport` stopWatching 复位键盘高度回归测试

## Test Plan
- [x] `./scripts/pre-push-checks.sh --skip-android` 全部通过（Lint Go/Test Go/Build Go/Typecheck/Go+Frontend Coverage Gate/Android Lint/Build Frontend）
- [x] `go test ./internal/ai/...`
- [x] `npx vitest run src/composables/__tests__/useTerminalViewport.test.ts`