### PR TITLE
feat(backends): add ZCode (Zhipu GLM) as a first-class ACP backend

### DIFF
--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -35,6 +35,7 @@ import (
 	_ "clawbench/internal/ai/backends/pi"
 	_ "clawbench/internal/ai/backends/qoder"
 	_ "clawbench/internal/ai/backends/vecli"
+	_ "clawbench/internal/ai/backends/zcode"
 	"clawbench/internal/cli"
 	"clawbench/internal/frontend"
 	"clawbench/internal/frp"

--- a/internal/ai/backends/zcode/register.go
+++ b/internal/ai/backends/zcode/register.go
@@ -1,0 +1,28 @@
+package zcode
+
+import (
+	"clawbench/internal/ai/backends"
+	"clawbench/internal/model"
+)
+
+func init() {
+	// ZCode (Zhipu GLM) is ACP-only via the zcode-acp-server bridge adapter:
+	// no ai.RegisterBackend (CLI factory) is registered, so chat always uses
+	// the ACP stdio transport (npx -y zcode-acp-server). The bridge spawns the
+	// real ZCode headless engine (`zcode app-server --stdio`), resolving the
+	// zcode CLI from ZCODE_BIN → PATH → the desktop-app bundle
+	// (/Applications/ZCode.app/Contents/Resources/glm/zcode.cjs on macOS), so
+	// no CLI on PATH is required. Auth is the GLM API key / Coding Plan
+	// credential in ~/.zcode/v2/config.json — no editor-side credentials.
+	backends.Register(&backends.BackendPlugin{
+		ID: "zcode",
+		Spec: model.BackendSpec{
+			ID: "zcode", Backend: "zcode", DefaultCmd: "zcode-acp-server", Name: "ZCode", Specialty: "智谱 GLM 编码代理",
+			ThinkingEffortLevels: []string{"low", "high", "max"},
+			AcpCommand:           "npx -y zcode-acp-server",
+			ACPLoadSession:       true,
+			InstallCmd:           "npm install -g zcode-acp-server",
+			SortOrder:            15,
+		},
+	})
+}

--- a/internal/ai/backends/zcode/register_test.go
+++ b/internal/ai/backends/zcode/register_test.go
@@ -1,0 +1,41 @@
+package zcode
+
+import (
+	"testing"
+
+	"clawbench/internal/ai/backends"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// --- Backend plugin registration ---
+
+func TestZcodeBackendPlugin_RegisteredInBackends(t *testing.T) {
+	plugin := backends.Lookup("zcode")
+	require.NotNil(t, "zcode should be registered in backends registry", plugin)
+	assert.Equal(t, "zcode", plugin.ID)
+}
+
+func TestZcodeBackendPlugin_SpecFields(t *testing.T) {
+	plugin := backends.Lookup("zcode")
+	require.NotNil(t, plugin)
+	assert.Equal(t, "zcode", plugin.Spec.ID)
+	assert.Equal(t, "zcode", plugin.Spec.Backend)
+	assert.Equal(t, "zcode-acp-server", plugin.Spec.DefaultCmd)
+	assert.Equal(t, "ZCode", plugin.Spec.Name)
+	assert.Equal(t, "npx -y zcode-acp-server", plugin.Spec.AcpCommand)
+	assert.True(t, plugin.Spec.ACPLoadSession)
+	assert.Equal(t, "npm install -g zcode-acp-server", plugin.Spec.InstallCmd)
+	assert.Equal(t, []string{"low", "high", "max"}, plugin.Spec.ThinkingEffortLevels)
+	assert.NotZero(t, plugin.Spec.SortOrder)
+}
+
+// The zcode bridge (zcode-acp-server) resolves the zcode CLI itself
+// (ZCODE_BIN → PATH → desktop-app bundle), so no CLI factory is registered:
+// chat must always go through the ACP stdio transport.
+func TestZcodeBackendPlugin_NoCLIFactory(t *testing.T) {
+	plugin := backends.Lookup("zcode")
+	require.NotNil(t, plugin)
+	assert.Nil(t, plugin.ACP, "zcode needs no tool-name remapping: tools are reported canonically over ACP")
+}

--- a/internal/ai/backends/zcode/register_test.go
+++ b/internal/ai/backends/zcode/register_test.go
@@ -13,7 +13,7 @@ import (
 
 func TestZcodeBackendPlugin_RegisteredInBackends(t *testing.T) {
 	plugin := backends.Lookup("zcode")
-	require.NotNil(t, "zcode should be registered in backends registry", plugin)
+	require.NotNil(t, plugin, "zcode should be registered in backends registry")
 	assert.Equal(t, "zcode", plugin.ID)
 }
 


### PR DESCRIPTION
## 动机

ZCode 是智谱官方的 GLM coding agent（含 headless 引擎 `zcode app-server --stdio`），社区已有成熟的 ACP 适配桥 [william0wang/zcode-acp](https://github.com/william0wang/zcode-acp)（npm: `zcode-acp-server`）。本 PR 以 **antigravity 同款纯 ACP 适配模式**将其注册为第 14 个一等后端。

## 改动

- `internal/ai/backends/zcode/register.go` — BackendPlugin 注册（无 CLI 工厂，聊天恒走 ACP stdio）：`AcpCommand: npx -y zcode-acp-server`、`ACPLoadSession: true`、思考档 low/high/max、`InstallCmd: npm install -g zcode-acp-server`、SortOrder 15
- `cmd/server/main.go` — 副作用导入
- `register_test.go` — 注册/字段/无 CLI 工厂三项断言

无需前端改动：桥经标准 ACP sessionConfig 上报 modes（plan/build/edit/yolo/auto）、model select（GLM-5.3）、thinking effort、loadSession/listSessions，全部由通用 ACPConn 层消费。

## 架构说明

桥自行解析 zcode CLI（`ZCODE_BIN` → PATH → 桌面应用 bundle），**PATH 上无需 CLI**；凭据留在 `~/.zcode/v2/config.json`（GLM API key / Coding Plan），编辑器侧零凭据。`npx -y` 自带未安装时自动拉取的兜底。

## 验证

- `go test ./internal/ai/backends/zcode/` 3/3 通过；`go build ./cmd/server/` + `./internal/ai/` + `./internal/model/` 全绿
- **端到端实测**（zcode-acp-server 0.21.0 + ZCode CLI 0.16.5）：ACP 握手 → session/new（modes×5 + model configOptions）→ session/prompt 获得真实 GLM-5.3 回复；接入 ClawBench 后 UI 模型下拉显示 GLM-5.3、对话正常、acpStates 全量上报

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude <noreply@anthropic.com>