### PR TITLE
feat(codex): add project-scoped session discovery and reliable restore

### DIFF
--- a/docs/spec/core/session-lifecycle.md
+++ b/docs/spec/core/session-lifecycle.md
@@ -2,6 +2,26 @@
 
 聊天会话从用户发送第一条消息开始创建，经历执行、排队、取消、完成等状态，最终被归档（软删除）或物理删除（Destroy）。定时任务的执行结果可以续接为新的交互式会话，继承原始对话上下文。理解会话的生命周期是理解系统运行时行为的关键——大多数用户交互都围绕"当前会话"展开，而 service 层的会话管理是整个系统的运行时核心。
 
+## Codex 项目级历史会话发现
+
+Codex Agent 优先使用 ACP `session/list`，并在第一页合并本地
+`CODEX_HOME/sessions`（默认 `~/.codex/sessions`）扫描结果。ACP 列举不可用
+或在分页开始前失败时，自动使用本地扫描兜底。恢复时不转换会话 ID，直接将
+`session_meta.payload.id` 作为 Codex thread ID 传给 ACP `LoadSession`。
+
+本地扫描器仅在 JSONL 文件头部读取恢复所需的 `id`、`cwd` 和时间戳，并只返回
+规范化后 `cwd` 与当前项目一致的会话。Windows 盘符大小写、正反斜杠、尾斜杠
+以及 `.`/`..` 差异均会规范化比较；损坏或缺字段的文件会记录警告并跳过，不会
+导致列表接口整体失败。
+
+扫描按最新日期优先，单次最多检查 10,000 个 rollout 文件并返回 200 条匹配
+会话，避免无界遍历。当前不解析 Codex 压缩的 `.jsonl.zst` 历史文件，此类会话
+仍依赖优先级更高的 ACP 列举。Codex 数据目录非默认位置时需设置 `CODEX_HOME`。
+
+排障时应确认：ClawBench 当前项目与 `session_meta.payload.cwd` 指向同一目录；
+rollout 首条有效记录是 `session_meta`；若列表可见但恢复失败，升级 Codex 与
+`codex-acp`，并确认 ACP `LoadSession` 接受该原始 thread ID。
+
 ## 流程图
 
 ### 会话主生命周期

--- a/internal/ai/acp_stdout_filter.go
+++ b/internal/ai/acp_stdout_filter.go
@@ -13,6 +13,11 @@ import (
 	"clawbench/internal/model"
 )
 
+const (
+	acpStdoutInitialBuffer = 64 * 1024
+	acpStdoutMaxMessage    = 32 * 1024 * 1024
+)
+
 // acpStdoutFilter wraps an io.Reader (agent stdout) and produces a filtered
 // io.Reader that fixes common ACP protocol violations. Currently handles:
 //
@@ -62,7 +67,7 @@ func newACPStdoutFilter(r io.Reader) *acpStdoutFilter {
 // pump reads lines from src, filters them, and writes to the pipe writer.
 func (f *acpStdoutFilter) pump(src io.Reader) {
 	scanner := bufio.NewScanner(src)
-	scanner.Buffer(make([]byte, 0, 64*1024), 1024*1024)
+	scanner.Buffer(make([]byte, 0, acpStdoutInitialBuffer), acpStdoutMaxMessage)
 
 	for scanner.Scan() {
 		line := scanner.Bytes()

--- a/internal/ai/acp_stdout_filter_test.go
+++ b/internal/ai/acp_stdout_filter_test.go
@@ -33,6 +33,18 @@ func TestACPStdoutFilter_PassesValidJSON(t *testing.T) {
 	}
 }
 
+func TestACPStdoutFilter_PassesLargeJSONMessage(t *testing.T) {
+	payload := strings.Repeat("x", 2*1024*1024)
+	input := `{"jsonrpc":"2.0","method":"session/update","params":{"content":"` + payload + `"}}` + "\n"
+	f := newACPStdoutFilter(strings.NewReader(input))
+	defer f.Close()
+
+	var buf bytes.Buffer
+	_, err := io.Copy(&buf, f)
+	require.NoError(t, err)
+	assert.Equal(t, input, buf.String())
+}
+
 func TestACPStdoutFilter_FixesStringNumericID(t *testing.T) {
 	// CodeWhale returns "id":"1" (string) when the request sent "id":1 (number)
 	input := `{"jsonrpc":"2.0","id":"1","result":{"status":"ok"}}

--- a/internal/ai/backends/codex/list_sessions.go
+++ b/internal/ai/backends/codex/list_sessions.go
@@ -1,0 +1,274 @@
+package codex
+
+import (
+	"bufio"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"log/slog"
+	"os"
+	"path"
+	"path/filepath"
+	"regexp"
+	"sort"
+	"strings"
+	"time"
+
+	acp "github.com/coder/acp-go-sdk"
+
+	"clawbench/internal/ai"
+	"clawbench/internal/model"
+)
+
+const (
+	codexSessionScanLimit   = 10000
+	codexSessionResultLimit = 200
+	codexSessionHeaderLimit = 256 * 1024
+	codexSessionWarnLimit   = 5
+)
+
+var windowsDrivePath = regexp.MustCompile(`^[A-Za-z]:/`)
+
+type codexDiskSession struct {
+	SessionID string
+	Cwd       string
+	CreatedAt time.Time
+	UpdatedAt time.Time
+}
+
+type codexRolloutLine struct {
+	Timestamp string          `json:"timestamp"`
+	Type      string          `json:"type"`
+	Payload   json.RawMessage `json:"payload"`
+}
+
+type codexSessionMeta struct {
+	ID        string `json:"id"`
+	SessionID string `json:"session_id"`
+	Cwd       string `json:"cwd"`
+	Timestamp string `json:"timestamp"`
+}
+
+func init() {
+	ai.ListSessionsFromDiskRegister("codex", listCodexSessionsFromDisk)
+}
+
+func listCodexSessionsFromDisk(_ *model.Agent, cwd string) ([]acp.SessionInfo, error) {
+	if strings.TrimSpace(cwd) == "" {
+		slog.Warn("codex on-disk ListSessions: project cwd is empty; skipping scan")
+		return nil, nil
+	}
+	codexHome, err := resolveCodexHome()
+	if err != nil {
+		return nil, err
+	}
+
+	disks, stats := scanCodexSessions(filepath.Join(codexHome, "sessions"), cwd, codexSessionScanLimit, codexSessionResultLimit)
+	sessions := make([]acp.SessionInfo, 0, len(disks))
+	for _, disk := range disks {
+		updatedAt := formatCodexSessionTime(disk.UpdatedAt)
+		sessions = append(sessions, acp.SessionInfo{
+			SessionId: acp.SessionId(disk.SessionID),
+			Cwd:       disk.Cwd,
+			UpdatedAt: updatedAt,
+		})
+	}
+
+	slog.Info("codex on-disk ListSessions",
+		"found", len(sessions),
+		"scanned", stats.scanned,
+		"skipped", stats.skipped,
+		"scan_limit_reached", stats.limitReached,
+		"project_scoped", true)
+	return sessions, nil
+}
+
+func resolveCodexHome() (string, error) {
+	if configured := strings.TrimSpace(os.Getenv("CODEX_HOME")); configured != "" {
+		return filepath.Clean(configured), nil
+	}
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return "", fmt.Errorf("resolve Codex home: %w", err)
+	}
+	return filepath.Join(home, ".codex"), nil
+}
+
+type codexScanStats struct {
+	scanned      int
+	skipped      int
+	limitReached bool
+}
+
+func scanCodexSessions(root, cwd string, scanLimit, resultLimit int) ([]codexDiskSession, codexScanStats) {
+	if scanLimit <= 0 || resultLimit <= 0 {
+		return nil, codexScanStats{}
+	}
+
+	var sessions []codexDiskSession
+	stats := codexScanStats{}
+	walkCodexSessionFilesNewestFirst(root, &stats, scanLimit, func(filePath string, info os.FileInfo) bool {
+		session, err := parseCodexSessionHeader(filePath, info)
+		if err != nil {
+			stats.skipped++
+			if stats.skipped <= codexSessionWarnLimit {
+				slog.Warn("codex on-disk ListSessions: skipping invalid rollout",
+					"file", filepath.Base(filePath),
+					"error", err)
+			}
+			return true
+		}
+		if cwd != "" && !codexProjectPathsEqual(session.Cwd, cwd) {
+			return true
+		}
+		sessions = append(sessions, session)
+		return true
+	})
+
+	sort.SliceStable(sessions, func(i, j int) bool {
+		if sessions[i].UpdatedAt.Equal(sessions[j].UpdatedAt) {
+			return sessions[i].CreatedAt.After(sessions[j].CreatedAt)
+		}
+		return sessions[i].UpdatedAt.After(sessions[j].UpdatedAt)
+	})
+	if len(sessions) > resultLimit {
+		sessions = sessions[:resultLimit]
+	}
+	return sessions, stats
+}
+
+func walkCodexSessionFilesNewestFirst(root string, stats *codexScanStats, scanLimit int, visit func(string, os.FileInfo) bool) {
+	var walk func(string) bool
+	walk = func(dir string) bool {
+		entries, err := os.ReadDir(dir)
+		if err != nil {
+			return true
+		}
+		for i := len(entries) - 1; i >= 0; i-- {
+			entry := entries[i]
+			entryPath := filepath.Join(dir, entry.Name())
+			if entry.IsDir() {
+				if !walk(entryPath) {
+					return false
+				}
+				continue
+			}
+			if !strings.HasPrefix(entry.Name(), "rollout-") || !strings.HasSuffix(entry.Name(), ".jsonl") {
+				continue
+			}
+			if stats.scanned >= scanLimit {
+				stats.limitReached = true
+				return false
+			}
+			stats.scanned++
+			info, err := entry.Info()
+			if err != nil {
+				stats.skipped++
+				continue
+			}
+			if !visit(entryPath, info) {
+				return false
+			}
+		}
+		return true
+	}
+	_ = walk(root)
+}
+
+func parseCodexSessionHeader(filePath string, info os.FileInfo) (codexDiskSession, error) {
+	f, err := os.Open(filePath)
+	if err != nil {
+		return codexDiskSession{}, err
+	}
+	defer func() { _ = f.Close() }()
+
+	reader := bufio.NewReader(io.LimitReader(f, codexSessionHeaderLimit))
+	for {
+		line, readErr := reader.ReadBytes('\n')
+		if len(strings.TrimSpace(string(line))) > 0 {
+			var rollout codexRolloutLine
+			if err := json.Unmarshal(line, &rollout); err != nil {
+				return codexDiskSession{}, fmt.Errorf("decode rollout header: %w", err)
+			}
+			if rollout.Type != "session_meta" {
+				return codexDiskSession{}, fmt.Errorf("first record type is %q", rollout.Type)
+			}
+			var meta codexSessionMeta
+			if err := json.Unmarshal(rollout.Payload, &meta); err != nil {
+				return codexDiskSession{}, fmt.Errorf("decode session metadata: %w", err)
+			}
+			sessionID := meta.ID
+			if sessionID == "" {
+				sessionID = meta.SessionID
+			}
+			if sessionID == "" || meta.Cwd == "" {
+				return codexDiskSession{}, errors.New("session metadata missing id or cwd")
+			}
+			createdAt := parseCodexSessionTime(meta.Timestamp)
+			if createdAt.IsZero() {
+				createdAt = parseCodexSessionTime(rollout.Timestamp)
+			}
+			return codexDiskSession{
+				SessionID: sessionID,
+				Cwd:       meta.Cwd,
+				CreatedAt: createdAt,
+				UpdatedAt: info.ModTime(),
+			}, nil
+		}
+		if readErr != nil {
+			if errors.Is(readErr, io.EOF) {
+				return codexDiskSession{}, errors.New("session metadata not found in bounded header")
+			}
+			return codexDiskSession{}, readErr
+		}
+	}
+}
+
+func parseCodexSessionTime(value string) time.Time {
+	if value == "" {
+		return time.Time{}
+	}
+	if parsed, err := time.Parse(time.RFC3339Nano, value); err == nil {
+		return parsed
+	}
+	if parsed, err := time.Parse("2006-01-02T15-04-05", value); err == nil {
+		return parsed.UTC()
+	}
+	return time.Time{}
+}
+
+func formatCodexSessionTime(value time.Time) *string {
+	if value.IsZero() {
+		return nil
+	}
+	formatted := value.UTC().Format(time.RFC3339)
+	return &formatted
+}
+
+func codexProjectPathsEqual(left, right string) bool {
+	left = normalizeCodexProjectPath(left)
+	right = normalizeCodexProjectPath(right)
+	return left == right
+}
+
+func normalizeCodexProjectPath(value string) string {
+	value = strings.TrimSpace(strings.ReplaceAll(value, `\`, "/"))
+	if value == "" {
+		return ""
+	}
+	isUNC := strings.HasPrefix(value, "//")
+	isWindows := isUNC || windowsDrivePath.MatchString(value)
+	cleaned := path.Clean(value)
+	if cleaned == "." {
+		return ""
+	}
+	if isUNC {
+		cleaned = "//" + strings.TrimLeft(cleaned, "/")
+	}
+	cleaned = strings.TrimSuffix(cleaned, "/")
+	if isWindows {
+		cleaned = strings.ToLower(cleaned)
+	}
+	return cleaned
+}

--- a/internal/ai/backends/codex/list_sessions.go
+++ b/internal/ai/backends/codex/list_sessions.go
@@ -186,7 +186,7 @@ func parseCodexSessionHeader(filePath string, info os.FileInfo) (codexDiskSessio
 	reader := bufio.NewReader(io.LimitReader(f, codexSessionHeaderLimit))
 	for {
 		line, readErr := reader.ReadBytes('\n')
-		if len(strings.TrimSpace(string(line))) > 0 {
+		if strings.TrimSpace(string(line)) != "" {
 			var rollout codexRolloutLine
 			if err := json.Unmarshal(line, &rollout); err != nil {
 				return codexDiskSession{}, fmt.Errorf("decode rollout header: %w", err)

--- a/internal/ai/backends/codex/list_sessions_test.go
+++ b/internal/ai/backends/codex/list_sessions_test.go
@@ -1,0 +1,120 @@
+package codex
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func writeCodexRollout(t *testing.T, root, day, id, cwd string, updatedAt time.Time) string {
+	t.Helper()
+	dir := filepath.Join(root, "sessions", filepath.FromSlash(day))
+	require.NoError(t, os.MkdirAll(dir, 0o755))
+	file := filepath.Join(dir, fmt.Sprintf("rollout-2026-08-27T10-00-00-%s.jsonl", id))
+	content := fmt.Sprintf(
+		`{"timestamp":"2026-08-27T10:00:00.000Z","type":"session_meta","payload":{"id":%q,"timestamp":"2026-08-27T10:00:00.000Z","cwd":%q,"originator":"codex_cli_rs","cli_version":"1.0.0"}}`+"\n"+
+			`{"timestamp":"2026-08-27T10:00:01.000Z","type":"response_item","payload":{"type":"message","role":"user","content":[{"type":"input_text","text":"sensitive text must not be parsed"}]}}`+"\n",
+		id, cwd,
+	)
+	require.NoError(t, os.WriteFile(file, []byte(content), 0o644))
+	require.NoError(t, os.Chtimes(file, updatedAt, updatedAt))
+	return file
+}
+
+func TestScanCodexSessionsFiltersProjectAndSortsNewestFirst(t *testing.T) {
+	codexHome := t.TempDir()
+	project := filepath.Join(t.TempDir(), "Project With Spaces")
+	older := time.Date(2026, 8, 26, 10, 0, 0, 0, time.UTC)
+	newer := older.Add(time.Hour)
+
+	writeCodexRollout(t, codexHome, "2026/08/26", "00000000-0000-4000-8000-000000000001", project, older)
+	writeCodexRollout(t, codexHome, "2026/08/27", "00000000-0000-4000-8000-000000000002", project, newer)
+	writeCodexRollout(t, codexHome, "2026/08/27", "00000000-0000-4000-8000-000000000003", filepath.Join(t.TempDir(), "other"), newer.Add(time.Hour))
+
+	sessions, stats := scanCodexSessions(filepath.Join(codexHome, "sessions"), project, 100, 100)
+
+	require.Len(t, sessions, 2)
+	assert.Equal(t, "00000000-0000-4000-8000-000000000002", sessions[0].SessionID)
+	assert.Equal(t, "00000000-0000-4000-8000-000000000001", sessions[1].SessionID)
+	assert.Equal(t, 3, stats.scanned)
+}
+
+func TestScanCodexSessionsSkipsMalformedAndMissingFields(t *testing.T) {
+	root := filepath.Join(t.TempDir(), "sessions", "2026", "08", "27")
+	require.NoError(t, os.MkdirAll(root, 0o755))
+	require.NoError(t, os.WriteFile(filepath.Join(root, "rollout-broken.jsonl"), []byte("{broken\n"), 0o644))
+	require.NoError(t, os.WriteFile(filepath.Join(root, "rollout-missing.jsonl"),
+		[]byte(`{"type":"session_meta","payload":{"id":"id-without-cwd"}}`+"\n"), 0o644))
+
+	sessions, stats := scanCodexSessions(filepath.Join(filepath.Dir(filepath.Dir(filepath.Dir(root)))), "C:/Work/Repo", 100, 100)
+
+	assert.Empty(t, sessions)
+	assert.Equal(t, 2, stats.skipped)
+}
+
+func TestCodexProjectPathsEqualWindowsVariants(t *testing.T) {
+	assert.True(t, codexProjectPathsEqual(`C:\Work\Repo With Spaces`, `c:/work/repo with spaces/`))
+	assert.True(t, codexProjectPathsEqual(`C:\Work\Repo\.\sub\..`, `c:/work/repo`))
+	assert.True(t, codexProjectPathsEqual(`\\Server\Share\Repo`, `//server/share/repo/`))
+	assert.False(t, codexProjectPathsEqual(`C:\Work\Repo`, `C:\Work\Other`))
+}
+
+func TestCodexProjectPathsEqualPreservesPOSIXCaseSensitivity(t *testing.T) {
+	assert.True(t, codexProjectPathsEqual("/home/user/repo/", "/home/user/repo"))
+	assert.False(t, codexProjectPathsEqual("/home/User/repo", "/home/user/repo"))
+}
+
+func TestScanCodexSessionsHonorsLimits(t *testing.T) {
+	codexHome := t.TempDir()
+	project := t.TempDir()
+	for i := 0; i < 5; i++ {
+		writeCodexRollout(t, codexHome, "2026/08/27",
+			fmt.Sprintf("00000000-0000-4000-8000-00000000000%d", i), project,
+			time.Date(2026, 8, 27, 10, i, 0, 0, time.UTC))
+	}
+
+	sessions, stats := scanCodexSessions(filepath.Join(codexHome, "sessions"), project, 3, 2)
+
+	assert.Len(t, sessions, 2)
+	assert.LessOrEqual(t, stats.scanned, 3)
+}
+
+func TestScanCodexSessionsAppliesResultLimitAfterUpdatedSort(t *testing.T) {
+	codexHome := t.TempDir()
+	project := t.TempDir()
+	base := time.Date(2026, 8, 27, 10, 0, 0, 0, time.UTC)
+	for i := 0; i < 3; i++ {
+		file := writeCodexRollout(t, codexHome, fmt.Sprintf("2026/08/%02d", 25+i),
+			fmt.Sprintf("00000000-0000-4000-8000-00000000001%d", i), project, base.Add(time.Duration(i)*time.Hour))
+		if i == 0 {
+			require.NoError(t, os.Chtimes(file, base.Add(10*time.Hour), base.Add(10*time.Hour)))
+		}
+	}
+
+	sessions, stats := scanCodexSessions(filepath.Join(codexHome, "sessions"), project, 100, 2)
+
+	require.Len(t, sessions, 2)
+	assert.Equal(t, "00000000-0000-4000-8000-000000000010", sessions[0].SessionID)
+	assert.Equal(t, 3, stats.scanned)
+}
+
+func TestParseCodexSessionHeaderUsesMetadataID(t *testing.T) {
+	codexHome := t.TempDir()
+	project := t.TempDir()
+	file := writeCodexRollout(t, codexHome, "2026/08/27",
+		"00000000-0000-4000-8000-000000000009", project, time.Now())
+	info, err := os.Stat(file)
+	require.NoError(t, err)
+
+	session, err := parseCodexSessionHeader(file, info)
+
+	require.NoError(t, err)
+	assert.Equal(t, "00000000-0000-4000-8000-000000000009", session.SessionID)
+	assert.Equal(t, project, session.Cwd)
+	assert.Equal(t, time.Date(2026, 8, 27, 10, 0, 0, 0, time.UTC), session.CreatedAt)
+}

--- a/internal/ai/backends/codex/list_sessions_test.go
+++ b/internal/ai/backends/codex/list_sessions_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 	"time"
 
+	"clawbench/internal/model"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -51,7 +52,8 @@ func TestScanCodexSessionsSkipsMalformedAndMissingFields(t *testing.T) {
 	require.NoError(t, os.WriteFile(filepath.Join(root, "rollout-missing.jsonl"),
 		[]byte(`{"type":"session_meta","payload":{"id":"id-without-cwd"}}`+"\n"), 0o644))
 
-	sessions, stats := scanCodexSessions(filepath.Join(filepath.Dir(filepath.Dir(filepath.Dir(root)))), "C:/Work/Repo", 100, 100)
+	sessionsRoot := filepath.Dir(filepath.Dir(filepath.Dir(root)))
+	sessions, stats := scanCodexSessions(sessionsRoot, "C:/Work/Repo", 100, 100)
 
 	assert.Empty(t, sessions)
 	assert.Equal(t, 2, stats.skipped)
@@ -72,7 +74,7 @@ func TestCodexProjectPathsEqualPreservesPOSIXCaseSensitivity(t *testing.T) {
 func TestScanCodexSessionsHonorsLimits(t *testing.T) {
 	codexHome := t.TempDir()
 	project := t.TempDir()
-	for i := 0; i < 5; i++ {
+	for i := range 5 {
 		writeCodexRollout(t, codexHome, "2026/08/27",
 			fmt.Sprintf("00000000-0000-4000-8000-00000000000%d", i), project,
 			time.Date(2026, 8, 27, 10, i, 0, 0, time.UTC))
@@ -88,7 +90,7 @@ func TestScanCodexSessionsAppliesResultLimitAfterUpdatedSort(t *testing.T) {
 	codexHome := t.TempDir()
 	project := t.TempDir()
 	base := time.Date(2026, 8, 27, 10, 0, 0, 0, time.UTC)
-	for i := 0; i < 3; i++ {
+	for i := range 3 {
 		file := writeCodexRollout(t, codexHome, fmt.Sprintf("2026/08/%02d", 25+i),
 			fmt.Sprintf("00000000-0000-4000-8000-00000000001%d", i), project, base.Add(time.Duration(i)*time.Hour))
 		if i == 0 {
@@ -117,4 +119,116 @@ func TestParseCodexSessionHeaderUsesMetadataID(t *testing.T) {
 	assert.Equal(t, "00000000-0000-4000-8000-000000000009", session.SessionID)
 	assert.Equal(t, project, session.Cwd)
 	assert.Equal(t, time.Date(2026, 8, 27, 10, 0, 0, 0, time.UTC), session.CreatedAt)
+}
+
+func TestListCodexSessionsFromDiskUsesCodexHomeAndReturnsACPInfo(t *testing.T) {
+	codexHome := t.TempDir()
+	project := t.TempDir()
+	updatedAt := time.Date(2026, 8, 27, 12, 0, 0, 0, time.UTC)
+	writeCodexRollout(t, codexHome, "2026/08/27",
+		"00000000-0000-4000-8000-000000000021", project, updatedAt)
+	t.Setenv("CODEX_HOME", codexHome)
+
+	sessions, err := listCodexSessionsFromDisk(&model.Agent{Backend: "codex"}, project)
+
+	require.NoError(t, err)
+	require.Len(t, sessions, 1)
+	assert.Equal(t, "00000000-0000-4000-8000-000000000021", string(sessions[0].SessionId))
+	assert.Equal(t, project, sessions[0].Cwd)
+	require.NotNil(t, sessions[0].UpdatedAt)
+	assert.Equal(t, updatedAt.Format(time.RFC3339), *sessions[0].UpdatedAt)
+}
+
+func TestListCodexSessionsFromDiskSkipsEmptyProject(t *testing.T) {
+	t.Setenv("CODEX_HOME", t.TempDir())
+
+	sessions, err := listCodexSessionsFromDisk(&model.Agent{Backend: "codex"}, " ")
+
+	require.NoError(t, err)
+	assert.Empty(t, sessions)
+}
+
+func TestResolveCodexHomeUsesEnvironment(t *testing.T) {
+	expected := filepath.Join(t.TempDir(), "custom", "..", "codex")
+	t.Setenv("CODEX_HOME", expected)
+
+	actual, err := resolveCodexHome()
+
+	require.NoError(t, err)
+	assert.Equal(t, filepath.Clean(expected), actual)
+}
+
+func TestScanCodexSessionsMissingRootAndDisabledLimits(t *testing.T) {
+	sessions, stats := scanCodexSessions(filepath.Join(t.TempDir(), "missing"), t.TempDir(), 100, 100)
+	assert.Empty(t, sessions)
+	assert.Zero(t, stats.scanned)
+
+	sessions, stats = scanCodexSessions(t.TempDir(), t.TempDir(), 0, 100)
+	assert.Empty(t, sessions)
+	assert.Zero(t, stats.scanned)
+}
+
+func TestScanCodexSessionsMarksScanLimitReached(t *testing.T) {
+	codexHome := t.TempDir()
+	project := t.TempDir()
+	for i := range 3 {
+		writeCodexRollout(t, codexHome, "2026/08/27",
+			fmt.Sprintf("00000000-0000-4000-8000-00000000003%d", i), project, time.Now())
+	}
+
+	sessions, stats := scanCodexSessions(filepath.Join(codexHome, "sessions"), project, 1, 10)
+
+	require.Len(t, sessions, 1)
+	assert.True(t, stats.limitReached)
+	assert.Equal(t, 1, stats.scanned)
+}
+
+func TestParseCodexSessionHeaderFallbacksAndErrors(t *testing.T) {
+	dir := t.TempDir()
+	modified := time.Date(2026, 8, 27, 13, 0, 0, 0, time.UTC)
+
+	sessionIDFallback := filepath.Join(dir, "session-id-fallback.jsonl")
+	require.NoError(t, os.WriteFile(sessionIDFallback, []byte(
+		"\n"+`{"timestamp":"2026-08-27T10-00-00","type":"session_meta","payload":{"session_id":"fallback-id","cwd":"/project"}}`+"\n",
+	), 0o644))
+	require.NoError(t, os.Chtimes(sessionIDFallback, modified, modified))
+	info, err := os.Stat(sessionIDFallback)
+	require.NoError(t, err)
+	session, err := parseCodexSessionHeader(sessionIDFallback, info)
+	require.NoError(t, err)
+	assert.Equal(t, "fallback-id", session.SessionID)
+	assert.Equal(t, time.Date(2026, 8, 27, 10, 0, 0, 0, time.UTC), session.CreatedAt)
+
+	wrongType := filepath.Join(dir, "wrong-type.jsonl")
+	require.NoError(t, os.WriteFile(wrongType, []byte(`{"type":"response_item","payload":{}}`+"\n"), 0o644))
+	info, err = os.Stat(wrongType)
+	require.NoError(t, err)
+	_, err = parseCodexSessionHeader(wrongType, info)
+	assert.ErrorContains(t, err, "first record type")
+
+	badPayload := filepath.Join(dir, "bad-payload.jsonl")
+	require.NoError(t, os.WriteFile(badPayload, []byte(`{"type":"session_meta","payload":"invalid"}`+"\n"), 0o644))
+	info, err = os.Stat(badPayload)
+	require.NoError(t, err)
+	_, err = parseCodexSessionHeader(badPayload, info)
+	assert.ErrorContains(t, err, "decode session metadata")
+
+	empty := filepath.Join(dir, "empty.jsonl")
+	require.NoError(t, os.WriteFile(empty, nil, 0o644))
+	info, err = os.Stat(empty)
+	require.NoError(t, err)
+	_, err = parseCodexSessionHeader(empty, info)
+	assert.ErrorContains(t, err, "session metadata not found")
+}
+
+func TestParseAndFormatCodexSessionTime(t *testing.T) {
+	assert.True(t, parseCodexSessionTime("").IsZero())
+	assert.True(t, parseCodexSessionTime("invalid").IsZero())
+	assert.Nil(t, formatCodexSessionTime(time.Time{}))
+
+	parsed := parseCodexSessionTime("2026-08-27T10:00:00.123456Z")
+	assert.Equal(t, 123456000, parsed.Nanosecond())
+	formatted := formatCodexSessionTime(parsed)
+	require.NotNil(t, formatted)
+	assert.Equal(t, "2026-08-27T10:00:00Z", *formatted)
 }

--- a/internal/handler/agent.go
+++ b/internal/handler/agent.go
@@ -8,7 +8,9 @@ import (
 	"os"
 	"path/filepath"
 	"regexp"
+	"sort"
 	"strings"
+	"time"
 	"unicode/utf8"
 
 	acp "github.com/coder/acp-go-sdk"
@@ -731,22 +733,39 @@ func acpSessionsCapCheck(w http.ResponseWriter, r *http.Request, loadSession, li
 // false an error response was written.
 func fetchACPSessions(w http.ResponseWriter, r *http.Request, agent *model.Agent, agentID string, conn *ai.ACPConn, listSessions bool, cursor string) ([]acp.SessionInfo, *string, bool) {
 	if listSessions {
-		if conn == nil {
-			slog.Warn("handler: failed to spawn ACP connection for ListSessions", "agent", agentID)
-			writeLocalizedErrorf(w, r, http.StatusServiceUnavailable, "ServiceUnavailable")
+		if conn != nil {
+			var cursorPtr *string
+			if cursor != "" {
+				cursorPtr = &cursor
+			}
+			sessions, nextCursor, err := conn.ListSessions(r.Context(), cursorPtr)
+			if err == nil {
+				if cursor == "" && ai.HasListSessionsFromDisk(agent.Backend) {
+					cwd := middleware.GetProjectFromCookie(r)
+					diskSessions, diskErr := ai.ListSessionsFromDisk(agent, cwd)
+					if diskErr != nil {
+						slog.Warn("handler: on-disk ListSessions augmentation failed",
+							"agent", agentID, "error", diskErr)
+					} else {
+						sessions = mergeACPSessions(sessions, diskSessions)
+					}
+				}
+				return sessions, nextCursor, true
+			}
+			slog.Warn("handler: ACP ListSessions failed; trying on-disk fallback",
+				"agent", agentID, "error", err)
+		} else {
+			slog.Warn("handler: failed to spawn ACP connection for ListSessions; trying on-disk fallback",
+				"agent", agentID)
+		}
+		if !ai.HasListSessionsFromDisk(agent.Backend) || cursor != "" {
+			if conn == nil {
+				writeLocalizedErrorf(w, r, http.StatusServiceUnavailable, "ServiceUnavailable")
+			} else {
+				writeLocalizedErrorf(w, r, http.StatusInternalServerError, "InternalError")
+			}
 			return nil, nil, false
 		}
-		var cursorPtr *string
-		if cursor != "" {
-			cursorPtr = &cursor
-		}
-		sessions, nextCursor, err := conn.ListSessions(r.Context(), cursorPtr)
-		if err != nil {
-			slog.Error("handler: ListSessions failed", "agent", agentID, "error", err)
-			writeLocalizedErrorf(w, r, http.StatusInternalServerError, "InternalError")
-			return nil, nil, false
-		}
-		return sessions, nextCursor, true
 	}
 
 	cwd := middleware.GetProjectFromCookie(r)
@@ -757,6 +776,39 @@ func fetchACPSessions(w http.ResponseWriter, r *http.Request, agent *model.Agent
 		return nil, nil, false
 	}
 	return sessions, nil, true
+}
+
+func mergeACPSessions(primary, fallback []acp.SessionInfo) []acp.SessionInfo {
+	seen := make(map[string]struct{}, len(primary)+len(fallback))
+	merged := make([]acp.SessionInfo, 0, len(primary)+len(fallback))
+	for _, group := range [][]acp.SessionInfo{primary, fallback} {
+		for _, session := range group {
+			id := string(session.SessionId)
+			if id == "" {
+				continue
+			}
+			if _, ok := seen[id]; ok {
+				continue
+			}
+			seen[id] = struct{}{}
+			merged = append(merged, session)
+		}
+	}
+	sort.SliceStable(merged, func(i, j int) bool {
+		return acpSessionUpdatedAt(merged[i]).After(acpSessionUpdatedAt(merged[j]))
+	})
+	return merged
+}
+
+func acpSessionUpdatedAt(session acp.SessionInfo) time.Time {
+	if session.UpdatedAt == nil {
+		return time.Time{}
+	}
+	parsed, err := time.Parse(time.RFC3339Nano, *session.UpdatedAt)
+	if err != nil {
+		return time.Time{}
+	}
+	return parsed
 }
 
 // filterAndRetitleACPSessions removes sessions already loaded into ClawBench

--- a/internal/handler/session_resume_test.go
+++ b/internal/handler/session_resume_test.go
@@ -3,6 +3,7 @@ package handler
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"net/http"
 	"net/http/httptest"
@@ -765,6 +766,151 @@ func TestServeACPSessions_DiskScanFallback(t *testing.T) {
 	assert.Equal(t, "disk-session-1", first["sessionId"])
 	assert.Equal(t, env.ProjectDir, first["cwd"])
 	assert.Equal(t, "磁盘会话", first["title"])
+}
+
+func TestServeACPSessions_MergesDiskSessionsIntoACPFirstPage(t *testing.T) {
+	env, teardown := setupTestEnv(t)
+	defer teardown()
+
+	const testBackend = "disk-augment-backend"
+	agentID := "acp-disk-augment"
+	model.Agents = map[string]*model.Agent{
+		agentID: {ID: agentID, Backend: testBackend, Transport: "acp-stdio", AcpCommand: "echo"},
+	}
+	model.AgentList = []*model.Agent{model.Agents[agentID]}
+	ai.GetAgentCapabilityRegistry().ForceUpdateIfNeeded(agentID, nil, nil, nil, nil, nil, true, true)
+
+	updatedRPC := "2026-08-27T10:00:00Z"
+	updatedDisk := "2026-08-27T11:00:00Z"
+	ai.ListSessionsFromDiskRegister(testBackend, func(a *model.Agent, cwd string) ([]acp.SessionInfo, error) {
+		assert.Equal(t, env.ProjectDir, cwd)
+		return []acp.SessionInfo{
+			{SessionId: "shared-session", Cwd: cwd, UpdatedAt: &updatedRPC},
+			{SessionId: "disk-only-session", Cwd: cwd, UpdatedAt: &updatedDisk},
+		}, nil
+	})
+	defer ai.ListSessionsFromDiskRegister(testBackend, nil)
+
+	connKey := agentID + ":"
+	conn := ai.NewACPConnForTest(model.Agents[agentID], connKey)
+	conn.SetAliveForTest()
+	conn.SetListSessionsFnForTest(func(ctx context.Context, cursor *string) ([]acp.SessionInfo, *string, error) {
+		return []acp.SessionInfo{
+			{SessionId: "rpc-only-session", Cwd: env.ProjectDir, UpdatedAt: &updatedRPC},
+			{SessionId: "shared-session", Cwd: env.ProjectDir, UpdatedAt: &updatedRPC},
+		}, nil, nil
+	})
+	mgr := ai.GetACPConnManager()
+	mgr.SetConnForTest(connKey, conn)
+	defer mgr.CloseConn(connKey)
+
+	req := newRequest(t, http.MethodGet, "/api/agents/"+agentID+"/acp-sessions", nil)
+	req = withProjectCookie(req, env.ProjectDir)
+	w := httptest.NewRecorder()
+	ServeACPSessions(w, req)
+
+	require.Equal(t, http.StatusOK, w.Code)
+	var resp struct {
+		Sessions []struct {
+			SessionID string `json:"sessionId"`
+		} `json:"sessions"`
+	}
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &resp))
+	require.Len(t, resp.Sessions, 3)
+	assert.Equal(t, "disk-only-session", resp.Sessions[0].SessionID)
+	assert.Equal(t, "rpc-only-session", resp.Sessions[1].SessionID)
+	assert.Equal(t, "shared-session", resp.Sessions[2].SessionID)
+}
+
+func TestServeACPSessions_FallsBackToDiskWhenACPListFails(t *testing.T) {
+	env, teardown := setupTestEnv(t)
+	defer teardown()
+
+	const testBackend = "disk-error-fallback-backend"
+	agentID := "acp-disk-error-fallback"
+	model.Agents = map[string]*model.Agent{
+		agentID: {ID: agentID, Backend: testBackend, Transport: "acp-stdio", AcpCommand: "echo"},
+	}
+	model.AgentList = []*model.Agent{model.Agents[agentID]}
+	ai.GetAgentCapabilityRegistry().ForceUpdateIfNeeded(agentID, nil, nil, nil, nil, nil, true, true)
+
+	ai.ListSessionsFromDiskRegister(testBackend, func(a *model.Agent, cwd string) ([]acp.SessionInfo, error) {
+		return []acp.SessionInfo{{SessionId: "disk-recovered-session", Cwd: cwd}}, nil
+	})
+	defer ai.ListSessionsFromDiskRegister(testBackend, nil)
+
+	connKey := agentID + ":"
+	conn := ai.NewACPConnForTest(model.Agents[agentID], connKey)
+	conn.SetAliveForTest()
+	conn.SetListSessionsFnForTest(func(ctx context.Context, cursor *string) ([]acp.SessionInfo, *string, error) {
+		return nil, nil, errors.New("session/list unavailable")
+	})
+	mgr := ai.GetACPConnManager()
+	mgr.SetConnForTest(connKey, conn)
+	defer mgr.CloseConn(connKey)
+
+	req := newRequest(t, http.MethodGet, "/api/agents/"+agentID+"/acp-sessions", nil)
+	req = withProjectCookie(req, env.ProjectDir)
+	w := httptest.NewRecorder()
+	ServeACPSessions(w, req)
+
+	require.Equal(t, http.StatusOK, w.Code)
+	assert.Contains(t, w.Body.String(), "disk-recovered-session")
+}
+
+func TestACPDiskDiscoveryToLoadSessionIntegration(t *testing.T) {
+	env, teardown := setupTestEnv(t)
+	defer teardown()
+
+	agentID := "disk-discovery-load"
+	discoveredID := "00000000-0000-4000-8000-000000000099"
+	model.Agents = map[string]*model.Agent{
+		agentID: {ID: agentID, Name: "Disk Discovery Load", Backend: "claude", Transport: "acp-stdio", AcpCommand: "echo"},
+	}
+	model.AgentList = []*model.Agent{model.Agents[agentID]}
+	ai.GetAgentCapabilityRegistry().ForceUpdateIfNeeded(agentID, nil, nil, nil, nil, nil, true, false)
+
+	ai.ListSessionsFromDiskRegister("claude", func(a *model.Agent, cwd string) ([]acp.SessionInfo, error) {
+		return []acp.SessionInfo{{SessionId: acp.SessionId(discoveredID), Cwd: cwd}}, nil
+	})
+	defer ai.ListSessionsFromDiskRegister("claude", nil)
+
+	listReq := newRequest(t, http.MethodGet, "/api/agents/"+agentID+"/acp-sessions", nil)
+	listReq = withProjectCookie(listReq, env.ProjectDir)
+	listRecorder := httptest.NewRecorder()
+	ServeACPSessions(listRecorder, listReq)
+	require.Equal(t, http.StatusOK, listRecorder.Code)
+
+	var listResp struct {
+		Sessions []struct {
+			SessionID string `json:"sessionId"`
+		} `json:"sessions"`
+	}
+	require.NoError(t, json.Unmarshal(listRecorder.Body.Bytes(), &listResp))
+	require.Len(t, listResp.Sessions, 1)
+
+	mockConn := ai.NewACPConnForTest(model.Agents[agentID], "disk-discovery-load-mock")
+	mockConn.SetAliveForTest()
+	mockConn.SetClientForTest(ai.NewClawBenchACPClient())
+	var loadedID string
+	origFn := getOrCreateConnForLoad
+	getOrCreateConnForLoad = func(ctx context.Context, agent *model.Agent, clawbenchSID, acpSID, cwd string) (*ai.ACPConn, error) {
+		loadedID = acpSID
+		ai.GetACPConnManager().SetConnForTest(clawbenchSID, mockConn)
+		return mockConn, nil
+	}
+	defer func() { getOrCreateConnForLoad = origFn }()
+
+	body := fmt.Sprintf(`{"agentId":%q,"acpSessionId":%q}`, agentID, listResp.Sessions[0].SessionID)
+	loadReq := httptest.NewRequest(http.MethodPost, "/api/ai/session/acp-load", strings.NewReader(body))
+	loadReq.Header.Set("Content-Type", "application/json")
+	withProjectCookie(loadReq, env.ProjectDir)
+	loadRecorder := httptest.NewRecorder()
+	ServeACPLoadSession(loadRecorder, loadReq)
+
+	require.Equal(t, http.StatusOK, loadRecorder.Code)
+	assert.Equal(t, discoveredID, loadedID)
+	assert.Contains(t, loadRecorder.Body.String(), "sessionId")
 }
 
 func TestServeACPSessions_FilterExistingExternalSessionID(t *testing.T) {

--- a/web/src/components/chat/AcpSessionDrawer.vue
+++ b/web/src/components/chat/AcpSessionDrawer.vue
@@ -115,14 +115,19 @@ function normalizeProjectPath(p: string): string {
   return result.replace(/\/+$/, '')
 }
 
+const displayableSessions = computed(() => {
+  if (backendId.value !== 'codex') return acpSessions.value
+  return acpSessions.value.filter((session) => session.title.trim() !== '')
+})
+
 const sessionsInCurrentProject = computed(() => {
   const root = normalizeProjectPath(store.state.projectRoot || '')
   if (!root) return []
-  return acpSessions.value.filter((s) => normalizeProjectPath(s.cwd || '') === root)
+  return displayableSessions.value.filter((s) => normalizeProjectPath(s.cwd || '') === root)
 })
 
 const hiddenOtherProjectCount = computed(
-  () => acpSessions.value.length - sessionsInCurrentProject.value.length
+  () => displayableSessions.value.length - sessionsInCurrentProject.value.length
 )
 
 const filteredSessions = computed(() => {

--- a/web/src/components/chat/AcpSessionDrawer.vue
+++ b/web/src/components/chat/AcpSessionDrawer.vue
@@ -95,14 +95,30 @@ const backendId = computed(() => getAgentBackend(props.agentId))
 const backendDisplayName = computed(() => getBackendDisplayName(backendId.value))
 const drawerTitle = computed(() => t('chat.acpSession.resumeTitle', { agent: backendDisplayName.value }))
 
-function trimTrailingSlash(p: string): string {
-  return p.replace(/\/+$/, '')
+function normalizeProjectPath(p: string): string {
+  const normalized = p.trim().replace(/\\/g, '/')
+  const isUnc = normalized.startsWith('//')
+  const isWindows = isUnc || /^[A-Za-z]:\//.test(normalized)
+  const parts: string[] = []
+  for (const part of normalized.split('/')) {
+    if (!part || part === '.') continue
+    if (part === '..') {
+      parts.pop()
+    } else {
+      parts.push(part)
+    }
+  }
+  let result = parts.join('/')
+  if (isUnc) result = `//${result}`
+  else if (normalized.startsWith('/')) result = `/${result}`
+  if (isWindows) result = result.toLowerCase()
+  return result.replace(/\/+$/, '')
 }
 
 const sessionsInCurrentProject = computed(() => {
-  const root = trimTrailingSlash(store.state.projectRoot || '')
+  const root = normalizeProjectPath(store.state.projectRoot || '')
   if (!root) return []
-  return acpSessions.value.filter((s) => trimTrailingSlash(s.cwd || '') === root)
+  return acpSessions.value.filter((s) => normalizeProjectPath(s.cwd || '') === root)
 })
 
 const hiddenOtherProjectCount = computed(

--- a/web/src/components/chat/__tests__/AcpSessionDrawer.test.ts
+++ b/web/src/components/chat/__tests__/AcpSessionDrawer.test.ts
@@ -274,6 +274,28 @@ describe('AcpSessionDrawer', () => {
       await nextTick()
       expect(wrapper.text()).toContain('Project Session')
     })
+
+    it('matches Windows paths ignoring drive case, slash style, dot segments, and spaces', async () => {
+      mockStoreState.projectRoot = String.raw`C:\Work\Repo With Spaces`
+      mockSessions.value = [
+        inProject('s1', 'Windows Project Session', 'c:/work/repo with spaces/./'),
+        inProject('s2', 'Other Windows Project', 'C:/Work/Other'),
+      ]
+
+      const wrapper = mountDrawer()
+      await nextTick()
+      expect(wrapper.text()).toContain('Windows Project Session')
+      expect(wrapper.text()).not.toContain('Other Windows Project')
+    })
+
+    it('matches UNC paths case-insensitively', async () => {
+      mockStoreState.projectRoot = String.raw`\\Server\Share\Repo`
+      mockSessions.value = [inProject('s1', 'UNC Project Session', '//server/share/repo/')]
+
+      const wrapper = mountDrawer()
+      await nextTick()
+      expect(wrapper.text()).toContain('UNC Project Session')
+    })
   })
 
   describe('loading indicator', () => {

--- a/web/src/components/chat/__tests__/AcpSessionDrawer.test.ts
+++ b/web/src/components/chat/__tests__/AcpSessionDrawer.test.ts
@@ -50,13 +50,14 @@ vi.mock('@/composables/useSessionIdentity', () => ({
 }))
 
 const mockStoreState = vi.hoisted(() => ({ projectRoot: '/project' }))
+const mockAgentBackend = vi.hoisted(() => ({ value: 'claude' }))
 vi.mock('@/stores/app.ts', () => ({
   store: { state: mockStoreState },
 }))
 
 vi.mock('@/composables/useAgents', () => ({
   useAgents: () => ({
-    getAgentBackend: () => 'claude',
+    getAgentBackend: () => mockAgentBackend.value,
   }),
 }))
 
@@ -124,6 +125,7 @@ describe('AcpSessionDrawer', () => {
     mockNextCursor.value = null
     mockResuming.value = false
     mockStoreState.projectRoot = '/project'
+    mockAgentBackend.value = 'claude'
   })
 
   describe('handleSelect', () => {
@@ -264,6 +266,20 @@ describe('AcpSessionDrawer', () => {
       await nextTick()
       expect(wrapper.text()).toContain('chat.acpSession.hiddenInOtherProjects')
       expect((wrapper.vm as { hiddenOtherProjectCount: number }).hiddenOtherProjectCount).toBe(2)
+    })
+
+    it('hides untitled Codex sessions without affecting other backends', async () => {
+      mockAgentBackend.value = 'codex'
+      mockSessions.value = [
+        inProject('s1', 'Main Session', '/project'),
+        inProject('s2', '', '/project'),
+        inProject('s3', '   ', '/project'),
+      ]
+
+      const wrapper = mountDrawer()
+      await nextTick()
+      expect(wrapper.text()).toContain('Main Session')
+      expect(wrapper.findAll('.acp-session-item')).toHaveLength(1)
     })
 
     it('matches the current project ignoring a trailing slash on cwd', async () => {

--- a/web/src/composables/__tests__/useAcpSession.test.ts
+++ b/web/src/composables/__tests__/useAcpSession.test.ts
@@ -120,6 +120,33 @@ describe('useAcpSession', () => {
       expect(acpSessions.value).toHaveLength(2)
     })
 
+    it('deduplicates sessions repeated on later ACP pages', async () => {
+      mockFetch
+        .mockResolvedValueOnce({
+          ok: true,
+          json: () => Promise.resolve({
+            sessions: [{ sessionId: 's1', title: 'First' }],
+            nextCursor: 'cursor-1',
+          }),
+        })
+        .mockResolvedValueOnce({
+          ok: true,
+          json: () => Promise.resolve({
+            sessions: [
+              { sessionId: 's1', title: 'Repeated' },
+              { sessionId: 's2', title: 'Second' },
+            ],
+            nextCursor: null,
+          }),
+        })
+
+      const { acpSessions, loadAcpSessions } = useAcpSession({ currentAgentId })
+      await loadAcpSessions()
+      await loadAcpSessions(undefined, true)
+
+      expect(acpSessions.value.map((session) => session.sessionId)).toEqual(['s1', 's2'])
+    })
+
     it('handles fetch exception gracefully', async () => {
       mockFetch.mockRejectedValue(new Error('network error'))
 

--- a/web/src/composables/useAcpSession.ts
+++ b/web/src/composables/useAcpSession.ts
@@ -67,7 +67,12 @@ export function useAcpSession(options: UseAcpSessionOptions) {
         updatedAt: s.updatedAt || s.updated_at || '',
       }))
       if (append) {
-        acpSessions.value.push(...sessions)
+        const existingIds = new Set(acpSessions.value.map((session) => session.sessionId))
+        acpSessions.value.push(...sessions.filter((session) => {
+          if (existingIds.has(session.sessionId)) return false
+          existingIds.add(session.sessionId)
+          return true
+        }))
       } else {
         acpSessions.value = sessions
       }


### PR DESCRIPTION
## Problem
Codex ACP session discovery is not consistently project-scoped, and some Codex versions/adapters do not reliably expose all resumable local sessions through `session/list`. This makes existing sessions difficult to find or restore from ClawBench.

Large histories also fail during `session/load` when a replay contains a JSON-RPC line larger than the current 1 MiB stdout scanner limit. Codex additionally persists many untitled subagent threads that clutter the restore drawer.

## Solution
- Keep native ACP `session/list` as the primary source.
- Augment its first page with a bounded local scan of `CODEX_HOME/sessions/YYYY/MM/DD/rollout-*.jsonl`.
- Fall back to the local scanner when ACP listing is unavailable or fails.
- Filter local records by normalized project path, including Windows drive casing, slash variants, dot segments, UNC paths, and paths containing spaces.
- Pass the persisted Codex thread ID unchanged to ACP `session/load`.
- Raise the bounded ACP stdout JSON message limit from 1 MiB to 32 MiB so large history replays do not fail with `bufio.Scanner: token too long`.
- Hide untitled Codex entries in the restore drawer; local files are not changed or deleted.

## Safety and performance
- Inspect at most 10,000 rollout files and return at most 200 matching sessions.
- Read at most 256 KiB from each rollout header.
- Extract only session ID, cwd, and timestamps; conversation content is not scanned.
- Malformed or incomplete files are skipped with bounded warning logs.
- An empty current-project path returns no disk sessions to avoid cross-project exposure.
- ACP messages retain a finite 32 MiB upper bound and a 64 KiB initial allocation.

## Tests
- Codex scanner unit coverage: ordering, limits, malformed/missing metadata, environment configuration, timestamps, Windows/UNC/POSIX path matching, and ACP conversion.
- Handler coverage: ACP augmentation, disk fallback, RPC-error fallback, deduplication, and discovered-ID-to-`LoadSession` flow.
- Frontend coverage: path normalization, pagination deduplication, and Codex untitled-session filtering.
- Large ACP JSON message regression test.

Validated locally:
- `go test ./internal/ai/backends/codex ./internal/handler -count=1`
- `npx vitest run web/src/components/chat/__tests__/AcpSessionDrawer.test.ts web/src/composables/__tests__/useAcpSession.test.ts --no-file-parallelism` — 47/47 passed
- `npm run typecheck`
- Real Codex session restore: HTTP 200, 76 messages replayed from a previously failing large history.

## Compatibility and limitations
- Existing non-Codex backends and ACP-first behavior are preserved.
- Only uncompressed `.jsonl` rollouts are scanned; `.jsonl.zst` is not currently supported.
- Untitled Codex main threads are hidden together with untitled subagent threads, but remain available in Codex local storage.