### PR TITLE
fix(pdf): use pdfjs-dist legacy builds for older WebView support

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -212,7 +212,14 @@ export default defineConfig({
       output: {
         manualChunks: {
           'vendor-vue': ['vue', 'vue-i18n'],
-          'vendor-pdf': ['pdfjs-dist'],
+          // Keep the legacy pdfjs module in the vendor-pdf chunk (matching
+          // subpath, not the bare 'pdfjs-dist' specifier) so the library
+          // stays in one cacheable, separately-testable chunk instead of
+          // being inlined into the per-component pdf chunk.
+          // 让 legacy 版 pdfjs 落入 vendor-pdf 独立 chunk（匹配子路径而非裸
+          // 'pdfjs-dist' 指定符），使库保持单个可缓存、可独立测试的 chunk，
+          // 而不是内联进组件级 pdf chunk。
+          'vendor-pdf': ['pdfjs-dist', 'pdfjs-dist/legacy/build/pdf.mjs'],
           'vendor-diff': ['diff'],
           'vendor-purify': ['dompurify'],
           'vendor-redoc': ['redoc'],

--- a/web/src/components/media/PdfPreview.vue
+++ b/web/src/components/media/PdfPreview.vue
@@ -164,8 +164,28 @@ async function loadPdf() {
   renderedPages.clear()
 
   try {
-    const pdfjsLib = await import('pdfjs-dist')
-    const workerUrl = await import('pdfjs-dist/build/pdf.worker.min.mjs?url')
+    // Use pdfjs-dist's *legacy* builds, which bundle core-js polyfills for
+    // older engines (mobile WebViews, older Chrome). The modern build hard
+    // requires very new APIs on both the main thread and inside the worker:
+    // URL.parse (Chromium 126+), Promise.try (134+) and — fatally for
+    // parsing, because the worker computes PDF fingerprints with it —
+    // Uint8Array.prototype.toHex (Chromium 133+ / Node 22+). On engines
+    // below that, opening a PDF throws "URL.parse is not a function" or
+    // hangs forever with the spinner ("a.toHex is not a function" inside
+    // the worker). The worker must come from the same legacy tree, or the
+    // handshake still dies mid-parse. Cost: worker grows ~50KB (core-js).
+    //
+    // 改用 pdfjs-dist 的 *legacy* 构建（内嵌 core-js polyfill，兼容旧引擎：
+    // 手机 WebView、旧版 Chrome）。现代构建在主线程和 worker 两侧都硬依赖极新
+    // 的 API：URL.parse（Chromium 126+）、Promise.try（134+），以及最致命的
+    // Uint8Array.prototype.toHex（Chromium 133+ / Node 22+）——worker 计算 PDF
+    // 指纹（calculateMD5(...).toHex()）必经此路径。低于上述版本的引擎上，打开
+    // PDF 要么抛 "URL.parse is not a function"，要么永久转圈（worker 内
+    // "a.toHex is not a function"）。主线程模块与 worker 必须来自同一 legacy
+    // 树，混用会导致握手中途失败。代价：worker 增大约 50KB（core-js）。
+    // 在新引擎上 polyfill 经特性检测为无操作，行为零变化。
+    const pdfjsLib = await import('pdfjs-dist/legacy/build/pdf.mjs')
+    const workerUrl = await import('pdfjs-dist/legacy/build/pdf.worker.min.mjs?url')
     pdfjsLib.GlobalWorkerOptions.workerSrc = workerUrl.default || workerUrl
 
     const loadingTask = pdfjsLib.getDocument(mediaUrl.value)

--- a/web/src/components/media/__tests__/PdfPreview.test.ts
+++ b/web/src/components/media/__tests__/PdfPreview.test.ts
@@ -15,12 +15,12 @@ vi.mock('@/utils/download.ts', () => ({
 
 // Mock pdfjs-dist. getDocument's return value is set per-test so existing
 // tests (which never resolve a document) keep failing over to the error path.
-vi.mock('pdfjs-dist', () => ({
+vi.mock('pdfjs-dist/legacy/build/pdf.mjs', () => ({
   GlobalWorkerOptions: {},
   getDocument: vi.fn(),
 }))
 
-vi.mock('pdfjs-dist/build/pdf.worker.min.mjs?url', () => ({
+vi.mock('pdfjs-dist/legacy/build/pdf.worker.min.mjs?url', () => ({
   default: 'mock-worker-url',
 }))
 
@@ -131,7 +131,7 @@ describe('PdfPreview', () => {
       destroy: vi.fn(),
     }
 
-    const pdfjs = await import('pdfjs-dist')
+    const pdfjs = await import('pdfjs-dist/legacy/build/pdf.mjs')
     ;(pdfjs.getDocument as any).mockReturnValue({ promise: Promise.resolve(fakeDoc) })
 
     const wrapper = mountPdf()

--- a/web/src/components/media/__tests__/pdfLegacyEngine.test.ts
+++ b/web/src/components/media/__tests__/pdfLegacyEngine.test.ts
@@ -1,0 +1,69 @@
+// @vitest-environment jsdom
+import { describe, expect, it, vi } from 'vitest'
+
+// pdfjs-dist's legacy build unconditionally requires a native canvas module
+// when it detects Node (we only parse, never render). Stub it so the test
+// does not load @napi-rs/canvas's native bindings and leak a GC handle into
+// the worker process.
+vi.mock('@napi-rs/canvas', () => new Proxy({}, {
+  get: () => { throw new Error('canvas not needed in this test') },
+}))
+
+// Regression test for the PDF preview on older engines (mobile WebViews,
+// Chromium < 133).
+// 旧引擎（手机 WebView、Chromium < 133）上 PDF 预览的回归测试。 pdfjs-dist's modern build hard-requires
+// Uint8Array.prototype.toHex (worker-side, used for PDF fingerprints),
+// URL.parse and Promise.try. PdfPreview therefore imports the *legacy*
+// builds, which bundle core-js polyfills. This test simulates an old engine
+// by deleting those APIs before the legacy build is imported and verifies
+// that (a) the build restores them and (b) a document still parses.
+
+/** Build a structurally valid single-page PDF with a correct xref table. */
+function buildMinimalPdf(): Uint8Array {
+  const objects = [
+    '<</Type/Catalog/Pages 2 0 R>>',
+    '<</Type/Pages/Kids[3 0 R]/Count 1>>',
+    '<</Type/Page/Parent 2 0 R/MediaBox[0 0 200 200]>>',
+  ]
+  let pdf = '%PDF-1.4\n'
+  const offsets: number[] = []
+  objects.forEach((body, i) => {
+    offsets.push(pdf.length)
+    pdf += `${i + 1} 0 obj${body}endobj\n`
+  })
+  const startxref = pdf.length
+  pdf += `xref\n0 ${objects.length + 1}\n0000000000 65535 f \n`
+  for (const off of offsets) pdf += `${String(off).padStart(10, '0')} 00000 n \n`
+  pdf += `trailer<</Size ${objects.length + 1}/Root 1 0 R>>\nstartxref\n${startxref}\n%%EOF`
+  return new TextEncoder().encode(pdf)
+}
+
+describe('pdfjs legacy build on an old engine', () => {
+  it('self-polyfills missing Uint8Array.prototype.toHex and URL.parse, then parses a PDF', async () => {
+    const proto = Uint8Array.prototype as unknown as Record<string, unknown>
+    const savedToHex = proto.toHex
+    const savedParse = URL.parse
+    delete proto.toHex
+    ;(URL as unknown as Record<string, unknown>).parse = undefined
+    expect(proto.toHex).toBeUndefined()
+    expect(URL.parse).toBeUndefined()
+
+    try {
+      // Fresh module graph so core-js installs its polyfills now, with the
+      // APIs missing — exactly like a first load on an old WebView.
+      vi.resetModules()
+      const pdfjs = await import('pdfjs-dist/legacy/build/pdf.mjs')
+
+      expect(typeof proto.toHex).toBe('function')
+      expect(typeof URL.parse).toBe('function')
+
+      const doc = await pdfjs.getDocument({ data: buildMinimalPdf() }).promise
+      expect(doc.numPages).toBe(1)
+    } finally {
+      if (savedToHex === undefined) delete proto.toHex
+      else proto.toHex = savedToHex
+      if (savedParse === undefined) delete (URL as any).parse
+      else URL.parse = savedParse
+    }
+  })
+})


### PR DESCRIPTION
## Symptom / 症状

| Engine | Result |
|---|---|
| Huawei WebView (app) | `PDF 加载失败 URL.parse is not a function` |
| Chrome < 133 (mobile) | infinite spinner |
| Chrome ≥ 133 | works (this is why it looks "random") |

| 引擎 | 表现 |
|---|---|
| 华为 WebView(app) | `PDF 加载失败 URL.parse is not a function` |
| Chrome < 133(手机) | 永久转圈 |
| Chrome ≥ 133 | 正常(所以问题看起来"看机型") |

## Root cause / 根因

pdf.js runs in TWO separate JS contexts — the main thread and a Web Worker (a different file, different global object; a polyfill installed on the page never reaches it). The modern build hard-requires very new APIs on BOTH sides:

pdf.js 跑在**两个隔离的 JS 上下文**里——主线程和 Web Worker(不同文件、不同全局对象;装在页面上的 polyfill 根本到不了 worker)。现代构建在两侧都硬依赖极新的 API:

| Missing API | Needs | Side | Effect |
|---|---|---|---|
| `Uint8Array.prototype.toHex` | Chromium 133+ / Node 22+ | **worker** — every PDF parse computes a fingerprint `calculateMD5(...).toHex()` | fatal: parse always dies |
| `URL.parse` | Chromium 126+ | both | throws on open |
| `Promise.try` | Chromium 134+ | main | throws on open |
| `Promise.withResolvers` | Chromium 119+ | both | throws on open |

Verified in a headless Chromium with `toHex` deleted: the modern chunks reject with `a.toHex is not a function`.

在删掉 `toHex` 的无头 Chromium 实测:现代构建以 `a.toHex is not a function` 拒绝。

## Fix / 修复

Two import lines change to pdfjs-dist's **legacy** builds (same version, same features, pre-compiled for old engines with core-js bundled INSIDE both the main module and the worker — the pdf.js-supported path):

两行 import 改为 pdfjs-dist 的 **legacy** 构建(同版本同功能,面向旧引擎预编译,core-js 内嵌在主模块和 worker 两侧——pdf.js 官方支持的旧引擎路径):

```
import('pdfjs-dist/legacy/build/pdf.mjs')                    ← main thread 主线程
import('pdfjs-dist/legacy/build/pdf.worker.min.mjs?url')     ← worker (same tree! 必须同树)
```

On an old engine the worker self-polyfills at startup (feature-detected); on a new engine the polyfills are no-ops — zero behavior change. The worker must come from the SAME legacy tree as the main module, otherwise the handshake dies mid-parse.

旧引擎上 worker 启动时自我补齐(特性检测);新引擎上 polyfill 为空操作——行为零变化。worker 必须与主模块来自**同一** legacy 树,否则握手中途失败。

Also keeps the legacy module in the `vendor-pdf` manual chunk (cacheable, separately testable). Cost: worker 1.23 MB → 1.29 MB (+50 KB of core-js).

同时让 legacy 模块留在 `vendor-pdf` 独立 chunk(可缓存、可独立测试)。代价:worker 1.23 MB → 1.29 MB(+50 KB core-js)。

## What happens on each open (old engine) / 每次打开 PDF 的执行步骤(旧引擎)

```
用户点开 PDF
  → loadPdf() 运行
  → import legacy 主模块       core-js 检测缺失 API → 装上(主线程侧)      [URL.parse 等]
  → import legacy worker URL   workerSrc 指向同树的 legacy worker 文件
  → new Worker(workerSrc)      worker 启动 → core-js 再次在 worker 全局装上 [toHex 等]
  → 握手(消息往返)             双方语言齐备 → 成功
  → worker 取 PDF 字节         calculateMD5(...).toHex() 可用 → 指纹计算成功
  → 解析 → 逐页渲染            spinner 消失,PDF 显示

新版引擎上:第 3/5 步的特性检测发现原生 API 已存在 → 什么都不装 → 行为与现代构建无差异
坏时代(修复前):worker 内 toHex 缺失 → 指纹计算抛错 → 要么报错要么永久转圈
```

## Verification / 验证

1. Headless Chromium WITHOUT `Uint8Array.prototype.toHex`: modern build fails with `a.toHex is not a function`; legacy build parses the same PDF fully (25 pages) — tested against both the raw files and the actual built chunks.
2. Real devices: Huawei WebView (app) and mobile Chrome both open PDFs; desktop unaffected.
3. Regression test `pdfLegacyEngine.test.ts` deletes `toHex`/`URL.parse` before importing the legacy build and asserts it self-polyfills and parses.

1. 无 `Uint8Array.prototype.toHex` 的无头 Chromium:现代构建报 `a.toHex is not a function`,legacy 构建完整解析同一 PDF(25 页)——原始文件与实际构建产物都测过。
2. 实机:华为 WebView(app)与手机 Chrome 均可打开 PDF;桌面不受影响。
3. 回归测试 `pdfLegacyEngine.test.ts` 在导入 legacy 构建前删掉 `toHex`/`URL.parse`,断言其自我补齐并完成解析。

🤖 Generated with [Claude Code](https://claude.com/claude-code)