### PR TITLE
fix: wait for text selection to finish before showing quote bar

### DIFF
--- a/web/src/components/file/CodeMirrorViewer.vue
+++ b/web/src/components/file/CodeMirrorViewer.vue
@@ -210,8 +210,8 @@ function handleSelectionChange(update) {
     const startLine = update.state.doc.lineAt(sel.from).number
     const endLine = update.state.doc.lineAt(sel.to).number
     selDebounceTimer = setTimeout(() => {
-        // delay: 0 — double-click is not used in code mode, so there is no
-        // pointerdown that could immediately close the bar (see useQuoteQuestion).
+        // Code mode does not need the double-click delay. useQuoteQuestion
+        // still defers the actual bar display until pointerup during a drag.
         quoteQuestion.showBar({
             text,
             filePath: props.file?.path || '',

--- a/web/src/composables/__tests__/useQuoteQuestion.test.ts
+++ b/web/src/composables/__tests__/useQuoteQuestion.test.ts
@@ -421,6 +421,54 @@ describe('useQuoteQuestion', () => {
       wrapper.unmount()
     })
 
+    it('waits for pointerup before showing the bar during a drag selection', () => {
+      const wrapper = mountWithComposable()
+      createSelectionInContainer('markdown-body', {
+        'data-file-path': '/drag.md',
+      })
+
+      document.dispatchEvent(new MouseEvent('pointerdown', { button: 0 }))
+      document.dispatchEvent(new Event('selectionchange'))
+      vi.advanceTimersByTime(150)
+
+      const qq = useQuoteQuestion()
+      expect(qq.visible.value).toBe(false)
+
+      document.dispatchEvent(new MouseEvent('pointerup', { button: 0 }))
+      vi.advanceTimersByTime(0)
+
+      expect(qq.visible.value).toBe(true)
+      expect(ctx.quoteData.value?.text).toBe('selected code text')
+
+      wrapper.unmount()
+    })
+
+    it('defers a programmatic CodeMirror bar request until pointerup', () => {
+      const wrapper = mountWithComposable()
+      createSelectionInContainer('cm-editor')
+      const qq = useQuoteQuestion()
+
+      document.dispatchEvent(new MouseEvent('pointerdown', { button: 0 }))
+      qq.showBar({
+        text: 'selected code text',
+        filePath: '/main.ts',
+        language: 'typescript',
+        startLine: 1,
+        endLine: 1,
+      }, { delay: 0 })
+      vi.advanceTimersByTime(0)
+
+      expect(qq.visible.value).toBe(false)
+
+      document.dispatchEvent(new MouseEvent('pointerup', { button: 0 }))
+      vi.advanceTimersByTime(0)
+
+      expect(qq.visible.value).toBe(true)
+      expect(ctx.quoteData.value?.filePath).toBe('/main.ts')
+
+      wrapper.unmount()
+    })
+
     it('shows bar when text is selected inside .raw-content-pre', () => {
       const wrapper = mountWithComposable()
       createSelectionInContainer('raw-content-pre', {

--- a/web/src/composables/useQuoteQuestion.ts
+++ b/web/src/composables/useQuoteQuestion.ts
@@ -23,10 +23,16 @@ const barPinned = ref(false)  // When pinned, selection loss won't auto-hide the
 const sheetOpen = ref(false)
 
 let debounceTimer: ReturnType<typeof setTimeout> | null = null
+let pointerSelecting = false
+let pendingShow: QuoteData | null = null
 
-function onSelectionChange() {
+function scheduleSelectionChange(delay = 150) {
   if (debounceTimer) clearTimeout(debounceTimer)
   debounceTimer = setTimeout(() => {
+    // A native text selection can emit selectionchange while the pointer is
+    // still down. Do not show the bar until the drag has finished.
+    if (pointerSelecting) return
+
     const sel = window.getSelection()
     if (!sel || sel.isCollapsed || !sel.toString().trim()) {
       // Drop only the active selection. Staged quotes remain in the chat draft.
@@ -65,7 +71,36 @@ function onSelectionChange() {
 
     setQuoteData({ text, filePath, language, startLine, endLine })
     barVisible.value = true
-  }, 150)
+  }, delay)
+}
+
+function onSelectionChange() {
+  scheduleSelectionChange()
+}
+
+function applyShow(data: QuoteData) {
+  setQuoteData(data)
+  barVisible.value = true
+}
+
+function onPointerDown(event: PointerEvent) {
+  if (event.button === 0) pointerSelecting = true
+}
+
+function onPointerUp() {
+  if (!pointerSelecting) return
+  pointerSelecting = false
+
+  // CodeMirror reports its selection independently of the DOM. If its
+  // callback fired during the drag, flush that request after release.
+  if (pendingShow) {
+    const data = pendingShow
+    pendingShow = null
+    applyShow(data)
+  }
+
+  // Process the final native selection immediately after pointerup.
+  scheduleSelectionChange(0)
 }
 
 // Global listener management
@@ -84,6 +119,9 @@ export function useQuoteQuestion() {
     listenerCount++
     if (listenerCount === 1) {
       document.addEventListener('selectionchange', onSelectionChange)
+      document.addEventListener('pointerdown', onPointerDown)
+      document.addEventListener('pointerup', onPointerUp)
+      document.addEventListener('pointercancel', onPointerUp)
     }
   })
 
@@ -91,10 +129,18 @@ export function useQuoteQuestion() {
     listenerCount--
     if (listenerCount === 0) {
       document.removeEventListener('selectionchange', onSelectionChange)
+      document.removeEventListener('pointerdown', onPointerDown)
+      document.removeEventListener('pointerup', onPointerUp)
+      document.removeEventListener('pointercancel', onPointerUp)
+      if (debounceTimer) clearTimeout(debounceTimer)
+      debounceTimer = null
+      pointerSelecting = false
+      pendingShow = null
     }
   })
 
   function closeSheet() {
+    pendingShow = null
     const sel = window.getSelection()
     if (sel) sel.removeAllRanges()
     barVisible.value = false
@@ -116,6 +162,7 @@ export function useQuoteQuestion() {
    * selection is internal and never reaches the global selectionchange handler).
    */
   function hideBar() {
+    pendingShow = null
     barVisible.value = false
     barPinned.value = false
     setQuoteData(null)
@@ -125,12 +172,15 @@ export function useQuoteQuestion() {
    * 编程式显示引用问答栏（不依赖 selectionchange 事件）。
    * 默认延迟 400ms 显示，避免双击的 pointerdown 事件触发"点击外部关闭"
    * （markdown 预览双击复制依赖此延迟）。传 { delay: 0 } 可立即显示
-   * （代码模式拖选无 pointerdown 干扰）。
+   * （代码模式使用此路径；拖选期间仍会统一等到 pointerup）。
    */
   function showBar(data: QuoteData, opts: { delay?: number } = {}) {
     setTimeout(() => {
-      setQuoteData(data)
-      barVisible.value = true
+      if (pointerSelecting) {
+        pendingShow = data
+        return
+      }
+      applyShow(data)
     }, opts.delay ?? 400)
   }
 


### PR DESCRIPTION
## Problem

In the desktop file reader, the quote question bar could appear while the user was still dragging to select text.

Both native DOM selections and CodeMirror selections emit updates continuously during a drag. The existing 150 ms or 200 ms debounce could therefore open the bar before pointer release. On desktop the bar immediately expands and focuses its textarea, which interrupts the active drag and makes the selection caret and selected text disappear.

This affects rendered Markdown, raw text and office previews, plus read-only CodeMirror file views.

## Fix

- Track primary-pointer selection state in the shared quote-question composable.
- Ignore native selection updates while the pointer is still held down, then process the final range on pointerup.
- Queue CodeMirror programmatic show requests during a drag and flush the latest request after pointer release.
- Clear pending timers and selection state when the final listener is removed, and clear queued show requests when the bar is closed or hidden.
- Preserve the existing debounce and desktop auto-expand behavior after selection has completed.

## Tests

- Added coverage proving the native selection bar stays hidden during drag and appears after pointerup.
- Added coverage proving CodeMirror show requests are deferred until pointerup.
- Relevant frontend tests: 99 passed.
- TypeScript typecheck passed.