### PR TITLE
ci(auto-merge): merge instead of squash to preserve commit history

### DIFF
--- a/.github/workflows/auto-merge.yml
+++ b/.github/workflows/auto-merge.yml
@@ -127,7 +127,7 @@ jobs:
             echo "✅ All checks passed, merging PR #$PR_NUMBER"
             gh pr merge "$PR_NUMBER" \
               --repo "$GITHUB_REPOSITORY" \
-              --squash \
+              --merge \
               --admin \
               --subject "$(gh pr view "$PR_NUMBER" --repo "$GITHUB_REPOSITORY" --json title --jq '.title')" \
               --body "Auto-merged after CI passed"


### PR DESCRIPTION
将 auto-merge 的合并策略从 squash 改为 merge，保留每个 PR 的完整提交历史。