### PR TITLE
feat(settings): default system-prompt interval and archive retention to 0 (off)

### DIFF
--- a/internal/model/config.go
+++ b/internal/model/config.go
@@ -55,14 +55,14 @@ type Config struct {
 		InitialMessages          int  `yaml:"initial_messages"`           // Number of messages to load initially (default: 20)
 		PageSize                 int  `yaml:"page_size"`                  // Number of messages per lazy-load batch (default: 20)
 		SessionPageSize          int  `yaml:"session_page_size"`          // Number of sessions per page in session list (default: 10)
-		SystemPromptInterval     int  `yaml:"system_prompt_interval"`     // Re-inject system prompt every N assistant turns (0=never, default: 10)
+		SystemPromptInterval     int  `yaml:"system_prompt_interval"`     // Re-inject system prompt every N assistant turns (0=never, default: 0)
 		RecommendEnabled         bool `yaml:"recommend_enabled"`          // 推荐回复: generate a next-step recommendation after each assistant reply (default: false)
 		RecommendContextMessages int  `yaml:"recommend_context_messages"` // 推荐回复参考的最近消息条数（用户+助手） (default: 10)
 	} `yaml:"chat"`
 	Session struct {
 		MaxCount                int  `yaml:"max_count"`                 // Maximum number of chat sessions per project (default: 10)
 		ArchiveRetentionEnabled bool `yaml:"archive_retention_enabled"` // Enable auto-purge of archived sessions after retention period (default: false)
-		ArchiveRetentionDays    int  `yaml:"archive_retention_days"`    // Days to keep archived sessions before auto-purge (0=keep forever, default: 30)
+		ArchiveRetentionDays    int  `yaml:"archive_retention_days"`    // Days to keep archived sessions before auto-purge (0=keep forever, default: 0)
 	} `yaml:"session"`
 	RecentProjects struct {
 		MaxCount int `yaml:"max_count"` // Maximum number of recent projects to keep (default: 10)

--- a/internal/model/defaults.go
+++ b/internal/model/defaults.go
@@ -136,8 +136,16 @@ func ApplyDefaults(cfg *Config, presence map[string]bool) string { //nolint:goco
 	if cfg.Chat.SessionPageSize <= 0 {
 		cfg.Chat.SessionPageSize = 10
 	}
-	if cfg.Chat.SystemPromptInterval <= 0 {
-		cfg.Chat.SystemPromptInterval = 10
+	// SystemPromptInterval: 0 = never re-inject is the intentional DEFAULT.
+	// The old `<= 0 → 10` rewrite made 0 unexpressable — a user who
+	// explicitly disabled periodic re-injection was silently switched back
+	// to every-10-turns. Negative values (hand-edited yaml only; PATCH
+	// rejects them earlier) clamp to 0.
+	// 0 = 从不重注即为默认值。旧的 `<= 0 → 10` 改写使 0 无法表达——显式
+	// 关闭周期性重注的用户会被静默改回每 10 轮。负值(仅手改 yaml 可产生;
+	// PATCH 已在更早处拦截)收敛为 0。
+	if cfg.Chat.SystemPromptInterval < 0 {
+		cfg.Chat.SystemPromptInterval = 0
 	}
 	// RecommendEnabled: bool zero-value (false) is the intentional default.
 	// Use presence map to distinguish "user wrote false" from "user omitted the field".
@@ -159,8 +167,14 @@ func ApplyDefaults(cfg *Config, presence map[string]bool) string { //nolint:goco
 	} else {
 		cfg.Session.ArchiveRetentionEnabled = false
 	}
-	if cfg.Session.ArchiveRetentionDays <= 0 {
-		cfg.Session.ArchiveRetentionDays = 30
+	// ArchiveRetentionDays: 0 = keep forever is the intentional DEFAULT —
+	// archived sessions should not vanish by surprise. The old `<= 0 → 30`
+	// rewrite made 0 unexpressable, so a user who wanted retention disabled
+	// was silently enrolled in a 30-day purge. Negative values clamp to 0.
+	// 0 = 永久保留即为默认值——归档会话不应莫名消失。旧的 `<= 0 → 30` 改写
+	// 使 0 无法表达,想关闭留存的用户被静默纳入 30 天清理。负值收敛为 0。
+	if cfg.Session.ArchiveRetentionDays < 0 {
+		cfg.Session.ArchiveRetentionDays = 0
 	}
 
 	// --- Recent Projects ---

--- a/internal/model/defaults_test.go
+++ b/internal/model/defaults_test.go
@@ -465,8 +465,8 @@ func TestApplyDefaults_ChatSessionPageSize(t *testing.T) {
 	if cfg.Chat.SessionPageSize != 10 {
 		t.Errorf("Chat.SessionPageSize = %d, want 10", cfg.Chat.SessionPageSize)
 	}
-	if cfg.Chat.SystemPromptInterval != 10 {
-		t.Errorf("Chat.SystemPromptInterval = %d, want 10", cfg.Chat.SystemPromptInterval)
+	if cfg.Chat.SystemPromptInterval != 0 {
+		t.Errorf("Chat.SystemPromptInterval = %d, want 0 (never is the default)", cfg.Chat.SystemPromptInterval)
 	}
 }
 
@@ -811,5 +811,48 @@ func TestApplyDefaults_PushMode_ExplicitFeishuSyncsEnabled(t *testing.T) {
 	}
 	if cfg.DingTalk.Enabled {
 		t.Error("expected DingTalk.Enabled=false when PushMode=feishu")
+	}
+}
+
+func TestApplyDefaults_ZeroMeansOff_NotRewritten(t *testing.T) {
+	setupTestBinDir(t)
+
+	// The old `<= 0 → N` rewrites made the documented 0 ("never" / "keep
+	// forever") unexpressable — an explicit 0 was silently replaced by the
+	// nonzero default. 0 must now survive ApplyDefaults.
+	cfg := Config{}
+	cfg.Chat.SystemPromptInterval = 0
+	cfg.Session.ArchiveRetentionDays = 0
+	ApplyDefaults(&cfg, nil)
+	if cfg.Chat.SystemPromptInterval != 0 {
+		t.Errorf("explicit SystemPromptInterval=0 rewritten to %d, want 0", cfg.Chat.SystemPromptInterval)
+	}
+	if cfg.Session.ArchiveRetentionDays != 0 {
+		t.Errorf("explicit ArchiveRetentionDays=0 rewritten to %d, want 0", cfg.Session.ArchiveRetentionDays)
+	}
+
+	// Explicit nonzero values are preserved as-is.
+	cfg = Config{}
+	cfg.Chat.SystemPromptInterval = 3
+	cfg.Session.ArchiveRetentionDays = 90
+	ApplyDefaults(&cfg, nil)
+	if cfg.Chat.SystemPromptInterval != 3 {
+		t.Errorf("explicit SystemPromptInterval=3 rewritten to %d, want 3", cfg.Chat.SystemPromptInterval)
+	}
+	if cfg.Session.ArchiveRetentionDays != 90 {
+		t.Errorf("explicit ArchiveRetentionDays=90 rewritten to %d, want 90", cfg.Session.ArchiveRetentionDays)
+	}
+
+	// Negative (only possible via hand-edited yaml) clamps to 0, not to a
+	// nonzero default.
+	cfg = Config{}
+	cfg.Chat.SystemPromptInterval = -1
+	cfg.Session.ArchiveRetentionDays = -7
+	ApplyDefaults(&cfg, nil)
+	if cfg.Chat.SystemPromptInterval != 0 {
+		t.Errorf("negative SystemPromptInterval=%d, want clamp to 0", cfg.Chat.SystemPromptInterval)
+	}
+	if cfg.Session.ArchiveRetentionDays != 0 {
+		t.Errorf("negative ArchiveRetentionDays=%d, want clamp to 0", cfg.Session.ArchiveRetentionDays)
 	}
 }

--- a/web/src/i18n/locales/en.ts
+++ b/web/src/i18n/locales/en.ts
@@ -1466,7 +1466,7 @@ export default {
       messageDisplayModeSummary: 'Summary mode',
       messageDisplayModeOriginal: 'Original text',
       chatSystemPromptInterval: 'System Prompt Interval',
-      chatSystemPromptIntervalDesc: 'Insert a system prompt every N messages',
+      chatSystemPromptIntervalDesc: 'Insert a system prompt every N messages (0 = never)',
       sessionMaxCount: 'Max Sessions',
       sessionMaxCountDesc: 'Maximum number of concurrent chat sessions',
       archiveRetentionSectionHeader: 'Archive Retention',

--- a/web/src/i18n/locales/zh.ts
+++ b/web/src/i18n/locales/zh.ts
@@ -1466,7 +1466,7 @@ export default {
       messageDisplayModeSummary: '摘要模式',
       messageDisplayModeOriginal: '原文模式',
       chatSystemPromptInterval: '系统提示间隔',
-      chatSystemPromptIntervalDesc: '每隔多少条消息插入一次系统提示',
+      chatSystemPromptIntervalDesc: '每隔多少条消息插入一次系统提示（0 = 从不插入）',
       sessionMaxCount: '最大会话数',
       sessionMaxCountDesc: '允许同时存在的聊天会话上限',
       archiveRetentionSectionHeader: '归档留存',


### PR DESCRIPTION
## Problem | 问题

Two Settings → Chat defaults quietly work against long-running sessions:

1. **`chat.system_prompt_interval` defaults to 10** — every 10 assistant turns the client re-injects the system prompt as a text block into the conversation. In long sessions this accumulates many redundant prompt blocks in the history, consuming context window on every resume/compaction. Users who want it off must set 0 — but see the bug below.
2. **`session.archive_retention_days` defaults to 30** — a user who enables auto-purge without setting days gets a surprise 30-day purge of archived sessions. Important archived sessions should not vanish by default.

Both fields document `0` as a meaningful value ("never" / "keep forever") — yet `ApplyDefaults` used `<= 0 → N` rewrites, so **0 could never survive**: a user who explicitly set `system_prompt_interval: 0` in config.yaml was silently switched back to 10 on every load.

设置 → 聊天中有两个默认值在悄悄地与长期会话作对：

1. **`chat.system_prompt_interval` 默认 10** —— 每 10 轮助手回复客户端就向会话重注一次系统提示文本块。长会话里历史累积大量重复提示块,每次恢复/压缩都消耗上下文窗口。想关闭需设 0——但见下面的 bug。
2. **`session.archive_retention_days` 默认 30** —— 开启自动清理而未设天数的用户,归档会话会在 30 天后被意外清除。重要的归档会话不应默认消失。

两个字段文档里 0 都是有意义的值("从不"/"永久保留")——但 `ApplyDefaults` 用的是 `<= 0 → N` 改写,导致 **0 永远无法生效**:在 config.yaml 里显式写 `system_prompt_interval: 0` 的用户,每次加载都被静默改回 10。

## Change | 改动

- Defaults become **0 = off** for both fields (fresh installs / keys omitted from yaml)
  两个字段默认值改为 **0 = 关闭**(新安装 / yaml 中省略该键时)
- `<= 0 → N` rewrites replaced with `if < 0 → 0`: explicit 0 survives, explicit nonzero values preserved, negatives (hand-edited yaml only — PATCH already rejects them) clamp to 0
  `<= 0 → N` 改写替换为 `if < 0 → 0`:显式 0 得以保留,显式非零值原样保留,负值(仅手改 yaml 可产生——PATCH 已在更早处拦截)收敛为 0
- Struct doc comments updated (`default: 0`); i18n descriptions now mention the 0 semantics (interval desc previously did not)
  结构体注释更新(`default: 0`);i18n 描述补充 0 的语义(间隔条目原先未说明)
- Consumer semantics already correct and untouched: `internal/ai/interface.go` treats `interval <= 0` as "never re-inject"; the cleanup worker only purges when `archive_retention_enabled` is true
  消费端语义本就正确且未改动:`internal/ai/interface.go` 将 `interval <= 0` 视为"从不重注";清理 worker 仅在 `archive_retention_enabled` 为 true 时才清理

**Compatibility | 兼容性**: existing config.yaml files with explicit values are untouched — the new defaults only apply where the key is absent.
已有 config.yaml 中的显式取值不受影响——新默认值仅在键缺失时生效。

## Verification | 验证

- New test `TestApplyDefaults_ZeroMeansOff_NotRewritten`: explicit 0 survives; explicit 3/90 preserved; negatives clamp to 0 (both fields)
- Updated existing default assertion (10 → 0)
- `go test ./internal/model/ ./internal/handler/ ./internal/service/` all pass; golangci-lint clean; pre-push checks pass (Tier 2 diff coverage PASS; Tier 1 shows only the pre-existing local baseline drift in untouched packages `internal/ai`/`internal/platform`)
- 新增测试 `TestApplyDefaults_ZeroMeansOff_NotRewritten`:显式 0 保留;显式 3/90 原样;负值收敛为 0(两字段)
- 更新既有默认值断言(10 → 0)
- 三个受影响包测试全过;golangci-lint 干净;推送前检查通过(Tier 2 变更覆盖 PASS;Tier 1 仅存在未触碰包 `internal/ai`/`internal/platform` 的既有本地基线漂移)

🤖 Generated with [Claude Code](https://claude.com/claude-code)