### PR TITLE
fix(codex): discover models from models_cache.json

### DIFF
--- a/internal/ai/backends/codex/discovery.go
+++ b/internal/ai/backends/codex/discovery.go
@@ -1,6 +1,7 @@
 package codex
 
 import (
+	"encoding/json"
 	"log/slog"
 	"os"
 	"path/filepath"
@@ -59,24 +60,80 @@ func codexTargetTriple() string {
 }
 
 // DiscoverCodexModels discovers Codex model IDs using multiple strategies:
-// 1. Run `strings` on the embedded Rust binary (works for unstripped binaries)
-// 2. Read model info from the Codex state SQLite database (~/.codex/state_*.sqlite)
-// 3. Fall back to hardcoded defaults based on the installed Codex version
+// 1. Read the model catalog cached by modern Codex CLI versions
+// 2. Run `strings` on the embedded Rust binary (works for unstripped binaries)
+// 3. Read model info from the Codex state SQLite database (~/.codex/state_*.sqlite)
+// 4. Fall back to hardcoded defaults based on the installed Codex version
 func DiscoverCodexModels() []model.AgentModel {
-	// Strategy 1: Try strings on the Rust binary
+	// Strategy 1: Read the complete model catalog cached by modern Codex versions
+	if platform.ResolveCLIPath("codex") != "" {
+		if models := discoverCodexModelsFromCache(); len(models) > 0 {
+			models[0].Default = true
+			return models
+		}
+	}
+
+	// Strategy 2: Try strings on the Rust binary
 	if models := discoverCodexModelsFromBinary(); len(models) > 0 {
 		return models
 	}
 
-	// Strategy 2: Read from Codex state SQLite database
+	// Strategy 3: Read from Codex state SQLite database
 	if models := discoverCodexModelsFromStateDB(); len(models) > 0 {
 		return models
 	}
 
-	// Strategy 3: Hardcoded defaults for the current generation of Codex models
+	// Strategy 4: Hardcoded defaults for the current generation of Codex models
 	// The Codex Rust binary is stripped, so strings extraction often fails.
 	// We provide known model IDs based on the Codex version.
 	return discoverCodexModelsDefaults()
+}
+
+// discoverCodexModelsFromCache reads the model catalog fetched by modern
+// Codex CLI versions. Unlike binary strings, this contains the complete list
+// currently available to the authenticated account.
+func discoverCodexModelsFromCache() []model.AgentModel {
+	codexHome, err := resolveCodexHome()
+	if err != nil {
+		return nil
+	}
+	cachePath := filepath.Join(codexHome, "models_cache.json")
+	data, err := os.ReadFile(cachePath)
+	if err != nil {
+		slog.Debug("codex model discovery: read cache failed", "path", cachePath, "error", err)
+		return nil
+	}
+	var cache struct {
+		Models []struct {
+			Slug        string `json:"slug"`
+			DisplayName string `json:"display_name"`
+			Visibility  string `json:"visibility"`
+		} `json:"models"`
+	}
+	if err := json.Unmarshal(data, &cache); err != nil {
+		slog.Debug("codex model discovery: parse cache failed", "path", cachePath, "error", err)
+		return nil
+	}
+	models := make([]model.AgentModel, 0, len(cache.Models))
+	seen := make(map[string]struct{}, len(cache.Models))
+	for _, item := range cache.Models {
+		if item.Slug == "" || (item.Visibility != "" && item.Visibility != "list") {
+			continue
+		}
+		if _, ok := seen[item.Slug]; ok {
+			continue
+		}
+		seen[item.Slug] = struct{}{}
+		name := item.DisplayName
+		if name == "" {
+			name = item.Slug
+		}
+		models = append(models, model.AgentModel{ID: item.Slug, Name: name})
+	}
+	if len(models) > 0 {
+		slog.Info("codex model discovery (cache) succeeded", "models", len(models))
+	}
+	return models
 }
 
 // discoverCodexModelsFromBinary tries to extract model IDs by scanning the
@@ -155,13 +212,12 @@ func discoverCodexModelsFromBinary() []model.AgentModel {
 // discoverCodexModelsFromStateDB reads model info from the Codex state SQLite database.
 // The state database stores the model catalog that Codex fetched from OpenAI's API.
 func discoverCodexModelsFromStateDB() []model.AgentModel {
-	homeDir, err := os.UserHomeDir()
+	codexDir, err := resolveCodexHome()
 	if err != nil {
 		return nil
 	}
 
 	// Find the state SQLite database (e.g., state_5.sqlite)
-	codexDir := filepath.Join(homeDir, ".codex")
 	entries, err := os.ReadDir(codexDir)
 	if err != nil {
 		return nil

--- a/internal/ai/backends/codex/discovery_test.go
+++ b/internal/ai/backends/codex/discovery_test.go
@@ -196,6 +196,8 @@ func TestDiscoverCodexModels_BinaryStrategyWins(t *testing.T) {
 	// When the strings strategy finds models, it must take priority over the
 	// hardcoded defaults. (Strings below minLen=4 are not extracted, so use
 	// multi-char model IDs.)
+	t.Setenv("HOME", t.TempDir())
+	t.Setenv("CODEX_HOME", "")
 	mockCodexInstall(t, []string{"gpt-5.5", "o4-mini"})
 	models := DiscoverCodexModels()
 
@@ -206,6 +208,8 @@ func TestDiscoverCodexModels_BinaryStrategyWins(t *testing.T) {
 
 func TestDiscoverCodexModels_FallsBackToDefaults(t *testing.T) {
 	// Codex installed but the binary tree has no extractable models → defaults.
+	t.Setenv("HOME", t.TempDir())
+	t.Setenv("CODEX_HOME", "")
 	mockCodexInstall(t, []string{"unrelated string"})
 	models := DiscoverCodexModels()
 
@@ -229,8 +233,38 @@ func TestDiscoverCodexModelsDefaults_NotInstalled(t *testing.T) {
 	assert.Nil(t, models)
 }
 
+func TestDiscoverCodexModelsFromCache(t *testing.T) {
+	home := t.TempDir()
+	codexDir := filepath.Join(home, ".codex")
+	require.NoError(t, os.MkdirAll(codexDir, 0o755))
+	cache := `{"models":[{"slug":"gpt-6-astra","display_name":"GPT-6-Astra","visibility":"list"},{"slug":"gpt-6-astra","display_name":"duplicate","visibility":"list"},{"slug":"gpt-5.6-luna","display_name":"GPT-5.6 Luna","visibility":"list"},{"slug":"hidden","visibility":"hide"}]}`
+	require.NoError(t, os.WriteFile(filepath.Join(codexDir, "models_cache.json"), []byte(cache), 0o644))
+	t.Setenv("CODEX_HOME", codexDir)
+	models := discoverCodexModelsFromCache()
+	require.Len(t, models, 2)
+	assert.Equal(t, "gpt-6-astra", models[0].ID)
+	assert.Equal(t, "GPT-5.6 Luna", models[1].Name)
+}
+
+func TestDiscoverCodexModels_CacheWins(t *testing.T) {
+	home := t.TempDir()
+	codexDir := filepath.Join(home, ".codex")
+	require.NoError(t, os.MkdirAll(codexDir, 0o755))
+	cache := `{"models":[{"slug":"gpt-6-astra","display_name":"GPT-6-Astra","visibility":"list"},{"slug":"gpt-5.6-luna","display_name":"GPT-5.6 Luna","visibility":"list"}]}`
+	require.NoError(t, os.WriteFile(filepath.Join(codexDir, "models_cache.json"), []byte(cache), 0o644))
+	t.Setenv("CODEX_HOME", codexDir)
+	mockCodexInstall(t, []string{"gpt-5.5"})
+
+	models := DiscoverCodexModels()
+	require.Len(t, models, 2)
+	assert.Equal(t, "gpt-6-astra", models[0].ID)
+	assert.True(t, models[0].Default)
+	assert.Equal(t, "gpt-5.6-luna", models[1].ID)
+}
+
 func TestDiscoverCodexModelsFromStateDB_NoCodexDir(t *testing.T) {
 	t.Setenv("HOME", t.TempDir())
+	t.Setenv("CODEX_HOME", "")
 	models := discoverCodexModelsFromStateDB()
 	assert.Nil(t, models)
 }
@@ -239,6 +273,7 @@ func TestDiscoverCodexModelsFromStateDB_NoStateFile(t *testing.T) {
 	home := t.TempDir()
 	require.NoError(t, os.MkdirAll(filepath.Join(home, ".codex"), 0o755))
 	t.Setenv("HOME", home)
+	t.Setenv("CODEX_HOME", "")
 	models := discoverCodexModelsFromStateDB()
 	assert.Nil(t, models)
 }
@@ -249,6 +284,7 @@ func TestDiscoverCodexModelsFromStateDB_UnrelatedFilesOnly(t *testing.T) {
 	require.NoError(t, os.MkdirAll(codexDir, 0o755))
 	require.NoError(t, os.WriteFile(filepath.Join(codexDir, "config.toml"), []byte("[x]\n"), 0o644))
 	t.Setenv("HOME", home)
+	t.Setenv("CODEX_HOME", "")
 	models := discoverCodexModelsFromStateDB()
 	assert.Nil(t, models)
 }


### PR DESCRIPTION
## 变更说明

### 背景与问题
Codex 官方 CLI 发布的二进制在生产环境中经过了 strip 处理，导致原有的二进制可打印字符串提取（`strings` 策略）经常无法提取出模型 ID，从而降级到硬编码兜底模型（`gpt-5.5` 等），无法及时感知并展示用户当前认证账号下实际可用的完整模型列表。

### 解决方案
现代 Codex CLI 版本在获取可用模型后会将其缓存到 `~/.codex/models_cache.json`（或 `$CODEX_HOME/models_cache.json`）。
本 PR 为 Codex 后端增加了优先从模型缓存文件中读取模型的发现策略：
1. **优先读取缓存**：通过 `resolveCodexHome()` 解析配置目录并读取 `models_cache.json`，按 `visibility == "list"` 过滤有效模型并设置首选默认；
2. **支持环境定制**：兼容 `$CODEX_HOME` 环境变量与标准 `~/.codex` 路径，全包路径解析逻辑统一；
3. **防守性去重**：使用 `seen` 集合过滤重复模型 slug；
4. **日志与降级保障**：补充 `slog` 观测性日志，缓存缺失或解析失败时平滑降级至既有的 strings 提取、state SQLite 与硬编码兜底逻辑；
5. **单元测试覆盖**：新增缓存读取、优先级匹配及去重测试，并强化了单测中的环境变量隔离。

## 变更类型

- [x] fix: Bug 修复

## 关联 Issue

无

## 测试

- [x] 已通过现有测试（`go test ./internal/ai/backends/codex/...` 全部 PASS）
- [x] 已添加新测试覆盖（`TestDiscoverCodexModelsFromCache`、`TestDiscoverCodexModels_CacheWins`）

## 自检清单

- [x] 代码遵循项目现有风格
- [x] 无硬编码密钥或敏感信息
- [x] 变更已反映在文档中（如适用）