### PR TITLE
fix(ai): ACP 模式下 CodeBuddy 无法识别 ~/.codebuddy/skills/ 目录 skills

### DIFF
--- a/internal/ai/acp_backend.go
+++ b/internal/ai/acp_backend.go
@@ -134,6 +134,16 @@ func (b *ACPBackend) ExecuteStream(ctx context.Context, req ChatRequest) (<-chan
 
 		// Step 3: Send prompt
 		slog.Info("acp perf: ExecuteStream.step3_Prompt_start", "session_id", req.SessionID, "after_emitSession", time.Since(streamStart))
+	// Inject CodeBuddy skills prompt into system prompt so skills are
+	// available in ACP mode just like TUI mode.
+	if conn.skillsPrompt != "" {
+		if req.SystemPrompt != "" {
+			req.SystemPrompt = req.SystemPrompt + "\n\n" + conn.skillsPrompt
+		} else {
+			req.SystemPrompt = conn.skillsPrompt
+		}
+		slog.Info("acp: injected skills prompt into system prompt", "session_id", req.SessionID, "skills_len", len(conn.skillsPrompt))
+	}
 		promptBlocks := b.buildPromptBlocks(req)
 		err = conn.Prompt(ctx, promptBlocks, ch, req)
 		if err != nil {

--- a/internal/ai/acp_conn_lifecycle.go
+++ b/internal/ai/acp_conn_lifecycle.go
@@ -600,6 +600,29 @@ func (c *ACPConn) spawnLocked(ctx context.Context) error {
 		}
 	}
 
+	// Pre-scan CodeBuddy skills so they are available in ACP mode just like TUI mode.
+	// CodeBuddy's ACP process does not auto-scan ~/.codebuddy/skills/, so we
+	// scan them here and inject a skills summary into the system prompt.
+	// Skills also appear in the slash command menu (/) via AvailableCommandsUpdate.
+	if isCodeBuddyBackend(c.agent) {
+		if skills := ScanCodeBuddySkills(); len(skills) > 0 {
+			c.skillsPrompt = buildSkillsSystemPrompt(skills)
+
+			// Register skills as slash commands so they appear in the / menu
+			skillCmds := SkillsToCommands(skills)
+			agentID := c.agent.ID
+			existing := GetAgentCapabilityRegistry().GetCommands(agentID)
+			merged := MergeCommands(existing, skillCmds)
+			GetAgentCapabilityRegistry().UpdateCommands(agentID, merged)
+			client.MergeCommandsFromScan(skillCmds)
+
+			slog.Info("acp: pre-scanned CodeBuddy skills",
+				"agent", agentID, "skill_count", len(skills), "command_count", len(skillCmds))
+		} else {
+			c.skillsPrompt = ""
+		}
+	}
+
 	c.cmd = cmd
 	c.conn = conn
 	c.client = client

--- a/internal/ai/acp_pool.go
+++ b/internal/ai/acp_pool.go
@@ -789,6 +789,11 @@ type ACPConn struct {
 	// Protected by rawOutputMu. Cleared at the start of each Prompt call.
 	rawOutputMu  sync.Mutex
 	rawOutputBuf strings.Builder
+
+	// skillsPrompt is the pre-built system prompt section for CodeBuddy skills,
+	// injected into each prompt so CodeBuddy can auto-load skills. Populated
+	// during spawn for CodeBuddy backend. Empty if no skills found.
+	skillsPrompt string
 }
 
 // AppendRawOutput appends a raw ACP notification payload to the connection's

--- a/internal/ai/codebuddy_skill_scanner.go
+++ b/internal/ai/codebuddy_skill_scanner.go
@@ -1,0 +1,184 @@
+package ai
+
+import (
+	"log/slog"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+)
+
+// SkillInfo represents a discovered skill from ~/.codebuddy/skills/.
+type SkillInfo struct {
+	Name        string // skill name from YAML frontmatter
+	Description string // description from YAML frontmatter
+	Path        string // full path to the SKILL.md file
+}
+
+// ScanCodeBuddySkills scans ~/.codebuddy/skills/ for skill definitions.
+// Each skill is a directory containing SKILL.md with YAML frontmatter.
+// Returns nil if directory doesn't exist or no skills found.
+func ScanCodeBuddySkills() []SkillInfo {
+	home, err := os.UserHomeDir()
+	if err != nil {
+		slog.Debug("acp skill scan: cannot resolve home dir", "error", err)
+		return nil
+	}
+	skillsDir := filepath.Join(home, ".codebuddy", "skills")
+	return scanSkillsFromDir(skillsDir)
+}
+
+// scanSkillsFromDir scans the given directory for skill subdirectories containing SKILL.md.
+// Separated for testability (injectable directory path).
+func scanSkillsFromDir(skillsDir string) []SkillInfo {
+	if _, err := os.Stat(skillsDir); os.IsNotExist(err) {
+		slog.Debug("acp skill scan: skills directory does not exist", "path", skillsDir)
+		return nil
+	}
+
+	entries, err := os.ReadDir(skillsDir)
+	if err != nil {
+		slog.Debug("acp skill scan: cannot read skills directory", "path", skillsDir, "error", err)
+		return nil
+	}
+
+	var skills []SkillInfo
+	for _, entry := range entries {
+		if !entry.IsDir() {
+			continue
+		}
+		skillFile := filepath.Join(skillsDir, entry.Name(), "SKILL.md")
+		info, err := os.Stat(skillFile)
+		if err != nil || info.IsDir() {
+			continue
+		}
+
+		data, err := os.ReadFile(skillFile) //nolint:gosec // G122: path is constructed from ReadDir entries; skills are trusted local files
+		if err != nil {
+			slog.Debug("acp skill scan: cannot read skill file", "path", skillFile, "error", err)
+			continue
+		}
+
+		name, description, ok := parseSkillFrontmatter(data)
+		if !ok {
+			slog.Debug("acp skill scan: no valid frontmatter in skill file", "path", skillFile)
+			continue
+		}
+
+		skills = append(skills, SkillInfo{
+			Name:        name,
+			Description: description,
+			Path:        skillFile,
+		})
+	}
+
+	if len(skills) == 0 {
+		return nil
+	}
+
+	// Sort by name for deterministic output
+	sort.Slice(skills, func(i, j int) bool {
+		return skills[i].Name < skills[j].Name
+	})
+
+	slog.Info("acp skill scan: found CodeBuddy skills", "count", len(skills))
+	return skills
+}
+
+// parseSkillFrontmatter parses YAML frontmatter from a SKILL.md file.
+// Returns (name, description, true) on success, ("", "", false) on failure.
+//
+// Expected format:
+//
+//	---
+//	name: skill-name
+//	description: "Some description text"
+//	---
+//
+// NOTE: This is a minimal frontmatter parser. It handles single-line
+// name and description values (quoted or unquoted). Multi-line YAML scalars
+// are not supported.
+func parseSkillFrontmatter(data []byte) (string, string, bool) {
+	content := string(data)
+
+	// Opening --- must be at the start of the file (line 1, column 1).
+	if !strings.HasPrefix(content, "---") {
+		return "", "", false
+	}
+	afterOpen := content[3:]
+
+	// Find closing --- (must be on its own line)
+	closeIdx := strings.Index(afterOpen, "\n---")
+	if closeIdx < 0 {
+		return "", "", false
+	}
+	frontmatter := afterOpen[:closeIdx]
+
+	var name, description string
+	for _, line := range strings.Split(frontmatter, "\n") {
+		line = strings.TrimSpace(line)
+		if line == "" {
+			continue
+		}
+		if strings.HasPrefix(line, "name:") {
+			name = strings.TrimSpace(strings.TrimPrefix(line, "name:"))
+			name = strings.Trim(name, "\"'")
+		} else if strings.HasPrefix(line, "description:") {
+			description = strings.TrimSpace(strings.TrimPrefix(line, "description:"))
+			description = strings.Trim(description, "\"'")
+		}
+	}
+
+	if name == "" || description == "" {
+		return "", "", false
+	}
+
+	return name, description, true
+}
+
+// SkillsToCommands converts SkillInfo slices to AvailableCommandInfo so skills
+// appear in the slash command menu (/) just like plugin commands. CodeBuddy
+// TUI mode exposes skills this way; we mirror it in ACP mode.
+func SkillsToCommands(skills []SkillInfo) []AvailableCommandInfo {
+	if len(skills) == 0 {
+		return nil
+	}
+	cmds := make([]AvailableCommandInfo, 0, len(skills))
+	for _, s := range skills {
+		name := s.Name
+		if !strings.HasPrefix(name, "/") {
+			name = "/" + name
+		}
+		cmds = append(cmds, AvailableCommandInfo{
+			Name:        name,
+			Description: s.Description,
+		})
+	}
+	return cmds
+}
+
+// buildSkillsSystemPrompt generates a system prompt section that informs
+// CodeBuddy about available skills. This is injected into the session
+// system prompt so CodeBuddy can auto-load skills based on triggers.
+func buildSkillsSystemPrompt(skills []SkillInfo) string {
+	if len(skills) == 0 {
+		return ""
+	}
+
+	var b strings.Builder
+	b.WriteString("## Available Skills\n\n")
+	b.WriteString("The following skills are available in your environment. ")
+	b.WriteString("When a skill's description matches the current task, ")
+	b.WriteString("load and follow its instructions automatically.\n\n")
+	b.WriteString("| Skill | Description |\n")
+	b.WriteString("|-------|-------------|\n")
+	for _, s := range skills {
+		b.WriteString("| ")
+		b.WriteString(s.Name)
+		b.WriteString(" | ")
+		b.WriteString(s.Description)
+		b.WriteString(" |\n")
+	}
+
+	return b.String()
+}

--- a/internal/ai/codebuddy_skill_scanner_test.go
+++ b/internal/ai/codebuddy_skill_scanner_test.go
@@ -1,0 +1,392 @@
+package ai
+
+import (
+	"os"
+	"path/filepath"
+	"runtime"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestParseSkillFrontmatter(t *testing.T) {
+	tests := []struct {
+		name        string
+		input       string
+		wantName    string
+		wantDesc    string
+		wantOK      bool
+	}{
+		{
+			name: "valid frontmatter with name and description",
+			input: `---
+name: skill-creator
+description: Guide for creating effective skills
+---
+Body text here`,
+			wantName: "skill-creator",
+			wantDesc: "Guide for creating effective skills",
+			wantOK:   true,
+		},
+		{
+			name: "valid frontmatter with quotes",
+			input: `---
+name: "test-skill"
+description: "Test description"
+---
+Body`,
+			wantName: "test-skill",
+			wantDesc: "Test description",
+			wantOK:   true,
+		},
+		{
+			name: "valid frontmatter with single quotes",
+			input: `---
+name: 'my-skill'
+description: 'My description'
+---
+Body`,
+			wantName: "my-skill",
+			wantDesc: "My description",
+			wantOK:   true,
+		},
+		{
+			name:   "no frontmatter",
+			input:  "Just a regular file without frontmatter",
+			wantOK: false,
+		},
+		{
+			name: "frontmatter without name",
+			input: `---
+description: Missing name
+---
+Body`,
+			wantOK: false,
+		},
+		{
+			name: "frontmatter without description",
+			input: `---
+name: missing-desc
+---
+Body`,
+			wantOK: false,
+		},
+		{
+			name: "empty name",
+			input: `---
+name: ""
+description: test
+---
+Body`,
+			wantOK: false,
+		},
+		{
+			name: "empty description",
+			input: `---
+name: test
+description: ""
+---
+Body`,
+			wantOK: false,
+		},
+		{
+			name:   "missing closing delimiter",
+			input:  "---\nname: test\ndescription: test",
+			wantOK: false,
+		},
+		{
+			name:   "--- not at start of file",
+			input:  "Some text before\n---\nname: test\ndescription: test\n---\nBody",
+			wantOK: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			name, desc, ok := parseSkillFrontmatter([]byte(tt.input))
+			assert.Equal(t, tt.wantOK, ok)
+			if ok {
+				assert.Equal(t, tt.wantName, name)
+				assert.Equal(t, tt.wantDesc, desc)
+			}
+		})
+	}
+}
+
+func TestScanSkillsFromDir_ValidDir(t *testing.T) {
+	tmpDir := t.TempDir()
+
+	// Create skill-creator/SKILL.md
+	skillDir := filepath.Join(tmpDir, "skill-creator")
+	require.NoError(t, os.MkdirAll(skillDir, 0o755))
+	require.NoError(t, os.WriteFile(filepath.Join(skillDir, "SKILL.md"), []byte(`---
+name: skill-creator
+description: Guide for creating effective skills
+---
+
+# Skill Creator
+
+Guide for creating skills`), 0o644))
+
+	// Create another-skill/SKILL.md
+	skillDir2 := filepath.Join(tmpDir, "another-skill")
+	require.NoError(t, os.MkdirAll(skillDir2, 0o755))
+	require.NoError(t, os.WriteFile(filepath.Join(skillDir2, "SKILL.md"), []byte(`---
+name: another-skill
+description: Another skill description
+---
+
+# Another Skill`), 0o644))
+
+	skills := scanSkillsFromDir(tmpDir)
+	require.Len(t, skills, 2)
+
+	// Results are sorted by name
+	assert.Equal(t, "another-skill", skills[0].Name)
+	assert.Equal(t, "Another skill description", skills[0].Description)
+	assert.Contains(t, skills[0].Path, filepath.Join("another-skill", "SKILL.md"))
+	assert.Equal(t, "skill-creator", skills[1].Name)
+	assert.Equal(t, "Guide for creating effective skills", skills[1].Description)
+	assert.Contains(t, skills[1].Path, filepath.Join("skill-creator", "SKILL.md"))
+}
+
+func TestScanSkillsFromDir_MissingDir(t *testing.T) {
+	skills := scanSkillsFromDir("/nonexistent/path")
+	assert.Nil(t, skills)
+}
+
+func TestScanSkillsFromDir_EmptyDir(t *testing.T) {
+	tmpDir := t.TempDir()
+	skills := scanSkillsFromDir(tmpDir)
+	assert.Nil(t, skills)
+}
+
+func TestScanSkillsFromDir_SkipsNonSkillMd(t *testing.T) {
+	tmpDir := t.TempDir()
+
+	// Create a subdirectory with non-SKILL.md file
+	skillDir := filepath.Join(tmpDir, "some-skill")
+	require.NoError(t, os.MkdirAll(skillDir, 0o755))
+	require.NoError(t, os.WriteFile(filepath.Join(skillDir, "README.md"), []byte(`---
+name: readme
+description: Should be skipped
+---
+Body`), 0o644))
+
+	// Create a valid SKILL.md
+	skillDir2 := filepath.Join(tmpDir, "valid-skill")
+	require.NoError(t, os.MkdirAll(skillDir2, 0o755))
+	require.NoError(t, os.WriteFile(filepath.Join(skillDir2, "SKILL.md"), []byte(`---
+name: valid-skill
+description: Valid skill
+---
+Body`), 0o644))
+
+	skills := scanSkillsFromDir(tmpDir)
+	require.Len(t, skills, 1)
+	assert.Equal(t, "valid-skill", skills[0].Name)
+}
+
+func TestScanSkillsFromDir_InvalidFrontmatter(t *testing.T) {
+	tmpDir := t.TempDir()
+
+	// File without frontmatter
+	skillDir := filepath.Join(tmpDir, "broken")
+	require.NoError(t, os.MkdirAll(skillDir, 0o755))
+	require.NoError(t, os.WriteFile(filepath.Join(skillDir, "SKILL.md"), []byte("No frontmatter here"), 0o644))
+
+	// File with empty name
+	skillDir2 := filepath.Join(tmpDir, "empty-name")
+	require.NoError(t, os.MkdirAll(skillDir2, 0o755))
+	require.NoError(t, os.WriteFile(filepath.Join(skillDir2, "SKILL.md"), []byte(`---
+name: ""
+description: test
+---
+Body`), 0o644))
+
+	skills := scanSkillsFromDir(tmpDir)
+	assert.Nil(t, skills)
+}
+
+func TestScanSkillsFromDir_SkipsUnreadableFile(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("Unix file permissions not supported on Windows")
+	}
+	if os.Getuid() == 0 {
+		t.Skip("root user can read all files, permission-based test unreliable")
+	}
+
+	tmpDir := t.TempDir()
+	skillDir := filepath.Join(tmpDir, "secret-skill")
+	require.NoError(t, os.MkdirAll(skillDir, 0o755))
+	unreadable := filepath.Join(skillDir, "SKILL.md")
+	require.NoError(t, os.WriteFile(unreadable, []byte(`---
+name: secret
+description: Cannot read me
+---
+Body`), 0o644))
+	require.NoError(t, os.Chmod(unreadable, 0o000))
+	defer os.Chmod(unreadable, 0o644)
+
+	skills := scanSkillsFromDir(tmpDir)
+	assert.Nil(t, skills)
+}
+
+func TestScanCodeBuddySkills_RealHomeDir(t *testing.T) {
+	tmpDir := t.TempDir()
+	skillsDir := filepath.Join(tmpDir, ".codebuddy", "skills")
+	skillDir := filepath.Join(skillsDir, "skill-creator")
+	require.NoError(t, os.MkdirAll(skillDir, 0o755))
+	require.NoError(t, os.WriteFile(filepath.Join(skillDir, "SKILL.md"), []byte(`---
+name: skill-creator
+description: Guide for creating effective skills
+---
+Body`), 0o644))
+
+	if runtime.GOOS == "windows" {
+		origProfile := os.Getenv("USERPROFILE")
+		require.NoError(t, os.Setenv("USERPROFILE", tmpDir))
+		defer os.Setenv("USERPROFILE", origProfile)
+	} else {
+		origHome := os.Getenv("HOME")
+		require.NoError(t, os.Setenv("HOME", tmpDir))
+		defer os.Setenv("HOME", origHome)
+	}
+
+	skills := ScanCodeBuddySkills()
+	require.Len(t, skills, 1)
+	assert.Equal(t, "skill-creator", skills[0].Name)
+	assert.Equal(t, "Guide for creating effective skills", skills[0].Description)
+}
+
+func TestScanCodeBuddySkills_RealHomeDir_NoSkillsDir(t *testing.T) {
+	tmpDir := t.TempDir()
+	if runtime.GOOS == "windows" {
+		origProfile := os.Getenv("USERPROFILE")
+		require.NoError(t, os.Setenv("USERPROFILE", tmpDir))
+		defer os.Setenv("USERPROFILE", origProfile)
+	} else {
+		origHome := os.Getenv("HOME")
+		require.NoError(t, os.Setenv("HOME", tmpDir))
+		defer os.Setenv("HOME", origHome)
+	}
+
+	skills := ScanCodeBuddySkills()
+	assert.Nil(t, skills)
+}
+
+func TestBuildSkillsSystemPrompt(t *testing.T) {
+	tests := []struct {
+		name    string
+		skills  []SkillInfo
+		want    string
+		wantLen int
+	}{
+		{
+			name:    "nil skills",
+			skills:  nil,
+			want:    "",
+			wantLen: 0,
+		},
+		{
+			name:    "empty skills",
+			skills:  []SkillInfo{},
+			want:    "",
+			wantLen: 0,
+		},
+		{
+			name: "single skill",
+			skills: []SkillInfo{
+				{Name: "skill-creator", Description: "Guide for creating skills"},
+			},
+			wantLen: 1,
+		},
+		{
+			name: "multiple skills",
+			skills: []SkillInfo{
+				{Name: "another", Description: "Another skill"},
+				{Name: "skill-creator", Description: "Guide for creating skills"},
+			},
+			wantLen: 2,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := buildSkillsSystemPrompt(tt.skills)
+			if tt.wantLen == 0 {
+				assert.Empty(t, got)
+			} else {
+				assert.NotEmpty(t, got)
+				assert.Contains(t, got, "Skills")
+				for _, s := range tt.skills {
+					assert.Contains(t, got, s.Name)
+					assert.Contains(t, got, s.Description)
+				}
+			}
+		})
+	}
+}
+
+func TestSkillsToCommands(t *testing.T) {
+	tests := []struct {
+		name       string
+		skills     []SkillInfo
+		wantNil    bool
+		wantNames  []string
+		wantDescs  []string
+		wantLen    int
+	}{
+		{
+			name:    "nil skills",
+			skills:  nil,
+			wantNil: true,
+		},
+		{
+			name:    "empty skills",
+			skills:  []SkillInfo{},
+			wantNil: true,
+		},
+		{
+			name: "single skill without slash",
+			skills: []SkillInfo{
+				{Name: "skill-creator", Description: "Guide for creating skills"},
+			},
+			wantNames: []string{"/skill-creator"},
+			wantDescs: []string{"Guide for creating skills"},
+			wantLen:   1,
+		},
+		{
+			name: "single skill with slash prefix",
+			skills: []SkillInfo{
+				{Name: "/skill-creator", Description: "Guide for creating skills"},
+			},
+			wantNames: []string{"/skill-creator"},
+			wantDescs: []string{"Guide for creating skills"},
+			wantLen:   1,
+		},
+		{
+			name: "multiple skills",
+			skills: []SkillInfo{
+				{Name: "skill-creator", Description: "Guide for creating skills"},
+				{Name: "docx", Description: "Word doc manipulation"},
+			},
+			wantNames: []string{"/skill-creator", "/docx"},
+			wantDescs: []string{"Guide for creating skills", "Word doc manipulation"},
+			wantLen:   2,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := SkillsToCommands(tt.skills)
+			if tt.wantNil {
+				assert.Nil(t, got)
+				return
+			}
+			require.Len(t, got, tt.wantLen)
+			for i, wantName := range tt.wantNames {
+				assert.Equal(t, wantName, got[i].Name, "command name mismatch at index %d", i)
+				assert.Equal(t, tt.wantDescs[i], got[i].Description, "command description mismatch at index %d", i)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## 变更说明

CodeBuddy ACP 模式缺失对 `~/.codebuddy/skills/` 目录的扫描。用户输入 `/` 时，命令列表中不显示 skills（如 `/skill-creator`），而 TUI 模式可以正常识别和使用这些 skills。本 PR 仿照现有 `plugins/cache/**/commands/*.md` 扫描机制，新增 skills 目录扫描，并通过 `AvailableCommandsUpdate` 暴露给前端。

## 变更类型

- [x] fix: Bug 修复

## 关联 Issue

<!-- 如有相关 Issue 请填入，例如 Fixes #N -->

## 测试

- [x] 已通过现有测试（`go test ./...`）
- [x] 已添加新测试覆盖（`codebuddy_skill_scanner_test.go`，10 个测试函数，全部通过）
- [x] 手动验证：启动服务后调用 `/api/agents`，确认 CodeBuddy 命令列表已包含 `/skill-creator`

## 自检清单

- [x] 代码遵循项目现有风格
- [x] 无硬编码密钥或敏感信息
- [x] 变更已反映在文档中（如适用）

---

## 详细变更范围

| 文件 | 变更 | 说明 |
|---|---|---|
| `internal/ai/codebuddy_skill_scanner.go` | **新增** (+184) | Skills 扫描器：扫描目录、解析 YAML frontmatter、生成命令和 system prompt |
| `internal/ai/codebuddy_skill_scanner_test.go` | **新增** (+392) | TDD 单元测试：`TestParseSkillFrontmatter` 等 10 个测试函数 |
| `internal/ai/acp_conn_lifecycle.go` | +23 | `spawnLocked()` 中预扫描 skills 并注册到 capability registry |
| `internal/ai/acp_backend.go` | +10 | `ExecuteStream()` 注入 skills system prompt |
| `internal/ai/acp_pool.go` | +5 | `ACPConn` 新增 `skillsPrompt` 缓存字段 |

## 技术细节

- **Dual Exposure 策略**：skills 同时通过 (a) `AvailableCommandsUpdate` 注册为 slash 命令供用户触发，(b) system prompt 注入供 AI 自动匹配
- **Token 控制**：只注入 name+description 摘要（不注入 SKILL.md 全文），避免 token 爆炸
- **缓存**：`skillsPrompt` 在 `ACPConn` 级别缓存，避免每次请求重复扫描文件系统
