### PR TITLE
fix(sessions): title sessions after the user's first message, not injected prompt blocks

### DIFF
--- a/internal/handler/acp_session_title_test.go
+++ b/internal/handler/acp_session_title_test.go
@@ -1,0 +1,324 @@
+package handler
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/stretchr/testify/require"
+
+	"clawbench/internal/model"
+)
+
+// writeTranscript creates a fake CLI transcript under home and returns its path.
+func writeTranscript(t *testing.T, home, cwd, sessionID string, lines []string) {
+	t.Helper()
+	munged := strings.ReplaceAll(cwd, "/", "-")
+	dir := filepath.Join(home, ".claude", "projects", munged)
+	require.NoError(t, os.MkdirAll(dir, 0o755))
+	path := filepath.Join(dir, sessionID+".jsonl")
+	require.NoError(t, os.WriteFile(path, []byte(strings.Join(lines, "\n")+"\n"), 0o600))
+}
+
+// userTurnJSON builds a minimal claude-cli transcript user line.
+func userTurnJSON(t *testing.T, text string) string {
+	t.Helper()
+	b, err := json.Marshal(map[string]any{
+		"type": "user",
+		"message": map[string]any{
+			"role":    "user",
+			"content": []map[string]string{{"type": "text", "text": text}},
+		},
+	})
+	require.NoError(t, err)
+	return string(b)
+}
+
+func TestACPDisplayTitle_HumanTitlePassesThrough(t *testing.T) {
+	home := t.TempDir()
+	got := acpDisplayTitleFromHome(home, "/Users/x", "sid-1", "怎么导出数据库备份")
+	assert.Equal(t, "怎么导出数据库备份", got)
+}
+
+func TestACPDisplayTitle_MachineTitleDerivedFromTranscript(t *testing.T) {
+	home := t.TempDir()
+	writeTranscript(t, home, "/Users/x", "sid-2", []string{
+		userTurnJSON(t, "[System Instructions: rules]\n\n如何配置定时备份"),
+	})
+	got := acpDisplayTitleFromHome(home, "/Users/x", "sid-2",
+		"[System Instructions: ## User Interaction (Hi")
+	assert.Equal(t, "如何配置定时备份", got)
+}
+
+func TestACPDisplayTitle_SkipsSummaryOnlyTurns(t *testing.T) {
+	home := t.TempDir()
+	writeTranscript(t, home, "/Users/x", "sid-3", []string{
+		userTurnJSON(t, "[System Instructions: rules]\n\n[Below is the conversation history from before this session.\n\nSummary:\n    old talk"),
+		userTurnJSON(t, "[Below is the conversation history from before this session.\n\nSummary:\n    more old talk"),
+		userTurnJSON(t, "[System Instructions: rules]\n\n定位 clawbench 壳类型"),
+	})
+	got := acpDisplayTitleFromHome(home, "/Users/x", "sid-3", "[Below is the conversation his")
+	assert.Equal(t, "定位 clawbench 壳类型", got)
+}
+
+func TestACPDisplayTitle_MissingTranscriptFallsBack(t *testing.T) {
+	home := t.TempDir()
+	// No transcript on disk. A HUMAN agent-reported title is used as the
+	// last-resort fallback; a MACHINE one is suppressed (empty) so no
+	// [System Instructions:...] noise is ever displayed.
+	// 无转录时：人类上报标题作末级兜底；机器上报标题被抑制为空，绝不显示
+	// [System Instructions:...] 噪声。
+	assert.Equal(t, "怎么导出数据库备份",
+		acpDisplayTitleFromHome(home, "/Users/x", "no-such-sid", "怎么导出数据库备份"))
+	assert.Equal(t, "",
+		acpDisplayTitleFromHome(home, "/Users/x", "no-such-sid", "[System Instructions: ## User Interaction (Hi"))
+}
+
+func TestACPDisplayTitle_TruncatesLongQuestions(t *testing.T) {
+	home := t.TempDir()
+	long := strings.Repeat("问", 80)
+	writeTranscript(t, home, "/Users/x", "sid-4", []string{
+		userTurnJSON(t, "[System Instructions: rules]\n\n"+long),
+	})
+	got := acpDisplayTitleFromHome(home, "/Users/x", "sid-4", "[System Instructions: x")
+	assert.Equal(t, strings.Repeat("问", 50)+"...", got)
+}
+
+func TestACPDisplayTitle_CrossProjectTranscriptFallback(t *testing.T) {
+	home := t.TempDir()
+	// Transcript lives under a different project dir than the cookie cwd.
+	writeTranscript(t, home, "/Users/other", "sid-x", []string{
+		userTurnJSON(t, "[System Instructions: rules]\n\n另一个项目的首个问题"),
+	})
+	got := acpDisplayTitleFromHome(home, "/Users/x", "sid-x",
+		"[System Instructions: ## User Interaction (Hi")
+	assert.Equal(t, "另一个项目的首个问题", got)
+}
+
+func TestACPTranscriptPath_RejectsUnsafeSessionIDs(t *testing.T) {
+	for _, sid := range []string{"../../etc/passwd", "a/b", `a\b`, "x..y", "*"} {
+		if got := acpTranscriptPath("/home/u", "/Users/x", sid); got != "" {
+			t.Errorf("sessionID %q should be rejected, got %q", sid, got)
+		}
+	}
+}
+
+func TestDeriveSessionTitleForAgent(t *testing.T) {
+	t.Run("claude transcript wins over post-compaction replay", func(t *testing.T) {
+		home := t.TempDir()
+		writeTranscript(t, home, "/Users/x", "sid-c", []string{
+			userTurnJSON(t, "怎么导出数据库备份"),
+			userTurnJSON(t, "This session is being continued from a previous conversation that ran out of context. …"),
+			userTurnJSON(t, "后续的压缩后消息"),
+		})
+		// Replay mirrors a heavily compacted session's CURRENT context: the
+		// original question is gone, a later message comes first — the
+		// replay path alone would title it after that later message.
+		userMsg := func(text string) replayMessage {
+			return replayMessage{role: strUser, content: fmt.Sprintf(`{"blocks":[{"type":"text","text":%q}]}`, text)}
+		}
+		replay := []replayMessage{
+			userMsg("后续的压缩后消息"),
+			{role: strAssistant, content: `{"blocks":[{"type":"text","text":"answer"}]}`},
+		}
+		assert.Equal(t, "后续的压缩后消息", deriveSessionTitleFromReplay(replay, nil))
+		// Transcript-first lookup returns the ORIGINAL first question.
+		assert.Equal(t, "怎么导出数据库备份", acpDisplayTitleFromHome(home, "/Users/x", "sid-c", ""))
+	})
+
+	t.Run("no transcript yields empty", func(t *testing.T) {
+		assert.Empty(t, acpDisplayTitleFromHome(t.TempDir(), "/Users/x", "no-sid", ""))
+	})
+
+	t.Run("machine-only transcript yields empty", func(t *testing.T) {
+		home := t.TempDir()
+		writeTranscript(t, home, "/Users/x", "sid-m", []string{
+			userTurnJSON(t, "This session is being continued from a previous conversation that ran out of context. …"),
+		})
+		assert.Empty(t, acpDisplayTitleFromHome(home, "/Users/x", "sid-m", ""))
+	})
+
+	t.Run("transcript in another project dir found via global lookup", func(t *testing.T) {
+		home := t.TempDir()
+		writeTranscript(t, home, "/Users/other", "sid-g", []string{
+			userTurnJSON(t, "另一个项目的首个问题"),
+		})
+		assert.Equal(t, "另一个项目的首个问题", acpDisplayTitleFromHome(home, "/Users/x", "sid-g", ""))
+	})
+}
+
+// customTitleJSON builds a minimal claude-cli custom-title transcript line.
+func customTitleJSON(t *testing.T, name string) string {
+	t.Helper()
+	b, err := json.Marshal(map[string]any{"type": "custom-title", "customTitle": name})
+	require.NoError(t, err)
+	return string(b)
+}
+
+func TestCustomTitleWinsOverEverything(t *testing.T) {
+	t.Run("custom name replaces all derived candidates", func(t *testing.T) {
+		home := t.TempDir()
+		writeTranscript(t, home, "/Users/x", "sid-n", []string{
+			customTitleJSON(t, "my-important-session"),
+			userTurnJSON(t, "怎么导出数据库备份"),
+		})
+		assert.Equal(t, "my-important-session", acpDisplayTitleFromHome(home, "/Users/x", "sid-n", ""))
+		// Also wins over a non-machine agent-reported title in the display path.
+		assert.Equal(t, "my-important-session", acpDisplayTitleFromHome(home, "/Users/x", "sid-n", "普通标题"))
+		// And over a machine one.
+		assert.Equal(t, "my-important-session", acpDisplayTitleFromHome(home, "/Users/x", "sid-n", "[System Instructions: x"))
+	})
+
+	t.Run("latest custom name wins", func(t *testing.T) {
+		home := t.TempDir()
+		writeTranscript(t, home, "/Users/x", "sid-n2", []string{
+			customTitleJSON(t, "old-name"),
+			userTurnJSON(t, "怎么导出数据库备份"),
+			customTitleJSON(t, "new-name"),
+		})
+		assert.Equal(t, "new-name", acpDisplayTitleFromHome(home, "/Users/x", "sid-n2", ""))
+	})
+
+	t.Run("no custom name falls through to first question", func(t *testing.T) {
+		home := t.TempDir()
+		writeTranscript(t, home, "/Users/x", "sid-n3", []string{
+			userTurnJSON(t, "怎么导出数据库备份"),
+		})
+		assert.Equal(t, "怎么导出数据库备份", acpDisplayTitleFromHome(home, "/Users/x", "sid-n3", ""))
+	})
+}
+
+func TestIsMachineGeneratedTitle_AllPrefixes(t *testing.T) {
+	// Every prefix in machineGeneratedUserPrefixes must be detected as
+	// machine-generated, both in full and truncated form (the CLI truncates
+	// titles to ~200 chars).
+	// machineGeneratedUserPrefixes 中的每个前缀都必须被判定为机器文本，
+	// 无论完整还是截断形式（CLI 会把标题截断到约 200 字符）。
+	for _, marker := range machineGeneratedUserPrefixes {
+		if !isMachineGeneratedTitle(marker + "rest of title") {
+			t.Errorf("full title starting with %q not detected as machine", marker)
+		}
+		if !isMachineGeneratedTitle(marker) {
+			t.Errorf("bare marker %q not detected as machine", marker)
+		}
+		// Truncated to half the marker length — still a prefix of the marker.
+		half := marker[:len(marker)/2+1]
+		if !isMachineGeneratedTitle(half) {
+			t.Errorf("truncated prefix %q not detected as machine", half)
+		}
+	}
+}
+
+func TestIsMachineGeneratedTitle_HumanTitles(t *testing.T) {
+	for _, title := range []string{"怎么导出数据库备份", "list", "你是什么模型", "weekend-hiking-plan"} {
+		if isMachineGeneratedTitle(title) {
+			t.Errorf("human title %q wrongly flagged as machine", title)
+		}
+	}
+	if isMachineGeneratedTitle("") {
+		t.Error("empty title should not be machine-generated")
+	}
+}
+
+func TestMachinePrefixesMatchStrip(t *testing.T) {
+	// Sync contract: every prefix in machineGeneratedUserPrefixes must be
+	// recognized by stripMachineText (so a title detected as
+	// machine is one whose source turn would actually be stripped). A turn
+	// that is ONLY the marker (no human text) must strip to ok=false.
+	// 同步契约：machineGeneratedUserPrefixes 中的每个前缀都必须能被
+	// stripMachineText 识别。仅含该标记、无人类文本的轮次必须
+	// 剥离为 ok=false。
+	for _, marker := range machineGeneratedUserPrefixes {
+		_, ok := stripMachineText(marker+" padding", stripRulesFor(claudeTranscriptResolver{}))
+		if ok {
+			t.Errorf("prefix %q not stripped by stripMachineGeneratedUserText (drift from isMachineGeneratedTitle)", marker)
+		}
+	}
+}
+
+// userTurnStringJSON builds a transcript user line whose content is a plain
+// string (claude-code writes this form in some contexts), not a block list.
+// 构造 content 为纯字符串（claude-code 部分场景用此形式）的转录用户行。
+func userTurnStringJSON(t *testing.T, text string) string {
+	t.Helper()
+	b, err := json.Marshal(map[string]any{
+		"type": "user",
+		"message": map[string]any{
+			"role":    "user",
+			"content": text,
+		},
+	})
+	require.NoError(t, err)
+	return string(b)
+}
+
+func TestFirstRealQuestion_StringContent(t *testing.T) {
+	home := t.TempDir()
+	// First user turn has string content (not a block list). The parser must
+	// still extract it; a machine prefix on a string turn is also stripped.
+	// 首条用户轮次的 content 为字符串（非块列表）。解析器须照样提取；
+	// 字符串轮次上的机器前缀也要剥离。
+	writeTranscript(t, home, "/Users/x", "sid-s", []string{
+		userTurnStringJSON(t, "[System Instructions: rules]\n\n如何配置自动备份"),
+	})
+	assert.Equal(t, "如何配置自动备份", acpDisplayTitleFromHome(home, "/Users/x", "sid-s", "再确认一下参数"))
+}
+
+// fakeTranscriptResolver proves the decoupling: a backend that was never
+// known to the title module gets full tier behavior by ONLY implementing
+// the standard input block and registering it.
+//
+// 证明解耦：标题模块从未感知过的后端，仅靠实现标准输入块并注册，即获得
+// 完整的层级行为。
+type fakeTranscriptResolver struct {
+	path     string
+	title    string
+	question string
+}
+
+func (f fakeTranscriptResolver) TranscriptPath(home, cwd, sessionID string) string {
+	if sessionID == "bad/sid" {
+		return "" // traversal-shaped IDs must be handled by the impl 防穿越由实现负责
+	}
+	if f.path != "" {
+		return f.path
+	}
+	return "/fake/any-transcript" // tiers key on a non-empty path 非空路径才进入转录层
+}
+func (f fakeTranscriptResolver) CustomTitle(path string) string   { return f.title }
+func (f fakeTranscriptResolver) FirstQuestion(path string) string { return f.question }
+func (f fakeTranscriptResolver) StripRules() []stripRule {
+	return []stripRule{{prefix: "<fake-compact-header ", kind: stripSkipTurn}}
+}
+
+func TestFakeBackendPlugsInViaRegistry(t *testing.T) {
+	reg := sessionTranscriptResolvers
+	t.Cleanup(func() { sessionTranscriptResolvers = reg })
+	sessionTranscriptResolvers = map[string]sessionTranscriptResolver{
+		"claude": claudeTranscriptResolver{},
+		"fake":   fakeTranscriptResolver{title: "fake-topic-name", question: "假后端的首个问题"},
+	}
+
+	t.Run("import path (deriveSessionTitleForAgent) uses the fake resolver", func(t *testing.T) {
+		agent := &model.Agent{Backend: "fake"}
+		got := deriveSessionTitleForAgent(agent, "/proj", "sid-1", nil)
+		assert.Equal(t, "fake-topic-name", got) // tier 1: custom title wins
+	})
+	t.Run("display core tier 3 falls to the fake first question", func(t *testing.T) {
+		r := fakeTranscriptResolver{question: "假后端的首个问题"}
+		assert.Equal(t, "假后端的首个问题", sessionDisplayTitle(r, "/h", "/proj", "sid-1", ""))
+	})
+	t.Run("fake native prefix is detected in titles for that backend", func(t *testing.T) {
+		assert.True(t, isMachineGeneratedTitleFor("<fake-compact-header rest", machinePrefixesFor(fakeTranscriptResolver{})))
+		assert.False(t, isMachineGeneratedTitleFor("<fake-compact-header rest", machinePrefixesFor(nil))) // unknown to others
+	})
+	t.Run("unregistered backend bypasses transcript tiers", func(t *testing.T) {
+		assert.Equal(t, "", sessionDisplayTitle(nil, "/h", "/proj", "sid-1", ""))
+		assert.Equal(t, "人类末级兜底", sessionDisplayTitle(nil, "/h", "/proj", "sid-1", "人类末级兜底"))
+	})
+}

--- a/internal/handler/agent.go
+++ b/internal/handler/agent.go
@@ -2,9 +2,13 @@
 package handler
 
 import (
+	"bufio"
 	"database/sql"
+	"encoding/json"
 	"log/slog"
 	"net/http"
+	"os"
+	"path/filepath"
 	"regexp"
 	"strings"
 	"unicode/utf8"
@@ -770,6 +774,51 @@ func ServeACPSessions(w http.ResponseWriter, r *http.Request) {
 		sessions = filtered
 	}
 
+	// Display-only title cleanup: agents title sessions after the last user
+	// message, which for ClawBench-origin sessions begins with the injected
+	// [System Instructions: ...] block (or a continuation summary). The
+	// agent truncates the reported title inside that block, so the user's
+	// actual text is not present in the title at all — recovery must
+	// re-read the session transcript on disk (read-only; the transcript
+	// itself is never modified) and re-derive the title from the first
+	// user-typed message.
+	//
+	// Backend support: title detection (isMachineGeneratedTitle) and this
+	// display-layer hook are backend-agnostic, but transcript recovery
+	// needs a per-backend resolver — where the CLI stores sessions and how
+	// to extract user messages from its format. Only the Claude CLI is
+	// implemented (acpTranscriptPath + resolveTranscriptPath +
+	// customTitleFromTranscript + firstRealQuestionFromTranscript, reading
+	// ~/.claude/projects/<munged-cwd>/<sid>.jsonl). To support another
+	// backend (e.g. opencode, codex): implement its transcript path
+	// resolution and first-question extraction mirroring those four
+	// functions, then widen the Backend == "claude" gate below to a
+	// backend→resolver dispatch. The acp-load import path
+	// (deriveSessionTitleForAgent in agent.go) uses the SAME resolver set
+	// and must be widened in lockstep so the two lists stay consistent.
+	//
+	// 后端支持：新增后端请按 acpTranscriptPath 上方的 BACKEND EXTENSION GUIDE
+	// （六步接入指南：定位存储→读真实格式→实现三解析器→追加机器前缀→两处门控
+	// 改注册表→真实样本测试）执行。标题检测（isMachineGeneratedTitle）与本展示
+	// 层钩子与后端无关，但转录恢复需要逐后端的解析器。
+	// 目前仅实现 Claude CLI（acpTranscriptPath + resolveTranscriptPath +
+	// customTitleFromTranscript + firstRealQuestionFromTranscript，读取
+	// ~/.claude/projects/<munged-cwd>/<sid>.jsonl）。新增后端（如 opencode、codex）
+	// 时：仿照这四个函数实现该后端的转录路径解析与首问提取，再把下方的
+	// Backend == "claude" 门控改为后端→解析器分发。acp-load 导入路径
+	// （agent.go 的 deriveSessionTitleForAgent）使用同一套解析器，必须同步放宽，
+	// 以保证两个列表一致。
+	cwd := middleware.GetProjectFromCookie(r)
+	if transcriptResolverFor(agent.Backend) != nil {
+		for i := range sessions {
+			if sessions[i].Title == nil {
+				continue
+			}
+			display := acpDisplayTitle(agent.Backend, cwd, string(sessions[i].SessionId), *sessions[i].Title)
+			sessions[i].Title = &display
+		}
+	}
+
 	writeJSON(w, http.StatusOK, map[string]any{
 		"sessions":   sessions,
 		"nextCursor": nextCursor,
@@ -788,6 +837,670 @@ func ServeACPSessions(w http.ResponseWriter, r *http.Request) {
 //     the backend (e.g. opencode's "ses_..."), captured on every run.
 //
 // Matching both covers sessions created through either path.
+// acpDisplayTitle returns a human-readable display title for an ACP session
+// in the external session list ("外部会话"). The agent reports a per-session
+// title via the session/list RPC, but for claude that reported title is an
+// inconsistent user message (often the LAST or a middle one, not the first),
+// so it is NOT trusted as the "first question". The transcript on disk is the
+// only reliable source of the first user question. The transcript is only
+// ever read.
+//
+// Tier order (claude), highest first:
+//  1. the CLI's persisted session title ("custom-title" transcript record —
+//     the auto-generated topic title);
+//  2. the transcript's first real user question (machine headers stripped);
+//  3. fall back to the agent-reported title (only when the transcript is
+//     unreadable or yields no question).
+//
+// acp-load (会话搜索) reuses this SAME function (with agentTitle=""), so a
+// session keeps one title while cycled between the two lists.
+//
+// 为"外部会话"列表中的 ACP 会话返回可读标题。agent 经 session/list RPC 上报每
+// 会话标题，但 claude 上报的是不一致的某条用户消息（常为末问或中间某条，非首问），
+// 故不可作为"首问"信任。磁盘转录是首问的唯一可靠来源。转录只读不改。
+// 层级（claude，从高到低）：1) CLI 持久化的会话标题（custom-title 记录，自动主题名）；
+// 2) 转录首问（剥离机器前缀后）；3) 回退到 agent 上报标题（仅当转录不可读或无首问时）。
+// acp-load（会话搜索）复用本函数（传 agentTitle=""），使会话在两列表间循环时标题一致。
+func acpDisplayTitle(backend, cwd, sessionID, agentTitle string) string {
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return agentTitle
+	}
+	return sessionDisplayTitle(transcriptResolverFor(backend), home, cwd, sessionID, agentTitle)
+}
+
+// acpDisplayTitleFromHome decides the display title for ONE session in the
+// external session list ("外部会话"). It runs per session on every list
+// request. Walkthrough:
+//
+// INPUT  cwd        the project dir from the cookie, e.g. /Users/x/Desktop/myproject
+//
+//	sessionID  the CLI session id, e.g. a1b2c3d4-1234-...
+//	agentTitle what the CLI reported via session/list, e.g. "再确认一下参数"
+//	           (claude reports SOME user message — often the last or a
+//	           middle one — NOT reliably the first question)
+//
+// STEP 1  locate the transcript file on disk:
+//
+//	  ~/.claude/projects/-Users-x-Desktop-myproject/<sessionID>.jsonl
+//	(slashes in cwd become '-'; if missing, search all project dirs by
+//	 sessionID — the session may have been created under another cwd)
+//	no file found → path = "", skip to STEP 4.
+//
+// STEP 2  scan the file for the newest "custom-title" line:
+//
+//	  {"type":"custom-title","customTitle":"weekend-hiking-plan"}
+//	found → return it (capped at 50 runes). DONE.
+//	(newer claude-code auto-writes this topic title; it is the CLI's
+//	 own authoritative name for the session)
+//
+// STEP 3  scan the file top-down for the first REAL user question:
+//   - skip assistant lines
+//   - user line → extract its text (content is either a plain string
+//     or a list of text blocks; transcriptContentText handles both)
+//   - text starting with a machine prefix (see
+//     machineGeneratedUserPrefixes) → strip the prefix and keep going;
+//     e.g. "[System Instructions: rules]\n\n如何配置自动备份"
+//     → "如何配置自动备份"
+//     a turn that is 100% machine text (e.g. a compaction header
+//     "This session is being continued from a previous ...") → skip
+//     to the next user line
+//     found → return it (capped at 50 runes). DONE.
+//
+// STEP 4  nothing readable on disk — last resort, the agent-reported title:
+//
+//	human text → return it; machine text → return "" (better no
+//	title than "[System Instructions:..." noise).
+//
+// acp-load (会话搜索) calls this SAME function with agentTitle="" so both
+// lists share one code path and a session keeps one title while cycled.
+//
+// acpDisplayTitleFromHome 决定"外部会话"列表中单个会话显示什么标题,每次拉取
+// 列表时对每个会话执行一次。操作步骤:
+//
+// 输入    cwd        cookie 里的项目目录,如 /Users/x/Desktop/myproject
+//
+//	sessionID  CLI 会话 ID,如 a1b2c3d4-1234-...
+//	agentTitle CLI 经 session/list 上报的标题,如 "再确认一下参数"
+//	           (claude 上报的是"某条"用户消息——常是末问或中间某条,
+//	            不保证是首问,所以不能直接信)
+//
+// 第 1 步  定位磁盘上的转录文件:
+//
+//	  ~/.claude/projects/-Users-x-Desktop-myproject/<sessionID>.jsonl
+//	(cwd 的斜杠转横杠;找不到再按 sessionID 在所有项目目录里全局搜,
+//	 会话可能是在别的目录下创建的)
+//	仍无 → path="",直接跳到第 4 步。
+//
+// 第 2 步  扫描文件里最新的 "custom-title" 行:
+//
+//	  {"type":"custom-title","customTitle":"weekend-hiking-plan"}
+//	有 → 返回它(截到 50 字),结束。
+//	(新版 claude-code 自动写入的会话主题名,是 CLI 自己的权威命名)
+//
+// 第 3 步  从文件顶部向下找第一条"真问题":
+//   - 跳过 assistant 行
+//   - user 行取出文本(content 可能是纯字符串或文本块列表,
+//     由 transcriptContentText 统一处理)
+//   - 文本以机器前缀开头(见 machineGeneratedUserPrefixes)→ 剥掉前缀
+//     继续用剩余部分;例:
+//     "[System Instructions: 规则]\n\n如何配置自动备份"
+//     → "如何配置自动备份"
+//     整轮都是机器文本(如压缩头 "This session is being continued
+//     from a previous ...")→ 跳过,看下一条 user 行
+//     找到 → 返回它(截到 50 字),结束。
+//
+// 第 4 步  磁盘上读不到任何可用信息——最后兜底用 CLI 上报标题:
+//
+//	是人话 → 返回;是机器文本 → 返回空(宁缺勿错,绝不显示噪声)。
+//
+// acp-load(会话搜索)以 agentTitle="" 调用本函数,两列表共用一条代码路径,
+// 会话在两列表间循环时标题保持不变。
+func acpDisplayTitleFromHome(home, cwd, sessionID, agentTitle string) string {
+	return sessionDisplayTitle(claudeTranscriptResolver{}, home, cwd, sessionID, agentTitle)
+}
+
+// sessionDisplayTitle is the resolver-aware title core — the tier logic with
+// every backend touchpoint injected through the standard input block. It is
+// the ONE function both lists' derivation runs on; a backend participates by
+// registering a sessionTranscriptResolver, nothing else changes.
+//
+//	r == nil (backend not registered) → tiers 1-3 are skipped; the human
+//	reported title is the last resort, machine ones suppressed.
+//
+// 解析器感知的标题核心——层级逻辑的全部后端触点经标准输入块注入。两个列表
+// 的派生都跑在这一个函数上;后端只要注册 sessionTranscriptResolver 即参与,
+// 其余零改动。r == nil(未注册后端)时跳过第 1-3 层,人类上报标题兜底,机器
+// 上报抑制为空。
+func sessionDisplayTitle(r sessionTranscriptResolver, home, cwd, sessionID, agentTitle string) string {
+	path := ""
+	if r != nil {
+		path = r.TranscriptPath(home, cwd, sessionID)
+	}
+	// Tier 1: the CLI's own persisted session title ("custom-title" records —
+	// auto-generated topic title or manual rename) outranks every derived
+	// candidate.
+	// 第 1 层：CLI 自持久化的会话标题（custom-title 记录，自动主题名或手动改名），
+	// 优先于一切派生候选。
+	if r != nil && path != "" {
+		if t := r.CustomTitle(path); t != "" {
+			return capTitle(t)
+		}
+	}
+	// Tier 2: the transcript's first real user question (machine headers
+	// stripped). The agent-reported title is deliberately NOT used here:
+	// claude reports an inconsistent user message (often the last or a middle
+	// one), not a reliable first question.
+	// 第 2 层：转录首问（剥离机器前缀后）。此处刻意不用 agent 上报标题：claude
+	// 上报的是不一致的某条用户消息（常为末问或中间某条），并非可靠的首问。
+	if r != nil && path != "" {
+		if t := r.FirstQuestion(path); t != "" {
+			return capTitle(t)
+		}
+	}
+	// Tier 3: fall back to the agent-reported title only when the transcript
+	// is unreadable or yields no question — but never display machine noise
+	// (isMachineGeneratedTitle); return empty so the caller falls back further
+	// (acp-load: to the replay; external list: empty field).
+	// 第 3 层：仅当转录不可读或无首问时回退到 agent 上报标题，但绝不显示机器文本
+	// （isMachineGeneratedTitle）；返回空，让调用方继续回退（acp-load：到重放；
+	// 外部列表：空字段）。
+	if agentTitle != "" && !isMachineGeneratedTitleFor(agentTitle, machinePrefixesFor(r)) {
+		return agentTitle
+	}
+	return ""
+}
+
+// claudeNativeUserPrefixes are the machine headers the claude-code CLI
+// itself prepends to user turns (its resolver's MachinePrefixes).
+//
+// claude-code CLI 自己拼在用户轮次前的机器头(即其解析器的 MachinePrefixes)。
+var claudeNativeUserPrefixes = []string{
+	"This session is being continued from a previous conversation",
+	"<command-name>/",
+	"<local-command",
+	"Caveat: The messages below were generated by the user",
+	"[Request interrupted",
+}
+
+// claudeTranscriptResolver adapts the claude-code CLI's storage to the
+// standard input block (sessionTranscriptResolver). Thin delegation to the
+// existing, individually-tested functions.
+//
+// 将 claude-code CLI 的存储适配到标准输入块(sessionTranscriptResolver)。
+// 对既有且各自带测试的函数做薄委托。
+type claudeTranscriptResolver struct{}
+
+func (claudeTranscriptResolver) TranscriptPath(home, cwd, sessionID string) string {
+	return resolveTranscriptPath(home, cwd, sessionID)
+}
+
+func (claudeTranscriptResolver) CustomTitle(path string) string {
+	return customTitleFromTranscript(path)
+}
+
+func (claudeTranscriptResolver) FirstQuestion(path string) string {
+	return firstRealQuestionFromTranscript(path)
+}
+
+func (claudeTranscriptResolver) StripRules() []stripRule {
+	return claudeNativeStripRules
+}
+
+// capTitle truncates a title candidate to maxReplayTitleRunes.
+// 将标题候选截断到 maxReplayTitleRunes（50 字符），超出部分以 "..." 结尾。
+func capTitle(t string) string {
+	if runes := []rune(t); len(runes) > maxReplayTitleRunes {
+		return string(runes[:maxReplayTitleRunes]) + "..."
+	}
+	return t
+}
+
+// resolveTranscriptPath locates the CLI transcript for a session: first the
+// munged project dir for cwd, then a global lookup by session ID (the
+// transcript may live under a different project directory). Returns "" when
+// no transcript exists.
+//
+// 定位会话的 CLI 转录文件：先按 cwd 映射的项目目录找（~/.claude/projects/
+// <cwd斜杠转横线>/<sid>.jsonl），找不到再按会话 ID 全局兜底（转录可能挂在别的
+// 项目目录下）。找不到返回 ""。
+func resolveTranscriptPath(home, cwd, sessionID string) string {
+	path := acpTranscriptPath(home, cwd, sessionID)
+	if path == "" {
+		return ""
+	}
+	if _, err := os.Stat(path); err != nil {
+		matches, _ := filepath.Glob(filepath.Join(home, ".claude", "projects", "*", sessionID+".jsonl"))
+		if len(matches) == 0 {
+			return ""
+		}
+		path = matches[0]
+	}
+	return path
+}
+
+// customTitleFromTranscript scans a transcript top-down and returns the
+// NEWEST "custom-title" line, e.g. for
+//
+//	{"type":"custom-title","sessionId":"...","customTitle":"weekend-hiking-plan"}
+//
+// it returns "weekend-hiking-plan". The CLI may write the line many
+// times (re-writes on activity); the last one wins. This is the CLI's own
+// authoritative name for the session and outranks every derived candidate.
+// No such line ever written → "".
+//
+// 返回 CLI 自己持久化的最新会话标题（"custom-title" 记录——新版 claude-code 会
+// 自动生成 kebab-case 主题标题写入转录；手动改名也落同一记录）。这是 CLI 对该
+// 会话的权威标题，优先级高于一切派生候选。CLI 从未写过则返回 ""。
+func customTitleFromTranscript(path string) string {
+	f, err := os.Open(path)
+	if err != nil {
+		return ""
+	}
+	defer func() { _ = f.Close() }()
+
+	scanner := bufio.NewScanner(f)
+	scanner.Buffer(make([]byte, 0, 64*1024), 16*1024*1024)
+	last := ""
+	for scanner.Scan() {
+		var d struct {
+			Type        string `json:"type"`
+			CustomTitle string `json:"customTitle"`
+		}
+		if err := json.Unmarshal(scanner.Bytes(), &d); err != nil || d.Type != "custom-title" {
+			continue
+		}
+		if s := strings.TrimSpace(d.CustomTitle); s != "" {
+			last = s
+		}
+	}
+	return last
+}
+
+// deriveSessionTitleForAgent picks the title for an acp-load (import) session,
+// i.e. what gets written into chat_sessions.title when the user imports a
+// session from the external list into "会话搜索". Operationally it just
+// re-runs the external list's derivation on the same transcript:
+//
+//	user clicks "下载/导入"
+//	  → acp-load replays the session via ACP (replay = CLI's CURRENT context)
+//	  → replay finishes → this function decides the title:
+//
+//	      claude backend?
+//	        YES → call acpDisplayTitleFromHome(home, projectPath, sid, "")
+//	              (the EXACT function the external list uses; agentTitle=""
+//	              because acp-load has no session/list RPC to ask the CLI)
+//	              → STEP 1-3 of that function run on the transcript
+//	                (custom-title → first real question)
+//	              → non-empty → write it to DB. DONE.
+//	        transcript unreadable / claude not the backend?
+//	          → deriveSessionTitleFromReplay(replay): first human message of
+//	            the replay, machine prefixes stripped, capped at 50 runes.
+//
+// Why the transcript instead of the replay: a session compacted N times has
+// its original first question already summarized away in the CLI's context,
+// so the replay starts with a compaction header and a LATER message — the
+// title would drift and disagree with the external list (which reads the
+// transcript from the top). Reading the same transcript in both paths keeps
+// the two lists byte-identical while the session is cycled between them.
+//
+// Adding a backend: follow the six-step BACKEND EXTENSION GUIDE above
+// acpTranscriptPath in this file (locate storage → read the real schema →
+// implement the three resolvers → append machine prefixes → widen both gates
+// to a registry → test with real anonymized fixtures).
+//
+// deriveSessionTitleForAgent 决定 acp-load(导入)会话的标题——即用户把外部会话
+// "下载"进"会话搜索"时写进 chat_sessions.title 的值。操作上就是把外部列表的
+// 派生函数在同一份转录上重跑一遍:
+//
+//	用户点"下载/导入"
+//	  → acp-load 经 ACP 重放会话(重放 = CLI 当前上下文)
+//	  → 重放完成 → 本函数决定标题:
+//
+//	      是 claude 后端?
+//	        是 → 调 acpDisplayTitleFromHome(home, projectPath, sid, "")
+//	            (与外部列表完全同一个函数;agentTitle="" 是因为 acp-load 手头
+//	             没有 session/list RPC 可向 CLI 要上报标题)
+//	            → 在转录上执行该函数的第 1-3 步(custom-title → 首问)
+//	            → 非空 → 写入 DB,结束。
+//	        转录读不到 / 不是 claude 后端?
+//	          → deriveSessionTitleFromReplay(重放):取重放里第一条人类消息,
+//	            剥机器前缀,截 50 字。
+//
+// 为何用转录而非重放:压缩过 N 次的会话,其原始首问早被 CLI 摘要替换,重放以
+// 压缩头开头、后面是较晚的消息——标题会漂移,与从顶部读转录的外部列表不一致。
+// 两条路径读同一份转录,会话在两列表间循环时标题逐字节一致。
+//
+// 新增后端:实现该后端的转录路径解析与首问提取(仿照 acpTranscriptPath /
+// firstRealQuestionFromTranscript / customTitleFromTranscript),把下方的
+// Backend == "claude" 门控改为后端→解析器分发;acpDisplayTitleFromHome 的调用
+// 方无须改动。
+func deriveSessionTitleForAgent(agent *model.Agent, projectPath, acpSessionID string, replay []replayMessage) string {
+	var r sessionTranscriptResolver
+	if agent != nil {
+		r = transcriptResolverFor(agent.Backend)
+		if r != nil {
+			if home, err := os.UserHomeDir(); err == nil {
+				// Reuse the resolver-aware core so both lists share ONE code
+				// path. acp-load has no agent-reported title (no session/list
+				// RPC), so pass "" — tiers 1-2 drive the result, and "" makes
+				// the agent-title fallback tier a no-op, falling through to
+				// the replay below when nothing is found.
+				// 复用解析器感知核心，使两列表共用一条代码路径。acp-load 无
+				// agent 上报标题（无 session/list RPC），故传 ""：第 1-2 层决定
+				// 结果，"" 使上报标题兜底层为空操作，未命中时回退到重放。
+				if title := sessionDisplayTitle(r, home, projectPath, acpSessionID, ""); title != "" {
+					return title
+				}
+			}
+		}
+	}
+	// Replay fallback: strip with this backend's rule set (universal +
+	// its native rules; unregistered backends get universal only).
+	// 重放兜底:按该后端的规则集剥离(通用+其原生规则;未注册后端仅通用)。
+	return deriveSessionTitleFromReplay(replay, r)
+}
+
+// isMachineGeneratedTitle reports whether an agent-reported session title was
+// derived from a machine-generated user turn (injected system prompt block or
+// continuation summary) rather than from user-typed text. Agents truncate
+// titles, so a title that is a prefix of a marker (truncation cut inside the
+// marker itself) also counts.
+// isMachineGeneratedTitle reports whether an agent-reported session title was
+// derived from a machine-generated user turn (injected system prompt block,
+// CLI continuation/compaction header, slash command, local-command caveat,
+// attachment header, interruption marker) rather than from user-typed text.
+// Agents truncate the reported title (~200 chars), so the check is
+// truncation-tolerant: a title that is a prefix of a known marker also counts.
+//
+// Uses machineGeneratedUserPrefixes (the same list stripMachineGeneratedUserText
+// strips on), so detection stays in lockstep with stripping.
+//
+// 判断 agent 上报的会话标题是否来自机器生成的用户轮次（注入系统提示块、CLI
+// 续接/压缩头、斜杠命令、本地命令警示、附件头、中断标记）而非人类输入。
+// agent 会把标题截断（约 200 字符），故匹配容忍截断：标题是某已知标记的前缀
+// 时同样判定为机器文本。复用 machineGeneratedUserPrefixes（与
+// stripMachineGeneratedUserText 剥离所用同一份列表），保证判定与剥离同步。
+// isMachineGeneratedTitleFor checks against an explicit prefix list
+// (client-injected + the backend's native prefixes — machinePrefixesFor).
+// isMachineGeneratedTitleFor 按显式前缀列表判定(客户端注入+该后端原生前缀,
+// 见 machinePrefixesFor)。
+func isMachineGeneratedTitleFor(title string, prefixes []string) bool {
+	if title == "" {
+		return false
+	}
+	for _, marker := range prefixes {
+		if strings.HasPrefix(title, marker) ||
+			(len(title) < len(marker) && strings.HasPrefix(marker, title)) {
+			return true
+		}
+	}
+	return false
+}
+
+// isMachineGeneratedTitle is the claude-flavoured default (combined list);
+// the resolver-aware core uses isMachineGeneratedTitleFor.
+//
+// claude 口味的默认版(合并列表);解析器感知的核心用 isMachineGeneratedTitleFor。
+func isMachineGeneratedTitle(title string) bool {
+	return isMachineGeneratedTitleFor(title, machineGeneratedUserPrefixes)
+}
+
+// ═══════════════════════════════════════════════════════════════════════════
+// BACKEND EXTENSION GUIDE — how to bring session-title derivation to another
+// CLI backend (codex, opencode, gemini, ...). Start here, then follow the
+// six steps. Everything above this block (tier order, capping, machine-title
+// detection) is backend-agnostic and needs NO changes.
+//
+// 后端扩展指南——如何把会话标题派生接入另一个 CLI 后端（codex、opencode、
+// gemini 等）。从这里开始，按六步执行。本块之上的所有内容（层级顺序、截断、
+// 机器标题判定）均与后端无关，无须改动。
+//
+// WHAT EACH BACKEND MUST PROVIDE — the standard input block is now a real
+// compile-time contract: sessionTranscriptResolver (session_title_resolver.go)
+// with FOUR methods (path / custom title / first question / native machine
+// prefixes). Implement it, register in sessionTranscriptResolvers, done.
+// 后端需要提供的——标准输入块已是编译期契约：sessionTranscriptResolver
+// （见 session_title_resolver.go）四个方法（路径/自定义标题/首问/原生机
+// 器前缀）。实现并注册即完成接入；本指南下方是 claude 的参考实现。
+//
+// STEP 1 — Locate the CLI's transcript storage with REAL data.
+//
+//	Run the CLI once in some project dir, create a session, then find
+//	where a session file appeared (e.g. `ls -lt ~ | head`, or the
+//	CLI's docs). Note: (a) the directory pattern, (b) how the project
+//	path is encoded in it, (c) the file naming.
+//	claude example: ~/.claude/projects/-Users-x-Desktop-myproject/<uuid>.jsonl
+//	                (project path with '/'→'-')
+//
+// 第1步——用真实数据定位该 CLI 的转录存储。在某项目目录里跑一次该 CLI、
+//
+//	建一个会话，找到会话文件出现在哪（如 `ls -lt ~ | head` 或官方文档）。
+//	记下：(a) 目录规律 (b) 项目路径如何编码进去 (c) 文件命名。
+//	claude 例: ~/.claude/projects/-Users-x-Desktop-myproject/<uuid>.jsonl
+//	           （项目路径 '/'→'-'）
+//
+// STEP 2 — Read 5-10 REAL transcript lines and note the schema:
+//
+//	how is a user turn shaped? (claude: {"type":"user","message":
+//	{"content": <string | [{type:"text",text:...}]>}}). Which fields
+//	mark the role? Does the CLI persist its own title record
+//	(claude: {"type":"custom-title","customTitle":...})? Which
+//	machine texts does IT prepend (the equivalent of claude's
+//	"This session is being continued..." compaction header)?
+//
+// 第2步——读 5-10 行真实转录，记下格式：用户轮次长什么样（claude:
+//
+//	{"type":"user","message":{"content":<字符串|[{type,text}块列表]>}}）；
+//	哪些字段标记角色；该 CLI 是否持久化自己的标题记录（claude:
+//	{"type":"custom-title",...}）；它自己会预置哪些机器文本（相当于
+//	claude 压缩头 "This session is being continued..." 的等价物）。
+//
+// STEP 3 — Implement the backend's three resolvers, mirroring the claude
+//
+//	ones directly below (same signatures, same "" semantics):
+//
+// 第3步——仿照正下方的 claude 版实现该后端的三个解析器（签名一致、空值
+//
+//	         语义一致）：
+//
+//		func xTranscriptPath(home, cwd, sessionID string) string        // STEP 1 findings
+//		func xCustomTitleFromTranscript(path string) string             // STEP 2 finding, or return ""
+//		func xFirstRealQuestionFromTranscript(path string) string       // STEP 2 schema
+//
+//		  Security copy acpTranscriptPath's rejection of session IDs carrying
+//		  '/', '\', '..', glob metacharacters — sessionID comes from the wire.
+//		  安全性：照抄 acpTranscriptPath 对含 '/', '\', '..', glob 元字符的
+//		  sessionID 的拒绝——sessionID 来自网络输入。
+//
+// STEP 4 — Append the backend's own machine prefixes to
+//
+//	machineGeneratedUserPrefixes (session_resume.go). NOTE which
+//	prefixes are whose:
+//	  clawbench-injected (ALL backends see them):
+//	    "[System Instructions:", "[Below is the conversation history",
+//	    "[Current file: ", "[Current directory: ", "[User uploaded "
+//	  claude-native (harmless no-ops for other backends):
+//	    "This session is being continued...", "<command-name>/",
+//	    "<local-command", "Caveat: The messages below...", "[Request interrupted"
+//	Everything downstream (stripper + title detector) updates
+//	automatically — they share this one list.
+//
+// 第4步——把该后端自己的机器前缀追加进 machineGeneratedUserPrefixes
+//
+//	（session_resume.go）。注意归属：clawbench 注入的（所有后端都会
+//	遇到）如 [System Instructions: 等；claude 原生的（对其他后端是无害
+//	空转）如压缩头、斜杠命令、Caveat 等。下游（剥离器+标题判定器）
+//	自动同步——它们共用这一份列表。
+//
+// STEP 5 — Widen BOTH gates from `Backend == "claude"` to a registry. Two
+//
+//	call sites, both marked with "Backend support" comments:
+//	  a) ServeACPSessions (external list display titles)
+//	  b) deriveSessionTitleForAgent (acp-load import titles)
+//	Suggested shape:
+//
+// 第5步——把两处 `Backend == "claude"` 门控改为注册表分发。两个调用点都有
+//
+//	         "Backend support" 注释标记：(a) ServeACPSessions 外部列表展示标题
+//	         (b) deriveSessionTitleForAgent 导入标题。建议形态：
+//
+//		type transcriptResolver struct {
+//		    path        func(home, cwd, sessionID string) string
+//		    customTitle func(path string) string
+//		    firstAsk    func(path string) string
+//		}
+//		var transcriptResolvers = map[string]transcriptResolver{
+//		    "claude": {acpTranscriptPath, customTitleFromTranscript, firstRealQuestionFromTranscript},
+//		    "codex":  {codexTranscriptPath, codexCustomTitle, codexFirstRealQuestion},
+//		}
+//		// then in both gates:  if r, ok := transcriptResolvers[agent.Backend]; ok { ... }
+//
+// STEP 6 — Tests with REAL fixtures. Copy 3-5 lines from a REAL session,
+//
+//	anonymise any personal content (paths → /Users/x/..., questions →
+//	neutral text), and put them in the test the way
+//	acp_session_title_test.go builds claude fixtures (writeTranscript
+//	+ userTurnJSON). Cover: path resolution, first-question extraction,
+//	each machine prefix of that backend, and traversal rejection.
+//
+// 第6步——用真实样本写测试。从真实会话拷 3-5 行，个人内容全部匿名化
+//
+//	（路径→/Users/x/...，提问→中性文本），按 acp_session_title_test.go
+//	构造 claude 样本的方式（writeTranscript + userTurnJSON）放进测试。
+//	覆盖：路径解析、首问提取、该后端每个机器前缀、穿越拒绝。
+//
+// 已验证 vs 未验证：仅当本机存在该后端的真实转录并按上面六步做过测试，才把
+// 它加进注册表——不要提交未经验证的解析器（blind resolver）。
+// Verified-only rule: add a backend to the registry only after its REAL
+// transcripts exist locally and the six steps were followed — never ship a
+// blind, unverified resolver.
+// ═══════════════════════════════════════════════════════════════════════════
+// acpTranscriptPath returns the expected CLI transcript path for a session,
+// e.g. ~/.claude/projects/-Users-luo/<sessionId>.jsonl, or "" when the
+// inputs are insufficient or unsafe. sessionID comes from the ACP agent's
+// session/list response, so anything carrying path separators, traversal
+// segments or glob metacharacters is rejected outright.
+//
+// 返回会话 CLI 转录的预期路径，如 ~/.claude/projects/-Users-luo/<sessionId>.jsonl；
+// 输入不足或不安全时返回 ""。sessionID 来自 ACP agent 的 session/list 响应，
+// 故凡携带路径分隔符、穿越段（..）或 glob 元字符的一律直接拒绝（防路径穿越）。
+func acpTranscriptPath(home, cwd, sessionID string) string {
+	if home == "" || cwd == "" || sessionID == "" {
+		return ""
+	}
+	if strings.ContainsAny(sessionID, `/\`) || strings.Contains(sessionID, "..") ||
+		strings.ContainsAny(sessionID, "*?[]") {
+		return ""
+	}
+	munged := strings.ReplaceAll(cwd, "/", "-")
+	return filepath.Join(home, ".claude", "projects", munged, sessionID+".jsonl")
+}
+
+// transcriptContentText extracts the plain text from a claude-cli transcript
+// user-message "content" field, which claude-code writes in either of two
+// shapes:
+//   - a plain string: "content": "the question"
+//   - a list of blocks: "content": [{"type":"text","text":"..."}, ...]
+//
+// RawMessage is used so both shapes decode without error; this returns "" for
+// any other shape.
+//
+// 从 claude-cli 转录用户消息的 content 字段提取纯文本。claude-code 的 content
+// 有两种形式：纯字符串 "content":"问题"；或块列表 "content":[{type:text,text:...}]。
+// 用 RawMessage 解码使两种形式都不报错；其他形式返回 ""。
+func transcriptContentText(content json.RawMessage) string {
+	if len(content) == 0 {
+		return ""
+	}
+	// String form: starts with '"'.
+	if content[0] == '"' {
+		var s string
+		if err := json.Unmarshal(content, &s); err == nil {
+			return s
+		}
+		return ""
+	}
+	// List-of-blocks form.
+	var blocks []struct {
+		Type string `json:"type"`
+		Text string `json:"text"`
+	}
+	if err := json.Unmarshal(content, &blocks); err != nil {
+		return ""
+	}
+	raw := ""
+	for _, b := range blocks {
+		if b.Type == "text" {
+			raw += b.Text
+		}
+	}
+	return raw
+}
+
+// firstRealQuestionFromTranscript reads a transcript top-down, line by
+// line (each line = one JSON record), and returns the FIRST human input:
+//
+//	line 1  {"type":"summary",...}                    → skipped (not user)
+//	line 2  {"type":"user", content:"查看当前目录..."}  → candidate!
+//	        strip machine prefixes → "查看当前目录..." stays
+//	        → return it (capped by caller)
+//	line 3+ never reached
+//
+// A user line that is 100% machine text (compaction header, slash command)
+// is skipped and the scan continues. The content field appears as either a
+// plain string or a list of text blocks — transcriptContentText handles
+// both shapes, so neither form is missed.
+//
+// 只读扫描 CLI 转录，返回剥离机器前缀后的第一条人类输入（剥离规则见
+// stripMachineGeneratedUserText）。转录的 content 字段有两种形式（纯字符串 /
+// 文本块列表），由 transcriptContentText 统一处理。
+func firstRealQuestionFromTranscript(path string) string {
+	f, err := os.Open(path)
+	if err != nil {
+		return ""
+	}
+	defer func() { _ = f.Close() }()
+
+	scanner := bufio.NewScanner(f)
+	scanner.Buffer(make([]byte, 0, 64*1024), 16*1024*1024)
+	for scanner.Scan() {
+		var d struct {
+			Type    string `json:"type"`
+			Message *struct {
+				// Content is either a plain string ("the question") or a
+				// list of blocks [{type:"text",text:"..."},...]. claude-code
+				// uses both forms across versions/contexts, so decode as
+				// RawMessage and handle each shape.
+				// content 可能是纯字符串（"问题"），也可能是块列表
+				// [{type:"text",text:"..."}]。claude-code 在不同版本/场景
+				// 下两种形式都有，故用 RawMessage 解码后分别处理。
+				Content json.RawMessage `json:"content"`
+			} `json:"message"`
+		}
+		if err := json.Unmarshal(scanner.Bytes(), &d); err != nil || d.Type != "user" {
+			continue
+		}
+		if d.Message == nil {
+			continue
+		}
+		raw := transcriptContentText(d.Message.Content)
+		// Claude transcript first-question extraction strips with the claude
+		// rule set (universal + claude-native) — this whole function is the
+		// claude resolver's FirstQuestion implementation.
+		// claude 转录首问提取按 claude 规则集剥离(通用+claude 原生)——本函数
+		// 即 claude resolver 的 FirstQuestion 实现。
+		text, ok := stripMachineText(raw, stripRulesFor(claudeTranscriptResolver{}))
+		if !ok {
+			continue
+		}
+		if t := strings.TrimSpace(text); t != "" {
+			return t
+		}
+	}
+	return ""
+}
+
 func findExistingACPSessions(acpSessionIDs []string) map[string]bool {
 	if len(acpSessionIDs) == 0 {
 		return nil

--- a/internal/handler/session_resume.go
+++ b/internal/handler/session_resume.go
@@ -1,5 +1,35 @@
 package handler
 
+// ═════════════════════════════════════════════════════════════════════════════
+// MODULE 1 — UNIVERSAL TITLE CLEANING (backend-agnostic, works for EVERY
+// agent out of the box). Counterpart: session_title_resolver.go (Module 2,
+// per-backend optimization).
+//
+// What this module does for every backend, with zero backend-specific code:
+//
+//	deriveSessionTitleFromReplay — takes the first user message from the
+//	  ACP LoadSession replay (protocol-uniform; no files read) and strips
+//	  machine-generated prefixes to surface the real question.
+//	stripMachineText — the data-driven stripper core. Receives rules as
+//	  DATA ([]stripRule: prefix + removal strategy), loops trim→match→apply
+//	  until human text remains. Never reads files, never names a backend.
+//	clientInjectedStripRules — the default rule set: machine headers the
+//	  CLIENT prepends to user turns for ALL backends. An unregistered
+//	  backend gets exactly these rules and nothing else — no backend's
+//	  native rules leak into another backend's path.
+//
+// 模块一——通用标题清洗(与后端无关,对所有智能体开箱即用)。对应模块见
+// session_title_resolver.go(模块二,逐后端优化)。
+//   • deriveSessionTitleFromReplay — 取 ACP LoadSession 重放的首条用户消息
+//     (协议统一,不读文件),剥机器前缀得到真实首问。
+//   • stripMachineText — 数据驱动的剥离器核心。规则以数据传入([]stripRule:
+//     前缀+剥离策略),循环"修剪→匹配→套用"直到剩下人类文本。不读文件、
+//     不出现任何后端名。
+//   • clientInjectedStripRules — 默认规则集:客户端对所有后端注入的机器头。
+//     未注册后端恰好拿到这些规则、别无其他——任何后端的原生规则都不会泄入
+//     其他后端的路径。
+// ═════════════════════════════════════════════════════════════════════════════
+
 import (
 	"context"
 	"database/sql"
@@ -8,6 +38,7 @@ import (
 	"log/slog"
 	"net/http"
 	"runtime/debug"
+	"strings"
 	"time"
 
 	"clawbench/internal/ai"
@@ -26,6 +57,190 @@ const (
 	strError     = "error"
 	strToolUse   = "tool_use"
 )
+
+// maxReplayTitleRunes caps the session title derived from a replayed message.
+const maxReplayTitleRunes = 50
+
+// clientInjectedUserPrefixes are the headers the CLIENT (ClawBench) prepends
+// to user turns for EVERY backend — universal by construction.
+//
+// 客户端(ClawBench)对所有后端都注入的头部——天然通用。
+var clientInjectedUserPrefixes = []string{
+	"[System Instructions:",
+	"[Below is the conversation history",
+	"[Current file: ",
+	"[Current directory: ",
+	"[User uploaded ",
+}
+
+// machineGeneratedUserPrefixes is the combined list used for title
+// machine-text DETECTION (isMachineGeneratedTitle): client-injected (all
+// backends) + claude-native. The STRIPPER is now data-driven off
+// stripRule slices (see stripRulesFor), so this flat list is only for the
+// detector's truncation-tolerant prefix match.
+//
+// 机器文本"检测"所用的合并列表(客户端注入全后端 + claude 原生)。剥离器已改为
+// 由 stripRule 切片数据驱动(见 stripRulesFor),此扁平列表仅供检测器的容截断
+// 前缀匹配使用。
+var machineGeneratedUserPrefixes = append(append([]string{}, clientInjectedUserPrefixes...), claudeNativeUserPrefixes...)
+
+// stripKind enumerates how a machine prefix is removed from a user turn.
+//
+// 机器前缀从用户轮次中移除的方式。
+type stripKind int
+
+const (
+	// stripSkipTurn: the WHOLE turn is machine text (e.g. a compaction
+	// header, a slash command) — discard it, ok=false.
+	// 整轮皆为机器文本(如压缩头、斜杠命令)——丢弃,ok=false。
+	stripSkipTurn stripKind = iota
+	// stripToDoubleNewline: strip the prefix paragraph (up to "\n\n") and
+	// keep scanning the remainder (e.g. a caveat wrapper).
+	// 剥到 "\n\n" 为止,保留剩余继续扫(如 Caveat 警示段)。
+	stripToDoubleNewline
+	// stripToDelimiter: strip up to a fixed end-delimiter and keep scanning
+	// (e.g. "[Below is ...[End of conversation history...]<rest>").
+	// 剥到固定结束分隔符为止,保留剩余继续扫。
+	stripToDelimiter
+	// stripToBracketClose: strip a "[...]\n\n" block and keep scanning
+	// (e.g. "[System Instructions: ...]\n\n<rest>").
+	// 剥掉 "[...]\n\n" 块,保留剩余继续扫。
+	stripToBracketClose
+	// stripToNewline: strip one line (up to "\n") and keep scanning
+	// (e.g. "[Current file: ...]\n<rest>").
+	// 剥掉一行(到 "\n"),保留剩余继续扫。
+	stripToNewline
+)
+
+// stripRule pairs a machine prefix with its removal strategy. Both the
+// client-injected (universal) prefixes and each backend's native prefixes
+// become stripRules; the stripper itself is backend-agnostic and works off
+// a merged slice.
+//
+// stripRule 把机器前缀与其移除策略配对。客户端注入(通用)前缀与各后端原生前缀
+// 都变成 stripRule;剥离器本身与后端无关,只在一个合并切片上工作。
+type stripRule struct {
+	prefix    string
+	kind      stripKind
+	delimiter string // only for stripToDelimiter
+}
+
+// clientInjectedStripRules are the client (ClawBench) headers prepended to
+// user turns for EVERY backend — universal by construction.
+//
+// 客户端(ClawBench)对所有后端注入的头部——天然通用。
+var clientInjectedStripRules = []stripRule{
+	{"[System Instructions:", stripToBracketClose, ""},
+	{"[Below is the conversation history", stripToDelimiter, "[End of conversation history. Now answer the user's new question.]"},
+	{"[Current file: ", stripToNewline, ""},
+	{"[Current directory: ", stripToNewline, ""},
+	{"[User uploaded ", stripToNewline, ""},
+}
+
+// claudeNativeStripRules are the claude-code CLI's own machine headers
+// (claudeTranscriptResolver's strip rules). Harmless no-ops for other
+// backends (their turns never start with these).
+//
+// claude-code CLI 自己的机器头(claude 解析器的剥离规则)。对其他后端为无害
+// 空转(它们的轮次不会以这些开头)。
+var claudeNativeStripRules = []stripRule{
+	{"This session is being continued from a previous conversation", stripSkipTurn, ""},
+	{"<command-name>/", stripSkipTurn, ""},
+	{"<local-command", stripSkipTurn, ""},
+	{"Caveat: The messages below were generated by the user", stripToDoubleNewline, ""},
+	{"[Request interrupted", stripSkipTurn, ""},
+}
+
+// deriveSessionTitleFromReplay picks the acp-load session title from the
+// first user-typed message in the replay. Machine-generated headers are
+// stripped with the rule set for the given backend: universal
+// client-injected rules always, plus that backend's native rules via its
+// resolver. A nil resolver (backend not registered) uses universal rules
+// ONLY — no backend's native rules leak into another backend's path.
+//
+// 从重放(ACP replay)中取第一条人类输入作为标题。按给定后端的规则集剥机器
+// 前缀:始终含客户端通用注入规则,加上该后端经 resolver 的原生规则。resolver
+// 为 nil(未注册后端)时只用通用规则——任何后端的原生规则都不会泄入其他后端
+// 的路径。
+func deriveSessionTitleFromReplay(messages []replayMessage, r sessionTranscriptResolver) string {
+	rules := stripRulesFor(r)
+	for _, msg := range messages {
+		if msg.role != strUser {
+			continue
+		}
+		text, ok := stripMachineText(service.ExtractPlainText(msg.content), rules)
+		if !ok {
+			continue
+		}
+		title := strings.TrimSpace(text)
+		if title == "" {
+			continue
+		}
+		if runes := []rune(title); len(runes) > maxReplayTitleRunes {
+			title = string(runes[:maxReplayTitleRunes]) + "..."
+		}
+		return title
+	}
+	return ""
+}
+
+// stripMachineText is the data-driven stripper core: loop, trim, match a
+// rule prefix, apply its strategy; stop at the first non-machine text.
+// It receives rules as DATA — the function itself is backend-agnostic and
+// never reads files. Concrete before → after examples:
+//
+//	"[System Instructions: rules]\n\n如何配置自动备份"        → "如何配置自动备份"
+//	"[Current file: /tmp/a.png]\n看看这张图"                  → "看看这张图"
+//	"[Below is ...[End of conversation history...]新问题"      → "新问题"
+//	"This session is being continued..."(整轮,claude规则)     → ok=false
+//	"怎么导出数据库备份"(纯人话)                              → 原样返回,ok=true
+//
+// 数据驱动的剥离器核心:循环、修剪、匹配规则前缀、套用其策略;遇到非机器文本停止。
+// 规则以数据传入——函数本身与后端无关、不读任何文件。
+func stripMachineText(text string, rules []stripRule) (string, bool) {
+	for {
+		text = strings.TrimLeft(text, " \t\n")
+		matched := false
+		for _, r := range rules {
+			if !strings.HasPrefix(text, r.prefix) {
+				continue
+			}
+			matched = true
+			switch r.kind {
+			case stripSkipTurn:
+				return "", false
+			case stripToDoubleNewline:
+				idx := strings.Index(text, "\n\n")
+				if idx < 0 {
+					return "", false
+				}
+				text = text[idx+2:]
+			case stripToDelimiter:
+				idx := strings.Index(text, r.delimiter)
+				if idx < 0 {
+					return "", false
+				}
+				text = text[idx+len(r.delimiter):]
+			case stripToBracketClose:
+				idx := strings.Index(text, "]\n\n")
+				if idx < 0 {
+					return "", false
+				}
+				text = text[idx+3:]
+			case stripToNewline:
+				nl := strings.IndexByte(text, '\n')
+				if nl < 0 {
+					return "", false
+				}
+				text = text[nl+1:]
+			}
+			break // re-loop from the trimmed remainder
+		}
+		if !matched {
+			return text, true
+		}
+	}
+}
 
 // getOrCreateConnForLoadFn is the function signature for obtaining an ACP
 // connection for loading a session. Used to allow test overrides.
@@ -311,19 +526,12 @@ func ServeACPLoadSession(w http.ResponseWriter, r *http.Request) {
 		}
 		persistReplayMessages(sessionID, projectPath, agent.Backend, messages)
 
-		// Set session title from first user message
-		for _, msg := range messages {
-			if msg.role == strUser {
-				title := service.ExtractPlainText(msg.content)
-				if title != "" {
-					if runes := []rune(title); len(runes) > 50 {
-						title = string(runes[:50]) + "..."
-					}
-					if err := service.UpdateSessionTitle(sessionID, title); err != nil {
-						slog.Warn("handler: failed to set title for acp-load session", "session_id", sessionID, "error", err)
-					}
-				}
-				break
+		// Set session title from the first real user-typed message,
+		// skipping machine-generated user turns (see
+		// deriveSessionTitleFromReplay).
+		if title := deriveSessionTitleForAgent(agent, projectPath, req.AcpSessionID, messages); title != "" {
+			if err := service.UpdateSessionTitle(sessionID, title); err != nil {
+				slog.Warn("handler: failed to set title for acp-load session", "session_id", sessionID, "error", err)
 			}
 		}
 

--- a/internal/handler/session_resume_test.go
+++ b/internal/handler/session_resume_test.go
@@ -1180,6 +1180,223 @@ func TestServeACPLoadSession_ReplayWithTitleTruncation(t *testing.T) {
 	assert.True(t, strings.HasSuffix(title, "..."), "truncated title should end with '...'")
 }
 
+func TestServeACPLoadSession_ReplayTitleSkipsInjectedSystemBlock(t *testing.T) {
+	env, teardown := setupTestEnv(t)
+	defer teardown()
+
+	agentID := "acp-load-skip-injected"
+	acpSessionID := "acp-sid-skip-injected"
+	model.Agents = map[string]*model.Agent{
+		agentID: {ID: agentID, Name: "ACP SkipInjected", Backend: "claude", Transport: "acp-stdio", AcpCommand: "echo"},
+	}
+	model.AgentList = []*model.Agent{model.Agents[agentID]}
+
+	ai.GetAgentCapabilityRegistry().ForceUpdateIfNeeded(agentID, nil, nil, nil, nil, nil, true, false)
+
+	mgr := ai.GetACPConnManager()
+	agent := model.Agents[agentID]
+	mockConn := ai.NewACPConnForTest(agent, "mock-session-skip")
+	mockConn.SetAliveForTest()
+	mockConn.SetSessionMappingForTest("mock-session-skip", acpSessionID)
+
+	// ClawBench-origin sessions carry the [System Instructions: ...] block
+	// prepended by buildPromptBlocks at the start of their first user turn,
+	// with the user's actual message after it.
+	client := ai.NewClawBenchACPClient()
+	client.SetLoadSessionBufForTest([]acp.SessionNotification{
+		{
+			Update: acp.SessionUpdate{
+				UserMessageChunk: &acp.SessionUpdateUserMessageChunk{
+					Content: acp.TextBlock("[System Instructions: repo coding rules]\n\n帮忙解释一下这个报错日志"),
+				},
+			},
+		},
+	})
+	mockConn.SetClientForTest(client)
+
+	origFn := getOrCreateConnForLoad
+	getOrCreateConnForLoad = func(ctx context.Context, ag *model.Agent, clawbenchSID, acpSID, cwd string) (*ai.ACPConn, error) {
+		mgr.SetConnForTest(clawbenchSID, mockConn)
+		return mockConn, nil
+	}
+	defer func() { getOrCreateConnForLoad = origFn }()
+
+	body := fmt.Sprintf(`{"agentId":%q,"acpSessionId":%q}`, agentID, acpSessionID)
+	req := httptest.NewRequest(http.MethodPost, "/api/ai/session/acp-load", strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	withProjectCookie(req, env.ProjectDir)
+	w := httptest.NewRecorder()
+	ServeACPLoadSession(w, req)
+
+	assert.Equal(t, http.StatusOK, w.Code)
+
+	var resp map[string]any
+	err := json.Unmarshal(w.Body.Bytes(), &resp)
+	require.NoError(t, err)
+	sid := resp["sessionId"].(string)
+
+	require.Eventually(t, func() bool {
+		var title string
+		err := service.UnsafeDBForTest().QueryRow(
+			"SELECT title FROM chat_sessions WHERE id = ?",
+			sid,
+		).Scan(&title)
+		return err == nil && title != ""
+	}, 3*time.Second, 50*time.Millisecond, "title should be set after replay completes")
+
+	var title string
+	err = service.UnsafeDBForTest().QueryRow(
+		"SELECT title FROM chat_sessions WHERE id = ?",
+		sid,
+	).Scan(&title)
+	assert.NoError(t, err)
+	assert.Equal(t, "帮忙解释一下这个报错日志", title)
+	assert.NotContains(t, title, "System Instructions")
+}
+
+func TestDeriveSessionTitleFromReplay(t *testing.T) {
+	userMsg := func(text string) replayMessage {
+		return replayMessage{
+			role:    strUser,
+			content: fmt.Sprintf(`{"blocks":[{"type":"text","text":%q}]}`, text),
+		}
+	}
+	assistantMsg := replayMessage{role: strAssistant, content: `{"blocks":[{"type":"text","text":"answer"}]}`}
+
+	t.Run("strips injected system block and keeps user text", func(t *testing.T) {
+		msgs := []replayMessage{
+			userMsg("[System Instructions: repo coding rules]\n\n用户的第一句话"),
+			assistantMsg,
+		}
+		assert.Equal(t, "用户的第一句话", deriveSessionTitleFromReplay(msgs, nil))
+	})
+
+	t.Run("bare injected block without user text is skipped", func(t *testing.T) {
+		msgs := []replayMessage{
+			userMsg("[System Instructions: rules]\n\n"),
+			assistantMsg,
+			userMsg("第二个真实问题"),
+		}
+		assert.Equal(t, "第二个真实问题", deriveSessionTitleFromReplay(msgs, nil))
+	})
+
+	t.Run("strips file reference header and keeps user text", func(t *testing.T) {
+		msgs := []replayMessage{
+			userMsg("[Current file: /tmp/a.png]\n看看这个截图"),
+		}
+		assert.Equal(t, "看看这个截图", deriveSessionTitleFromReplay(msgs, nil))
+	})
+
+	t.Run("interruption marker without user text is skipped", func(t *testing.T) {
+		msgs := []replayMessage{
+			userMsg("[Request interrupted by user for tool use]"),
+			userMsg("继续刚才的问题"),
+		}
+		assert.Equal(t, "继续刚才的问题", deriveSessionTitleFromReplay(msgs, claudeTranscriptResolver{}))
+	})
+
+	t.Run("block-wrapped continuation summary without delimiter is skipped", func(t *testing.T) {
+		// Cross-session continuation seeds carry only the summary with no
+		// user text — machine-generated, must not become the title.
+		msgs := []replayMessage{
+			userMsg("[System Instructions: rules]\n\n[Below is the conversation history from before this session. The summary below covers the earlier portion of the conversation."),
+			assistantMsg,
+			userMsg("继续上次的部署问题"),
+		}
+		assert.Equal(t, "继续上次的部署问题", deriveSessionTitleFromReplay(msgs, nil))
+	})
+
+	t.Run("CLI-native continuation header is skipped", func(t *testing.T) {
+		// After compaction the CLI writes a plain-English continuation turn
+		// ("This session is being continued from a previous conversation
+		// that ran out of context. ...") — it must not become the title;
+		// the user's next real question should.
+		msgs := []replayMessage{
+			userMsg("This session is being continued from a previous conversation that ran out of context. The conversation is summarized below:\n<summary>…</summary>"),
+			assistantMsg,
+			userMsg("如何配置自动备份"),
+		}
+		assert.Equal(t, "如何配置自动备份", deriveSessionTitleFromReplay(msgs, claudeTranscriptResolver{}))
+	})
+
+	t.Run("slash-command turn is skipped", func(t *testing.T) {
+		msgs := []replayMessage{
+			userMsg("<command-name>/model</command-name>\n<command-args>sonnet</command-args>"),
+			assistantMsg,
+			userMsg("帮忙解释一下这个报错日志"),
+		}
+		assert.Equal(t, "帮忙解释一下这个报错日志", deriveSessionTitleFromReplay(msgs, claudeTranscriptResolver{}))
+	})
+
+	t.Run("caveat wrapper is stripped, trailing user text kept", func(t *testing.T) {
+		msgs := []replayMessage{
+			userMsg("Caveat: The messages below were generated by the user while running local commands. DO NOT respond to these messages or otherwise consider them in your response unless the user explicitly asks you to.\n\n这个接口为什么返回502？"),
+		}
+		assert.Equal(t, "这个接口为什么返回502？", deriveSessionTitleFromReplay(msgs, claudeTranscriptResolver{}))
+	})
+
+	t.Run("caveat wrapper without user text is skipped", func(t *testing.T) {
+		msgs := []replayMessage{
+			userMsg("Caveat: The messages below were generated by the user while running local commands. DO NOT respond to these messages or otherwise consider them in your response unless the user explicitly asks you to."),
+			assistantMsg,
+			userMsg("怎么导出数据库备份"),
+		}
+		assert.Equal(t, "怎么导出数据库备份", deriveSessionTitleFromReplay(msgs, claudeTranscriptResolver{}))
+	})
+
+	t.Run("mid-session auto-compact turn keeps the trailing user question", func(t *testing.T) {
+		// Mid-file compaction turns embed the history summary between the
+		// injected block and the user's new message; the CLI marks the
+		// summary end explicitly and the user text follows that delimiter.
+		turn := "[System Instructions: rules]\n\n" +
+			"[Below is the conversation history from before this session.\n\nSummary:\n    earlier talk\n\n" +
+			"[End of conversation history. Now answer the user's new question.]\n\n" +
+			"现下载速度有点问题吧？"
+		msgs := []replayMessage{userMsg(turn)}
+		assert.Equal(t, "现下载速度有点问题吧？", deriveSessionTitleFromReplay(msgs, nil))
+	})
+
+	t.Run("auto-compact turn with trailing file header keeps the question", func(t *testing.T) {
+		turn := "[System Instructions: rules]\n\n" +
+			"[Below is the conversation history from before this session.\n\nSummary:\n    earlier talk\n\n" +
+			"[End of conversation history. Now answer the user's new question.]\n\n" +
+			"[Current file: /tmp/example.png]\n这个接口为什么返回502？"
+		msgs := []replayMessage{userMsg(turn)}
+		assert.Equal(t, "这个接口为什么返回502？", deriveSessionTitleFromReplay(msgs, nil))
+	})
+
+	t.Run("assistant-only replay yields empty title", func(t *testing.T) {
+		assert.Equal(t, "", deriveSessionTitleFromReplay([]replayMessage{assistantMsg}, nil))
+	})
+
+	t.Run("truncates long titles to 50 runes", func(t *testing.T) {
+		long := strings.Repeat("很", 60)
+		got := deriveSessionTitleFromReplay([]replayMessage{userMsg(long)}, nil)
+		assert.Equal(t, strings.Repeat("很", 50)+"...", got)
+	})
+
+	t.Run("blank user turn is skipped", func(t *testing.T) {
+		msgs := []replayMessage{
+			userMsg("   \n\t"),
+			userMsg("真实问题"),
+		}
+		assert.Equal(t, "真实问题", deriveSessionTitleFromReplay(msgs, nil))
+	})
+}
+
+func TestStripMachineGeneratedUserText(t *testing.T) {
+	t.Run("plain user text passes through", func(t *testing.T) {
+		got, ok := stripMachineText("普通消息", stripRulesFor(nil))
+		assert.True(t, ok)
+		assert.Equal(t, "普通消息", got)
+	})
+
+	t.Run("malformed system block prefix without terminator is dropped", func(t *testing.T) {
+		_, ok := stripMachineText("[System Instructions: no closing marker", stripRulesFor(nil))
+		assert.False(t, ok)
+	})
+}
+
 // --- helper functions ---
 
 // newACPConnForHandlerTest creates an *ai.ACPConn for handler-level testing.

--- a/internal/handler/session_title_resolver.go
+++ b/internal/handler/session_title_resolver.go
@@ -1,0 +1,137 @@
+package handler
+
+// ─────────────────────────────────────────────────────────────────────────────
+// ═════════════════════════════════════════════════════════════════════════
+// MODULE 2 — BACKEND-SPECIFIC TITLE OPTIMIZATION (per-agent enhancement
+// over Module 1's universal cleaning; see session_resume.go). Today this
+// ships the claude-code resolver: transcript reading for exact first
+// questions on compacted sessions, custom-title lookup, and claude-native
+// strip rules. Other backends plug in the same way — implement the four
+// methods, register, done. Unregistered backends simply keep Module 1's
+// universal behavior.
+//
+// 模块二——后端专属标题优化(在模块一的通用清洗之上做逐后端增强,见
+// session_resume.go)。当前内置 claude-code 解析器:读转录以在压缩会话上取
+// 精确首问、custom-title 查询、claude 原生剥离规则。其他后端以同样方式接入
+// ——实现四个方法、注册即完成。未注册后端保持模块一的通用行为。
+// ═════════════════════════════════════════════════════════════════════════
+//
+// STANDARD INPUT BLOCK — decoupling contract between the session-title module
+// and any agent backend's on-disk data structures.
+//
+// The title-fix module (tier order, capping, machine-title suppression) is
+// backend-agnostic. Everything backend-specific is reduced to THIS interface:
+// implement four methods, register under the backend name, and the whole
+// module works for that backend — both the external session list display and
+// the acp-load import path pick it up automatically.
+//
+// 标准输入块——会话标题模块与任意智能体后端磁盘数据结构的解耦契约。
+// 标题模块本身（层级顺序、截断、机器标题抑制）与后端无关；所有后端相关的
+// 部分被收敛为本接口：实现四个方法、按后端名注册，整个模块即对该后端生效
+// ——外部会话列表展示与 acp-load 导入两条路径都会自动接入。
+//
+// To add a backend (e.g. codex, opencode):
+//  1. Locate its transcript storage with REAL data (run the CLI, find where
+//     session files appear; note the dir pattern and how cwd is encoded).
+//  2. Implement the four methods below as a thin adapter over its path rules
+//     and transcript schema, mirroring claudeTranscriptResolver.
+//  3. Register it in sessionTranscriptResolvers.
+// Only register backends verified against REAL transcripts — never ship a
+// blind resolver (see the fuller guide above acpTranscriptPath in agent.go).
+//
+// 新增后端（如 codex、opencode）：
+//  1. 用真实数据定位其转录存储（跑一次 CLI，找到会话文件位置；记下目录规律
+//     与 cwd 编码方式）。
+//  2. 按其路径规则与转录格式实现下方四方法的薄适配层，仿 claudeTranscriptResolver。
+//  3. 在 sessionTranscriptResolvers 注册。
+// 仅注册经真实转录验证过的后端——禁止提交未经验证的盲解析器（完整指南见
+// agent.go 中 acpTranscriptPath 上方注释块）。
+// ─────────────────────────────────────────────────────────────────────────────
+
+// sessionTranscriptResolver is the standard input block: everything the
+// title module needs to know about one backend's session storage.
+//
+// 会话转录解析器即标准输入块：标题模块需要知道的关于某后端会话存储的全部。
+type sessionTranscriptResolver interface {
+	// TranscriptPath locates the backend's transcript file for a session.
+	// Return "" when no transcript exists. sessionID comes from the wire —
+	// implementations MUST reject IDs carrying path separators, traversal
+	// segments or glob metacharacters (see acpTranscriptPath).
+	//
+	// 定位该后端的会话转录文件；无则返回 ""。sessionID 来自网络输入——
+	// 实现必须拒绝含路径分隔符、穿越段或 glob 元字符的 ID（见 acpTranscriptPath）。
+	TranscriptPath(home, cwd, sessionID string) string
+
+	// CustomTitle returns the title the backend itself persisted for the
+	// session (a user rename or auto-generated topic name), "" when none.
+	//
+	// 返回后端自身为会话持久化的标题（用户改名或自动生成的主题名），无则 ""。
+	CustomTitle(path string) string
+
+	// FirstQuestion returns the first human-typed message from the
+	// transcript, with machine-generated prefixes stripped, "" when none.
+	//
+	// 返回转录中第一条人类输入（剥离机器前缀后），无则 ""。
+	FirstQuestion(path string) string
+
+	// StripRules returns THIS backend's native machine-prefix strip rules
+	// (compaction headers, slash-command wrappers, local-command caveats,
+	// ...). They add to clientInjectedStripRules (which the client prepends
+	// for every backend) and feed the data-driven stripper. Harmless no-ops
+	// for other backends.
+	//
+	// 返回该后端原生的机器前缀剥离规则（压缩头、斜杠命令包装、本地命令警示
+	// 等）。叠加在客户端对所有后端注入的 clientInjectedStripRules 之上，喂给
+	// 数据驱动剥离器。对其他后端为无害空转。
+	StripRules() []stripRule
+}
+
+// sessionTranscriptResolvers maps backend name → resolver. Backends absent
+// from this map fall back to the backend-agnostic ACP-replay derivation.
+//
+// 后端名 → 解析器注册表。未注册的后端回退到与后端无关的 ACP 重放派生。
+var sessionTranscriptResolvers = map[string]sessionTranscriptResolver{
+	"claude": claudeTranscriptResolver{},
+}
+
+// transcriptResolverFor looks up the resolver for a backend; nil when the
+// backend has none registered.
+//
+// 按后端名查解析器；未注册返回 nil。
+func transcriptResolverFor(backend string) sessionTranscriptResolver {
+	return sessionTranscriptResolvers[backend]
+}
+
+// machinePrefixesFor returns the full machine-prefix list used for title
+// detection for a backend: the client-injected universal set plus the
+// backend's native prefixes.
+//
+// 返回该后端标题判定所用的完整机器前缀列表：客户端注入的通用集 + 该后端
+// 的原生前缀。
+// stripRulesFor returns the full strip-rule set for a backend: the
+// client-injected universal rules plus the backend's native rules. The
+// detector (isMachineGeneratedTitleFor) derives its flat prefix list from
+// these rules too.
+//
+// 返回某后端的完整剥离规则集:客户端通用注入规则 + 该后端原生规则。检测器
+// (isMachineGeneratedTitleFor) 的扁平前缀列表也由此推导。
+func stripRulesFor(r sessionTranscriptResolver) []stripRule {
+	rules := append([]stripRule{}, clientInjectedStripRules...)
+	if r != nil {
+		rules = append(rules, r.StripRules()...)
+	}
+	return rules
+}
+
+// machinePrefixesFor returns the flat prefix list used for title
+// machine-text DETECTION, derived from stripRulesFor (prefixes only).
+//
+// 返回标题机器文本"检测"用的扁平前缀列表,由 stripRulesFor 推导(仅取前缀)。
+func machinePrefixesFor(r sessionTranscriptResolver) []string {
+	rules := stripRulesFor(r)
+	prefixes := make([]string, len(rules))
+	for i, r := range rules {
+		prefixes[i] = r.prefix
+	}
+	return prefixes
+}


### PR DESCRIPTION
## Problem / 问题

Both session lists showed machine text or inconsistent titles instead of the user's real question.

两个列表都显示机器文本或互相不一致的标题,而不是用户的真实提问。

**List 1 — "会话搜索" (imported/acp-load):** the title was taken from the first *replayed* user turn, which starts with the injected block:
**列表一"会话搜索"(导入):** 标题取自重放的首个用户轮次,而它以注入块开头:

```
[System Instructions: ## User Interaction ...
                   ...1500 chars of rules...]
真正的提问被顶到 200 字截断之外 → 标题 = 注入的提示词碎片
```

**List 2 — "外部会话" (external):** the CLI's session/list reports *some* user message — measured on a real machine: of 22 sessions, 8 titles were the LAST message, 9 a middle one, 1 the first. So trusting the reported title shows e.g. the last message `再确认一下参数` while the imported list shows the first question `帮我看看当前的配置文件在哪` — same session, two different titles.

**列表二"外部会话":** CLI 经 session/list 上报的是"某条"用户消息——实机测量 22 个会话:8 个标题=末问,9 个=中间某条,仅 1 个=首问。于是出现同一会话两边标题不同:外部显示末问 `再确认一下参数`,导入侧显示首问 `查看一下当前目录最近的会话是什么?`。

## Root cause / 根因

1. The two lists used **two different data sources**: the import path titled from the ACP *replay* (only the CLI's CURRENT in-context history — for a session compacted N times the original first question is already summarized away), while the external list trusted the *reported* title (an unpredictable user message).
2. No layer stripped machine-generated headers, and the transcript parser missed the plain-string `content` shape (claude-code writes both a string and a block list).

1. 两个列表用了**两个不同数据源**:导入路径从 ACP *重放*取标题(重放只含 CLI 当前上下文——压缩过 N 次的会话其原始首问早被摘要替换);外部列表则信任*上报*标题(不可预测的某条用户消息)。
2. 没有层剥离机器生成头部;转录解析器漏掉了 `content` 的纯字符串形式(claude-code 两种形式都写)。

## Fix — one function, one code path / 修复——一个函数,一条代码路径

Both lists now call the SAME function `acpDisplayTitleFromHome`. Walkthrough per session:

两个列表现在调用**同一个**函数 `acpDisplayTitleFromHome`。每个会话的执行步骤:

```
STEP 1  locate transcript:  ~/.claude/projects/-Users-x-Desktop-myproject/<sid>.jsonl
        (slashes→'-'; miss → global lookup by sid)
        第1步 定位转录文件(斜杠转横杠;找不到按 sid 全局搜)

STEP 2  newest "custom-title" line?                       CLI 的权威命名
        {"type":"custom-title","customTitle":"weekend-hiking-plan"}
        → use it. DONE.                                     第2步 有则直接用,结束

STEP 3  first REAL question, top-down:                     第3步 逐行找首问
        skip assistant lines; strip machine prefixes:
          "[System Instructions: rules]\n\n如何配置自动备份" → "如何配置自动备份"
          whole-turn machine text (compaction header) → skip line
        content 两种形式(纯字符串/块列表)都能解            → use it. DONE.

STEP 4  nothing readable → reported title, but only if human;
        machine → "" (never display noise)                 第4步 兜底:宁空勿噪
```

The import path (acp-load) calls the same function with `agentTitle=""` (it has no session/list RPC), so titles stay **byte-identical** while cycling a session between the two lists.

导入路径(acp-load)以 `agentTitle=""` 调用同一函数(它没有 session/list RPC),会话在两列表间循环时标题**逐字节一致**。

`machineGeneratedUserPrefixes` is the single source of truth shared by the stripper and the machine-title detector (truncation-tolerant), locked by `TestMachinePrefixesMatchStrip`.

`machineGeneratedUserPrefixes` 是剥离器与机器标题检测器共用的唯一标记源(容忍截断),由 `TestMachinePrefixesMatchStrip` 锁定同步。

## Tests / 测试

~30 cases: prefix stripping (before/after table in code comments), tier order, custom-title precedence, string-content parsing, path-traversal rejection, replay fallback, cross-project transcript lookup. `go test ./internal/handler/` all green.

约 30 个用例:前缀剥离(代码注释里有前后对照表)、层级顺序、custom-title 优先、字符串 content 解析、路径穿越拒绝、重放兜底、跨项目转录查找。`go test ./internal/handler/` 全绿。

## Real-machine verification / 实机验证

22/22 external sessions now show exactly the transcript-derived title (custom-title or first question); a previously-broken session went from last-message `再确认一下参数` to first question; the 36×-compacted 82MB session shows its CLI topic title `weekend-hiking-plan` in both lists, stable across download/remove cycles.

实机 22/22 个外部会话标题与转录预期完全一致;此前出错的一个会话从末问 `再确认一下参数` 修正为首问;压缩 36 次、82MB 的会话两列表都显示 CLI 主题名 `weekend-hiking-plan`,循环不移不变。

🤖 Generated with [Claude Code](https://claude.com/claude-code)