### PR TITLE
fix(settings): restore zero-means-off defaults lost in batch sync (#402 regression)

### DIFF
--- a/internal/model/config.go
+++ b/internal/model/config.go
@@ -55,14 +55,14 @@ type Config struct {
 		InitialMessages          int  `yaml:"initial_messages"`           // Number of messages to load initially (default: 20)
 		PageSize                 int  `yaml:"page_size"`                  // Number of messages per lazy-load batch (default: 20)
 		SessionPageSize          int  `yaml:"session_page_size"`          // Number of sessions per page in session list (default: 10)
-		SystemPromptInterval     int  `yaml:"system_prompt_interval"`     // Re-inject system prompt every N assistant turns (0=never, default: 10)
+		SystemPromptInterval     int  `yaml:"system_prompt_interval"`     // Re-inject system prompt every N assistant turns (0=never, default: 0)
 		RecommendEnabled         bool `yaml:"recommend_enabled"`          // 推荐回复: generate a next-step recommendation after each assistant reply (default: false)
 		RecommendContextMessages int  `yaml:"recommend_context_messages"` // 推荐回复参考的最近消息条数（用户+助手） (default: 10)
 	} `yaml:"chat"`
 	Session struct {
 		MaxCount                int  `yaml:"max_count"`                 // Maximum number of chat sessions per project (default: 10)
 		ArchiveRetentionEnabled bool `yaml:"archive_retention_enabled"` // Enable auto-purge of archived sessions after retention period (default: false)
-		ArchiveRetentionDays    int  `yaml:"archive_retention_days"`    // Days to keep archived sessions before auto-purge (0=keep forever, default: 30)
+		ArchiveRetentionDays    int  `yaml:"archive_retention_days"`    // Days to keep archived sessions before auto-purge (0=keep forever, default: 0)
 	} `yaml:"session"`
 	RecentProjects struct {
 		MaxCount int `yaml:"max_count"` // Maximum number of recent projects to keep (default: 10)

--- a/internal/model/defaults.go
+++ b/internal/model/defaults.go
@@ -136,8 +136,16 @@ func ApplyDefaults(cfg *Config, presence map[string]bool) string { //nolint:goco
 	if cfg.Chat.SessionPageSize <= 0 {
 		cfg.Chat.SessionPageSize = 10
 	}
-	if cfg.Chat.SystemPromptInterval <= 0 {
-		cfg.Chat.SystemPromptInterval = 10
+	// SystemPromptInterval: 0 = never re-inject is the intentional DEFAULT.
+	// The old `<= 0 → 10` rewrite made 0 unexpressable — a user who
+	// explicitly disabled periodic re-injection was silently switched back
+	// to every-10-turns. Negative values (hand-edited yaml only; PATCH
+	// rejects them earlier) clamp to 0.
+	// 0 = 从不重注即为默认值。旧的 `<= 0 → 10` 改写使 0 无法表达——显式
+	// 关闭周期性重注的用户会被静默改回每 10 轮。负值(仅手改 yaml 可产生;
+	// PATCH 已在更早处拦截)收敛为 0。
+	if cfg.Chat.SystemPromptInterval < 0 {
+		cfg.Chat.SystemPromptInterval = 0
 	}
 	// RecommendEnabled: bool zero-value (false) is the intentional default.
 	// Use presence map to distinguish "user wrote false" from "user omitted the field".
@@ -159,8 +167,14 @@ func ApplyDefaults(cfg *Config, presence map[string]bool) string { //nolint:goco
 	} else {
 		cfg.Session.ArchiveRetentionEnabled = false
 	}
-	if cfg.Session.ArchiveRetentionDays <= 0 {
-		cfg.Session.ArchiveRetentionDays = 30
+	// ArchiveRetentionDays: 0 = keep forever is the intentional DEFAULT —
+	// archived sessions should not vanish by surprise. The old `<= 0 → 30`
+	// rewrite made 0 unexpressable, so a user who wanted retention disabled
+	// was silently enrolled in a 30-day purge. Negative values clamp to 0.
+	// 0 = 永久保留即为默认值——归档会话不应莫名消失。旧的 `<= 0 → 30` 改写
+	// 使 0 无法表达,想关闭留存的用户被静默纳入 30 天清理。负值收敛为 0。
+	if cfg.Session.ArchiveRetentionDays < 0 {
+		cfg.Session.ArchiveRetentionDays = 0
 	}
 
 	// --- Recent Projects ---

--- a/internal/model/defaults_test.go
+++ b/internal/model/defaults_test.go
@@ -465,8 +465,8 @@ func TestApplyDefaults_ChatSessionPageSize(t *testing.T) {
 	if cfg.Chat.SessionPageSize != 10 {
 		t.Errorf("Chat.SessionPageSize = %d, want 10", cfg.Chat.SessionPageSize)
 	}
-	if cfg.Chat.SystemPromptInterval != 10 {
-		t.Errorf("Chat.SystemPromptInterval = %d, want 10", cfg.Chat.SystemPromptInterval)
+	if cfg.Chat.SystemPromptInterval != 0 {
+		t.Errorf("Chat.SystemPromptInterval = %d, want 0 (never is the default)", cfg.Chat.SystemPromptInterval)
 	}
 }
 
@@ -811,5 +811,48 @@ func TestApplyDefaults_PushMode_ExplicitFeishuSyncsEnabled(t *testing.T) {
 	}
 	if cfg.DingTalk.Enabled {
 		t.Error("expected DingTalk.Enabled=false when PushMode=feishu")
+	}
+}
+
+func TestApplyDefaults_ZeroMeansOff_NotRewritten(t *testing.T) {
+	setupTestBinDir(t)
+
+	// The old `<= 0 → N` rewrites made the documented 0 ("never" / "keep
+	// forever") unexpressable — an explicit 0 was silently replaced by the
+	// nonzero default. 0 must now survive ApplyDefaults.
+	cfg := Config{}
+	cfg.Chat.SystemPromptInterval = 0
+	cfg.Session.ArchiveRetentionDays = 0
+	ApplyDefaults(&cfg, nil)
+	if cfg.Chat.SystemPromptInterval != 0 {
+		t.Errorf("explicit SystemPromptInterval=0 rewritten to %d, want 0", cfg.Chat.SystemPromptInterval)
+	}
+	if cfg.Session.ArchiveRetentionDays != 0 {
+		t.Errorf("explicit ArchiveRetentionDays=0 rewritten to %d, want 0", cfg.Session.ArchiveRetentionDays)
+	}
+
+	// Explicit nonzero values are preserved as-is.
+	cfg = Config{}
+	cfg.Chat.SystemPromptInterval = 3
+	cfg.Session.ArchiveRetentionDays = 90
+	ApplyDefaults(&cfg, nil)
+	if cfg.Chat.SystemPromptInterval != 3 {
+		t.Errorf("explicit SystemPromptInterval=3 rewritten to %d, want 3", cfg.Chat.SystemPromptInterval)
+	}
+	if cfg.Session.ArchiveRetentionDays != 90 {
+		t.Errorf("explicit ArchiveRetentionDays=90 rewritten to %d, want 90", cfg.Session.ArchiveRetentionDays)
+	}
+
+	// Negative (only possible via hand-edited yaml) clamps to 0, not to a
+	// nonzero default.
+	cfg = Config{}
+	cfg.Chat.SystemPromptInterval = -1
+	cfg.Session.ArchiveRetentionDays = -7
+	ApplyDefaults(&cfg, nil)
+	if cfg.Chat.SystemPromptInterval != 0 {
+		t.Errorf("negative SystemPromptInterval=%d, want clamp to 0", cfg.Chat.SystemPromptInterval)
+	}
+	if cfg.Session.ArchiveRetentionDays != 0 {
+		t.Errorf("negative ArchiveRetentionDays=%d, want clamp to 0", cfg.Session.ArchiveRetentionDays)
 	}
 }

--- a/web/src/i18n/locales/en.ts
+++ b/web/src/i18n/locales/en.ts
@@ -1661,7 +1661,7 @@ export default {
       messageDisplayModeSummary: 'Summary mode',
       messageDisplayModeOriginal: 'Original text',
       chatSystemPromptInterval: 'System Prompt Interval',
-      chatSystemPromptIntervalDesc: 'Insert a system prompt every N messages',
+      chatSystemPromptIntervalDesc: 'Insert a system prompt every N messages (0 = never)',
       sessionMaxCount: 'Max Sessions',
       sessionMaxCountDesc: 'Maximum number of concurrent chat sessions',
       archiveRetentionSectionHeader: 'Archive Retention',

--- a/web/src/i18n/locales/zh.ts
+++ b/web/src/i18n/locales/zh.ts
@@ -1661,7 +1661,7 @@ export default {
       messageDisplayModeSummary: '摘要模式',
       messageDisplayModeOriginal: '原文模式',
       chatSystemPromptInterval: '系统提示间隔',
-      chatSystemPromptIntervalDesc: '每隔多少条消息插入一次系统提示',
+      chatSystemPromptIntervalDesc: '每隔多少条消息插入一次系统提示（0 = 从不插入）',
       sessionMaxCount: '最大会话数',
       sessionMaxCountDesc: '允许同时存在的聊天会话上限',
       archiveRetentionSectionHeader: '归档留存',


### PR DESCRIPTION
Fixes #424

## 问题

批量同步 commit 2939194 把已合并的 #402 hunks 原样回退，重新引入「0 不可表达」bug：`chat.system_prompt_interval: 0` 与 `session.archive_retention_days: 0` 在每次启动时被 `<= 0 → 10/30` 静默覆盖（磁盘文件不动，运行时变值）。v0.87.0 实测复现，详见 #424。

## 修复

逐 hunk 恢复 39b8440（#402）的原始实现，共 5 个文件 +67/−10，与其原始 diff 完全镜像：

- `internal/model/defaults.go` — `< 0 → 收敛为 0`（0 为合法值且是默认），恢复双语注释
- `internal/model/config.go` — 字段注释恢复 `default: 0`
- `internal/model/defaults_test.go` — 恢复被删除的回归测试 `TestApplyDefaults_ZeroMeansOff_NotRewritten`
- `web/src/i18n/locales/{en,zh}.ts` — 恢复设置页「(0 = never) /（0 = 从不插入）」提示

## 验证

- `go test ./internal/model/` ✅（含恢复的回归测试）
- `go test ./internal/handler/` ✅
- `go test ./...` 全量 ✅ exit 0
- 实机验证：修复前 v0.87.0 启动后 `/api/config` 返回 10/30（config.yaml 为 0）

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude <noreply@anthropic.com>