### PR TITLE
fix(acp): consume LoadSessionResponse state so reopened sessions keep their model list

### DIFF
--- a/internal/ai/acp_conn_state.go
+++ b/internal/ai/acp_conn_state.go
@@ -60,9 +60,18 @@ func (c *ACPConn) CacheNewSessionState() {
 // MergeResumedSessionState merges state from a ResumeSessionResponse, preserving
 // the user's current selections (re-applied by ensureAliveWithSession) while
 // updating available options lists from the resumed agent via the registry.
+// Sessions restored via the LoadSession path stash a LoadSessionResponse instead
+// (recoverViaLoadSession / SyncLoadSession), so when no resume response is
+// present we fall back to the load response — otherwise the model list (and
+// mode/effort options) would never reach the registry and the UI would keep
+// showing the static CLI-discovered defaults.
 func (c *ACPConn) MergeResumedSessionState() {
 	resumeResp := c.GetAndClearResumeSessionResp()
 	if resumeResp == nil {
+		if loadResp := c.GetAndClearLoadSessionResp(); loadResp != nil {
+			c.mergeLoadedSessionState(loadResp)
+			return
+		}
 		slog.Warn("acp: MergeResumedSessionState called with nil resumeResp")
 		return
 	}
@@ -79,6 +88,52 @@ func (c *ACPConn) MergeResumedSessionState() {
 	)
 
 	c.applyExtractedState(ext)
+}
+
+// mergeLoadedSessionState extracts session state from a LoadSessionResponse
+// (the caller has already consumed it from the stash). Mirrors the resume path:
+// LoadSessionResponse carries the same Modes + ConfigOptions shape.
+func (c *ACPConn) mergeLoadedSessionState(loadResp *acp.LoadSessionResponse) {
+	slog.Info(
+		"acp: merging loaded session state",
+		"has_modes", loadResp.Modes != nil,
+		"config_options_count", len(loadResp.ConfigOptions),
+	)
+
+	ext := c.extractLoadedSessionState(loadResp)
+	c.applyExtractedState(ext)
+}
+
+// extractLoadedSessionState extracts mode/config/thinking/model state from a
+// LoadSessionResponse, mirroring the resume branch of extractSessionState.
+func (c *ACPConn) extractLoadedSessionState(loadResp *acp.LoadSessionResponse) sessionStateExtracted {
+	var ext sessionStateExtracted
+
+	if modeState := extractACPModeStateFromLoad(loadResp); modeState != nil {
+		ext.modes = modeState.AvailableModes
+		ext.modeCurrentID = modeState.CurrentModeID
+		slog.Info("acp: loaded mode state", "current", modeState.CurrentModeID, "available", len(modeState.AvailableModes))
+	} else {
+		slog.Info("acp: no mode from loaded v1 Modes field")
+	}
+	ext.configState = extractACPConfigOptionsFromLoad(loadResp)
+	if effortState := extractACPThinkingEffortFromLoad(loadResp); effortState != nil {
+		ext.efforts = effortState.AvailableLevels
+		ext.effortCurrentID = effortState.CurrentID
+	}
+	if modelList := extractACPModelListFromLoad(loadResp); modelList != nil {
+		ext.models = modelList.Models
+		ext.modelCurrentID = modelList.CurrentModelID
+		slog.Info("acp: extracted model list from loaded session", "current", modelList.CurrentModelID, "available", len(modelList.Models))
+	} else if c.stdoutFilter != nil {
+		if cached := c.stdoutFilter.GetAndClearCachedModels(); cached != nil {
+			ext.models = cached.Models
+			ext.modelCurrentID = cached.CurrentModelID
+			slog.Info("acp: extracted model list from loaded SessionModelState extension", "current", cached.CurrentModelID, "available", len(cached.Models))
+		}
+	}
+
+	return ext
 }
 
 // extractSessionState extracts mode/config/thinking/model state from a session response.

--- a/internal/ai/acp_conn_state_test.go
+++ b/internal/ai/acp_conn_state_test.go
@@ -309,6 +309,164 @@ func TestExtractACPModelListFromLoad_NilAndPopulated(t *testing.T) {
 	assert.Equal(t, "glm-5.3[1m]", ml.Models[1].Name)
 }
 
+func TestExtractACPStateFromLoad_NilResponses(t *testing.T) {
+	// The FromLoad extractors must be nil-safe: a nil LoadSessionResponse or a
+	// response with no relevant ConfigOptions yields nil (never a panic).
+	assert.Nil(t, extractACPModeStateFromLoad(nil))
+	assert.Nil(t, extractACPConfigOptionsFromLoad(nil))
+	assert.Nil(t, extractACPThinkingEffortFromLoad(nil))
+
+	// Empty ConfigOptions also yields nil for each extractor.
+	empty := &acp.LoadSessionResponse{}
+	assert.Nil(t, extractACPModeStateFromLoad(empty))
+	assert.Nil(t, extractACPConfigOptionsFromLoad(empty))
+	assert.Nil(t, extractACPThinkingEffortFromLoad(empty))
+	assert.Nil(t, extractACPModelListFromLoad(empty))
+}
+
+func TestMergeResumedSessionState_LoadResponseAllStateExtracted(t *testing.T) {
+	// A LoadSessionResponse carrying mode + thought_level + model config
+	// options must flow through the merge fallback into the registry — the
+	// mirror of the resume path when every sub-extractor returns non-nil.
+	agent := &model.Agent{ID: "test-merge-load-all", Backend: "acp-stdio", AcpCommand: "echo"}
+	conn := newACPConn(agent, "test-merge-load-all")
+
+	modeCat := acp.SessionConfigOptionCategoryMode
+	thoughtCat := acp.SessionConfigOptionCategoryThoughtLevel
+	modelCat := acp.SessionConfigOptionCategoryModel
+	loadResp := &acp.LoadSessionResponse{
+		Modes: &acp.SessionModeState{
+			CurrentModeId: "plan",
+			AvailableModes: []acp.SessionMode{
+				{Id: "plan", Name: "Plan"},
+			},
+		},
+		ConfigOptions: []acp.SessionConfigOption{
+			{
+				Select: &acp.SessionConfigOptionSelect{
+					Category:     &thoughtCat,
+					Id:           "thinkingEffort",
+					Name:         "Thinking Effort",
+					CurrentValue: "high",
+					Options: acp.SessionConfigSelectOptions{
+						Ungrouped: &acp.SessionConfigSelectOptionsUngrouped{
+							{Value: "low", Name: "Low"},
+							{Value: "high", Name: "High"},
+						},
+					},
+				},
+			},
+			{
+				Select: &acp.SessionConfigOptionSelect{
+					Category:     &modeCat,
+					Id:           "mode",
+					Name:         "Mode",
+					CurrentValue: "plan",
+					Options: acp.SessionConfigSelectOptions{
+						Ungrouped: &acp.SessionConfigSelectOptionsUngrouped{
+							{Value: "plan", Name: "Plan"},
+						},
+					},
+				},
+			},
+			{
+				Select: &acp.SessionConfigOptionSelect{
+					Category:     &modelCat,
+					Id:           "model",
+					Name:         "Model",
+					CurrentValue: "sonnet",
+					Options: acp.SessionConfigSelectOptions{
+						Ungrouped: &acp.SessionConfigSelectOptionsUngrouped{
+							{Value: "default", Name: "Default (recommended)"},
+							{Value: "opus", Name: "glm-5.3[1m]"},
+							{Value: "sonnet", Name: "glm-5.3[1m]"},
+						},
+					},
+				},
+			},
+		},
+	}
+	conn.mu.Lock()
+	conn.lastLoadSessionResp = loadResp
+	conn.mu.Unlock()
+
+	conn.MergeResumedSessionState()
+
+	assert.Equal(t, "plan", conn.GetCurrentModeID())
+	assert.Equal(t, "high", conn.GetCurrentThinkingEffortID())
+	assert.Equal(t, "sonnet", conn.GetCurrentModelID())
+
+	// Registry carries effort levels so the UI tier chips populate.
+	es := GetAgentCapabilityRegistry().GetThinkingEffortState(agent.ID, "high")
+	require.NotNil(t, es)
+	require.Len(t, es.AvailableLevels, 2)
+	assert.Equal(t, "low", es.AvailableLevels[0].ID)
+}
+
+func TestMergeResumedSessionState_LoadResponseStdoutFilterFallback(t *testing.T) {
+	// When the load response carries no model ConfigOptions but the
+	// stdoutFilter has cached models (agent reports models via the
+	// SessionModelState extension), the fallback must surface them — mirroring
+	// the resume branch.
+	agent := &model.Agent{ID: "test-merge-load-filter", Backend: "acp-stdio", AcpCommand: "echo"}
+	conn := newACPConn(agent, "test-merge-load-filter")
+
+	filter := newACPStdoutFilter(strings.NewReader(""))
+	defer filter.Close()
+	filter.modelsMu.Lock()
+	filter.cachedModels = &ModelListState{
+		CurrentModelID: "kimi-code/k3",
+		Models: []model.AgentModel{
+			{ID: "kimi-code/k3", Name: "Kimi K3"},
+		},
+	}
+	filter.modelsMu.Unlock()
+	conn.stdoutFilter = filter
+
+	modeCat := acp.SessionConfigOptionCategoryMode
+	loadResp := &acp.LoadSessionResponse{
+		Modes: &acp.SessionModeState{
+			CurrentModeId: "default",
+			AvailableModes: []acp.SessionMode{
+				{Id: "default", Name: "Default"},
+			},
+		},
+		// No model ConfigOptions — model list must come from stdoutFilter.
+		ConfigOptions: []acp.SessionConfigOption{
+			{
+				Select: &acp.SessionConfigOptionSelect{
+					Category:     &modeCat,
+					Id:           "mode",
+					Name:         "Mode",
+					CurrentValue: "default",
+					Options: acp.SessionConfigSelectOptions{
+						Ungrouped: &acp.SessionConfigSelectOptionsUngrouped{
+							{Value: "default", Name: "Default"},
+						},
+					},
+				},
+			},
+		},
+	}
+	conn.mu.Lock()
+	conn.lastLoadSessionResp = loadResp
+	conn.mu.Unlock()
+
+	conn.MergeResumedSessionState()
+
+	assert.Equal(t, "kimi-code/k3", conn.GetCurrentModelID())
+	ml := GetAgentCapabilityRegistry().GetModelListState(agent.ID, "kimi-code/k3")
+	require.NotNil(t, ml)
+	require.Len(t, ml.Models, 1)
+	assert.Equal(t, "kimi-code/k3", ml.Models[0].ID)
+
+	// Cache must be cleared after the fallback consumed it.
+	filter.modelsMu.Lock()
+	cached := filter.cachedModels
+	filter.modelsMu.Unlock()
+	assert.Nil(t, cached)
+}
+
 // ---------------------------------------------------------------------------
 // extractSessionState — newResp with all sub-extractors returning non-nil
 // ---------------------------------------------------------------------------

--- a/internal/ai/acp_conn_state_test.go
+++ b/internal/ai/acp_conn_state_test.go
@@ -173,6 +173,143 @@ func TestMergeResumedSessionState_NoModeStateInResponse(t *testing.T) {
 }
 
 // ---------------------------------------------------------------------------
+// MergeResumedSessionState — fallback to LoadSessionResponse (LoadSession path)
+// ---------------------------------------------------------------------------
+
+func TestMergeResumedSessionState_FallsBackToLoadResponse(t *testing.T) {
+	// Sessions restored via recoverViaLoadSession / SyncLoadSession stash a
+	// LoadSessionResponse instead of a ResumeSessionResponse. The merge must
+	// fall back to it so mode/model state reaches the registry — otherwise the
+	// UI keeps showing the static CLI-discovered model defaults forever.
+	agent := &model.Agent{ID: "test-merge-load-fallback", Backend: "acp-stdio", AcpCommand: "echo"}
+	conn := newACPConn(agent, "test-merge-load-fallback")
+
+	modeCat := acp.SessionConfigOptionCategoryMode
+	modelCat := acp.SessionConfigOptionCategoryModel
+	loadResp := &acp.LoadSessionResponse{
+		Modes: &acp.SessionModeState{
+			CurrentModeId: "auto",
+			AvailableModes: []acp.SessionMode{
+				{Id: "auto", Name: "Auto"},
+			},
+		},
+		ConfigOptions: []acp.SessionConfigOption{
+			{
+				Select: &acp.SessionConfigOptionSelect{
+					Category:     &modeCat,
+					Id:           "mode",
+					Name:         "Mode",
+					CurrentValue: "auto",
+					Options: acp.SessionConfigSelectOptions{
+						Ungrouped: &acp.SessionConfigSelectOptionsUngrouped{
+							{Value: "auto", Name: "Auto"},
+						},
+					},
+				},
+			},
+			{
+				Select: &acp.SessionConfigOptionSelect{
+					Category:     &modelCat,
+					Id:           "model",
+					Name:         "Model",
+					CurrentValue: "sonnet",
+					Options: acp.SessionConfigSelectOptions{
+						Ungrouped: &acp.SessionConfigSelectOptionsUngrouped{
+							{Value: "default", Name: "Default (recommended)"},
+							{Value: "opus", Name: "glm-5.3[1m]"},
+							{Value: "sonnet", Name: "glm-5.3[1m]"},
+							{Value: "haiku", Name: "glm-5.3[1m]"},
+						},
+					},
+				},
+			},
+		},
+	}
+	conn.mu.Lock()
+	conn.lastLoadSessionResp = loadResp
+	conn.mu.Unlock()
+
+	conn.MergeResumedSessionState()
+
+	assert.Equal(t, "sonnet", conn.GetCurrentModelID())
+	assert.Equal(t, "auto", conn.GetCurrentModeID())
+
+	// The registry must carry the extracted list so /api/agents acpStates
+	// serves it to the frontend.
+	ml := GetAgentCapabilityRegistry().GetModelListState(agent.ID, "")
+	require.NotNil(t, ml)
+	require.Len(t, ml.Models, 4)
+	assert.Equal(t, "glm-5.3[1m]", ml.Models[1].Name)
+	assert.Equal(t, "glm-5.3[1m]", ml.Models[2].Name)
+}
+
+func TestMergeResumedSessionState_LoadResponseConsumedOnlyOnce(t *testing.T) {
+	// GetAndClear semantics: once the fallback consumed the load response, a
+	// second merge (the next prompt on the same conn) must be a no-op rather
+	// than re-applying stale state or panicking.
+	agent := &model.Agent{ID: "test-merge-load-consumed", Backend: "acp-stdio", AcpCommand: "echo"}
+	conn := newACPConn(agent, "test-merge-load-consumed")
+
+	modelCat := acp.SessionConfigOptionCategoryModel
+	loadResp := &acp.LoadSessionResponse{
+		ConfigOptions: []acp.SessionConfigOption{
+			{
+				Select: &acp.SessionConfigOptionSelect{
+					Category:     &modelCat,
+					Id:           "model",
+					Name:         "Model",
+					CurrentValue: "opus",
+					Options: acp.SessionConfigSelectOptions{
+						Ungrouped: &acp.SessionConfigSelectOptionsUngrouped{
+							{Value: "opus", Name: "glm-5.3[1m]"},
+						},
+					},
+				},
+			},
+		},
+	}
+	conn.mu.Lock()
+	conn.lastLoadSessionResp = loadResp
+	conn.mu.Unlock()
+
+	conn.MergeResumedSessionState()
+	assert.Equal(t, "opus", conn.GetCurrentModelID())
+
+	// Second call: both stashes empty — no-op, values preserved.
+	conn.MergeResumedSessionState()
+	assert.Equal(t, "opus", conn.GetCurrentModelID())
+}
+
+func TestExtractACPModelListFromLoad_NilAndPopulated(t *testing.T) {
+	assert.Nil(t, extractACPModelListFromLoad(nil))
+
+	modelCat := acp.SessionConfigOptionCategoryModel
+	loadResp := &acp.LoadSessionResponse{
+		ConfigOptions: []acp.SessionConfigOption{
+			{
+				Select: &acp.SessionConfigOptionSelect{
+					Category:     &modelCat,
+					Id:           "model",
+					Name:         "Model",
+					CurrentValue: "default",
+					Options: acp.SessionConfigSelectOptions{
+						Ungrouped: &acp.SessionConfigSelectOptionsUngrouped{
+							{Value: "default", Name: "Default (recommended)"},
+							{Value: "haiku", Name: "glm-5.3[1m]"},
+						},
+					},
+				},
+			},
+		},
+	}
+	ml := extractACPModelListFromLoad(loadResp)
+	require.NotNil(t, ml)
+	assert.Equal(t, "default", ml.CurrentModelID)
+	require.Len(t, ml.Models, 2)
+	assert.Equal(t, "glm-5.3[1m]", ml.Models[1].Name)
+}
+
+// ---------------------------------------------------------------------------
 // extractSessionState — newResp with all sub-extractors returning non-nil
 // ---------------------------------------------------------------------------
 

--- a/internal/ai/acp_state_extract.go
+++ b/internal/ai/acp_state_extract.go
@@ -204,6 +204,40 @@ func extractACPModelListFromResume(resumeResp *acp.ResumeSessionResponse) *Model
 	return extractModelListFromOpts(resumeResp.ConfigOptions)
 }
 
+// extractACPModeStateFromLoad extracts ModeState from a LoadSessionResponse.
+func extractACPModeStateFromLoad(loadResp *acp.LoadSessionResponse) *ModeState {
+	if loadResp == nil {
+		return nil
+	}
+	return extractModeStateFromModes(loadResp.Modes)
+}
+
+// extractACPConfigOptionsFromLoad extracts mode-relevant ConfigOptionState from a LoadSessionResponse.
+func extractACPConfigOptionsFromLoad(loadResp *acp.LoadSessionResponse) *ConfigOptionState {
+	if loadResp == nil {
+		return nil
+	}
+	return extractConfigOptionsFromOpts(loadResp.ConfigOptions)
+}
+
+// extractACPThinkingEffortFromLoad extracts ThinkingEffortState from a LoadSessionResponse.
+func extractACPThinkingEffortFromLoad(loadResp *acp.LoadSessionResponse) *ThinkingEffortState {
+	if loadResp == nil {
+		return nil
+	}
+	return extractThinkingEffortFromOpts(loadResp.ConfigOptions)
+}
+
+// extractACPModelListFromLoad extracts ModelListState from a LoadSessionResponse.
+// The LoadSession path is used for agents that advertise loadSession (e.g. claude
+// via claude-agent-acp); its response carries the same ConfigOptions as new/resume.
+func extractACPModelListFromLoad(loadResp *acp.LoadSessionResponse) *ModelListState {
+	if loadResp == nil {
+		return nil
+	}
+	return extractModelListFromOpts(loadResp.ConfigOptions)
+}
+
 func extractModelListFromOpts(opts []acp.SessionConfigOption) *ModelListState {
 	if len(opts) == 0 {
 		return nil


### PR DESCRIPTION
Fixes #426

## 问题

LoadSession 路径恢复的会话，其响应（`LoadSessionResponse`，携带与 new/resume 同构的 `Modes` + `ConfigOptions`）被暂存到 `lastLoadSessionResp` 后**零消费**——`GetAndClearLoadSessionResp` 没有任何调用方。下一条消息触发的 `MergeResumedSessionState` 只找 resume 暂存 → nil → 早退。

后果：重开旧会话后 agent 级 registry 永远收不到模型列表，`/api/agents` 不下发 `acpStates[].modelListState`，UI 永久回落到静态 CLI 默认模型列表；env 重定向模型（三档位全映射 `glm-5.3[1m]`）不可见，前端 tier-alias 对齐也无输入可用。详见 #426 的日志证据与时间线（9-1 前 Resume 路径正常，9-2 起全 nil）。

## 修复

- `acp_state_extract.go`：新增 `extractACPModeStateFromLoad` / `extractACPConfigOptionsFromLoad` / `extractACPThinkingEffortFromLoad` / `extractACPModelListFromLoad`（镜像 resume 变体，落到同一组 FromOpts/FromModes 共享助手）
- `acp_conn_state.go`：`MergeResumedSessionState` 在 resume 暂存为空时回落读取 load 暂存并跑同一套提取（`mergeLoadedSessionState` + `extractLoadedSessionState`，镜像 resume 分支含 stdoutFilter 兜底）；GetAndClear 语义保证只消费一次

修复点在通用 `ACPConn` 层：所有 ACP 后端共享，凡支持 loadSession 的 agent（claude 等）重开旧会话即恢复完整模型/模式/努力档状态；resume/new 路径零改动。

## 验证

- 新增 3 个测试：回落提取（含 registry 断言）、只消费一次、`extractACPModelListFromLoad` nil/正常
- `go test ./internal/ai/` 全绿（10.6s）
- 实测 claude-agent-acp 0.73.0：`session/load` 响应确实携带模型 ConfigOptions（default/opus/sonnet/haiku，env 重向下 name 均为 `glm-5.3[1m]`），修复后该数据将进入 registry 并经 `/api/agents` 下发

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude <noreply@anthropic.com>