### PR TITLE
fix: 壁纸面板不透明度下限放宽 0.5 + 半透明策略重构 + fbtn 暗色主题修复

### DIFF
--- a/docs/plans/2026-09-06-custom-wallpaper.md
+++ b/docs/plans/2026-09-06-custom-wallpaper.md
@@ -21,7 +21,7 @@
 | 主题适配 | 单张图 + 深浅自动遮罩（dark ~0.35 黑 / light ~0.12 黑），遮罩强度不开放配置 |
 | 与主题关系 | 完全独立：背景图跨主题共享，仅遮罩随深浅态变化 |
 | 铺法 | `cover` 铺满 + 居中 + 不重复 |
-| 面板不透明度 | 引入 `--panel-alpha` 变量，默认 0.85，滑块可配（70%~100%）；**无背景图时强制 alpha=1、滑块禁用置灰** |
+| 面板不透明度 | 引入 `--panel-alpha` 变量，默认 0.85，滑块可配（50%~100%）；**无背景图时强制 alpha=1、滑块禁用置灰** |
 | 配置项 | 两个 server key：`appearance.wallpaperFile` + `appearance.panelOpacity`（YAML snake_case：`wallpaper_file`/`panel_opacity`）。**无开关**：有文件=启用，空=未设置。移除 = DELETE 端点清 key + 删文件（轻量 toast，不弹确认）。**wallpaperFile 禁止 PATCH 直写非空值**（见 C3/I3） |
 | 背景切换动效 | 无渐变动效，设置后即时生效 + toast |
 | 格式子集 | png/jpg/jpeg/webp/gif/svg 允许；排除 bmp/ico/tiff/avif |
@@ -49,7 +49,7 @@
 
 面板不透明度滑块：
 
-- `appearance.panelOpacity` slider，范围 70%~100%，默认 85%
+- `appearance.panelOpacity` slider，范围 50%~100%，默认 85%
 - 未设置背景图时滑块禁用置灰（强制 alpha=1，UI 与现状完全一致）
 - 滑块值保留，设置背景图后自动沿用
 - **背景状态三态**：server config 未加载完成时滑块 disabled（unknown 态），加载后按 set/unset 决定 enabled/disabled——避免冷启动闪烁（见 I2）
@@ -91,7 +91,7 @@
 1. `config.go`：Config struct 增 `Appearance AppearanceConfig` 段；`AppearanceConfig { WallpaperFile string; PanelOpacity float64 }`（YAML snake_case：`wallpaper_file` / `panel_opacity`，PATCH/GET JSON 用 camelCase `wallpaperFile`/`panelOpacity`，命名统一见 M4）
 2. `defaults.go`：`ApplyDefaults` 补 `appearance.panel_opacity: 0.85`（默认值权威在服务端），**presence-map 语义防零值覆盖**（参考 RAG/tls 先例）
 3. `settings.go` `PatchableConfigPaths` 白名单补 `appearance.wallpaperFile`、`appearance.panelOpacity`
-4. `settings.go` `validatePatchValues`：`appearance.panelOpacity` 范围校验 0.7~1.0（参考 frp.server_port 先例）；**`appearance.wallpaperFile` 非空值一律拒绝**（仅允许 `""` 表示移除；实际移除走 DELETE 端点清文件后置空，PATCH 直写非空 = 路径穿越入口，见 I3）
+4. `settings.go` `validatePatchValues`：`appearance.panelOpacity` 范围校验 0.5~1.0（参考 frp.server_port 先例）；**`appearance.wallpaperFile` 非空值一律拒绝**（仅允许 `""` 表示移除；实际移除走 DELETE 端点清文件后置空，PATCH 直写非空 = 路径穿越入口，见 I3）
 5. `settings.go` `hotReloadFields`：`appearance.panelOpacity` 列入（PATCH 后即时生效）；`wallpaperFile` 不依赖 PATCH（专用端点写）
 6. `settings.go` `configResponse`：GET /api/config 输出两 key（嵌套 `appearance` 段）
 7. `handler.go`：注册 `POST /api/theme-background`、`DELETE /api/theme-background`、`GET /api/file/theme-background` 路由

--- a/internal/handler/settings.go
+++ b/internal/handler/settings.go
@@ -359,7 +359,7 @@ type configFonts struct {
 // configAppearance exposes custom wallpaper settings to the settings panel.
 type configAppearance struct {
 	WallpaperFile string  `json:"wallpaper_file"` // Active wallpaper file name in <DataDir>/theme ("" = none)
-	PanelOpacity  float64 `json:"panel_opacity"`  // Main work-panel opacity multiplier (0.7–1.0; default 0.85)
+	PanelOpacity  float64 `json:"panel_opacity"`  // Main work-panel opacity multiplier (0.5–1.0; default 0.85)
 }
 
 // PatchableConfigPaths defines the whitelist of config paths that PATCH /api/config accepts.
@@ -1008,8 +1008,8 @@ func validatePatchValues(patch map[string]any) error { //nolint:gocognit,gocyclo
 	// would be a path-traversal entry point — the GET/serve endpoint joins the
 	// stored value onto <DataDir>/theme.
 	if appearance, ok := patch["appearance"].(map[string]any); ok {
-		if v, ok := appearance["panel_opacity"].(float64); ok && (v < 0.7 || v > 1.0) {
-			return fmt.Errorf("appearance.panel_opacity must be between 0.7 and 1.0")
+		if v, ok := appearance["panel_opacity"].(float64); ok && (v < 0.5 || v > 1.0) {
+			return fmt.Errorf("appearance.panel_opacity must be between 0.5 and 1.0")
 		}
 		if v, ok := appearance["wallpaper_file"].(string); ok && v != "" {
 			return fmt.Errorf("appearance.wallpaper_file can only be cleared via PATCH (set to empty); use the theme-background endpoint to set a wallpaper")

--- a/internal/handler/settings_test.go
+++ b/internal/handler/settings_test.go
@@ -2610,7 +2610,8 @@ func TestServeConfig_Patch_AppearancePanelOpacityOutOfRangeRejected(t *testing.T
 	cfg.Appearance.PanelOpacity = 0.85
 	model.ConfigInstance = cfg
 
-	body := `{"appearance":{"panel_opacity":0.5}}`
+	// 0.5 is the new lower bound — anything below is rejected.
+	body := `{"appearance":{"panel_opacity":0.45}}`
 	req := httptest.NewRequest(http.MethodPatch, "/api/config", strings.NewReader(body))
 	req.Header.Set("Content-Type", "application/json")
 	withAuthCookie(req, model.SessionToken)
@@ -2618,6 +2619,25 @@ func TestServeConfig_Patch_AppearancePanelOpacityOutOfRangeRejected(t *testing.T
 
 	assert.Equal(t, http.StatusBadRequest, w.Code)
 	assert.Equal(t, 0.85, model.ConfigInstance.Appearance.PanelOpacity, "out-of-range patch must not apply")
+}
+
+func TestServeConfig_Patch_AppearancePanelOpacityLowerBoundAccepted(t *testing.T) {
+	_, teardown := setupTestEnv(t)
+	defer teardown()
+
+	cfg := model.Config{}
+	cfg.Appearance.PanelOpacity = 0.85
+	model.ConfigInstance = cfg
+
+	// The relaxed lower bound (0.5) must be accepted.
+	body := `{"appearance":{"panel_opacity":0.5}}`
+	req := httptest.NewRequest(http.MethodPatch, "/api/config", strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	withAuthCookie(req, model.SessionToken)
+	w := callHandler(ServeConfig, req)
+
+	assert.Equal(t, http.StatusOK, w.Code)
+	assert.Equal(t, 0.5, model.ConfigInstance.Appearance.PanelOpacity)
 }
 
 func TestServeConfig_Patch_AppearanceWallpaperFileNonEmptyRejected(t *testing.T) {

--- a/internal/model/config.go
+++ b/internal/model/config.go
@@ -51,7 +51,7 @@ type Config struct {
 	} `yaml:"fonts"`
 	Appearance struct {
 		WallpaperFile string  `yaml:"wallpaper_file"` // Active custom wallpaper file name (bare name in <DataDir>/theme); empty = not set
-		PanelOpacity  float64 `yaml:"panel_opacity"`  // Main work-panel opacity multiplier (0.7–1.0; default 0.85). Only meaningful when a wallpaper is set.
+		PanelOpacity  float64 `yaml:"panel_opacity"`  // Main work-panel opacity multiplier (0.5–1.0; default 0.85). Only meaningful when a wallpaper is set.
 	} `yaml:"appearance"`
 	DevPort int `yaml:"dev_port"` // Localhost-only HTTP port for dev proxy (0 = auto=Port+2 when TLS enabled, -1 = disabled)
 	Upload  struct {

--- a/internal/model/defaults.go
+++ b/internal/model/defaults.go
@@ -70,7 +70,7 @@ func ApplyDefaults(cfg *Config, presence map[string]bool) string { //nolint:goco
 	// --- Appearance (custom wallpaper) ---
 	// PanelOpacity: default 0.85 (85% opacity for main work panels when a
 	// wallpaper is set). An explicit user value (including 0 = fully opaque is
-	// NOT a valid target here; range 0.7–1.0 is enforced by PATCH validation)
+	// NOT a valid target here; range 0.5–1.0 is enforced by PATCH validation)
 	// must survive zero-value handling, so only fill when truly unset and the
 	// key was not explicitly present in the config file. Treat any missing or
 	// zero value as "use default". PanelOpacity intentionally has no presence

--- a/web/css/base.css
+++ b/web/css/base.css
@@ -124,58 +124,119 @@ html.wallpaper-active .wide-dock {
 }
 
 /* ── Extended page surfaces (wallpaper-active) ──────────────────────
-   Full-page roots and page-level bars across the task, port-forward,
-   settings, file-browser and media-preview panels. Their components declare
-   opaque var(--bg-*) backgrounds in scoped CSS; these rules (higher
-   specificity via the html.wallpaper-active prefix) make them translucent so
-   the wallpaper shows through. Content canvases stay opaque by design:
-   video player (#000), code editor (--code-bg), Excalidraw iframe, PDF page
-   canvas (#525659) and the terminal xterm surface. Cards/rows inside these
-   pages (task items, proxy port cards, settings card bodies, form sections)
-   deliberately keep their own opaque backgrounds (conservative depth). */
+   Full-page tab roots must NOT stack a second translucent layer over the
+   already-translucent .tab-panel: compounding alphas (panel root → card →
+   panel) dims the wallpaper until low-opacity settings nearly hide it. So,
+   following the .file-overlay precedent, whole-page roots AND the full-bleed
+   card/list surfaces inside them become fully transparent while the wallpaper
+   is active — the .tab-panel is the single visible surface and every tab reads
+   at the same translucency as the file browser. Only narrow page-level bars
+   keep a translucent tint (structure) and hover/active states re-add a tint as
+   feedback. Content canvases stay opaque by design: video player (#000), code
+   editor (--code-bg), Excalidraw iframe, PDF page canvas (#525659), the
+   terminal xterm surface, and input widgets inside forms (text fields,
+   textareas, selects keep their own solid fills). */
 
-/* bg-primary full-page roots + page-level action bars */
+/* Whole-page roots — remove the second scrim layer entirely */
 html.wallpaper-active .task-list-page,
 html.wallpaper-active .task-detail-page,
 html.wallpaper-active .task-form-page,
 html.wallpaper-active .exec-detail-page,
 html.wallpaper-active .task-overview,
-html.wallpaper-active .detail-actions,
-html.wallpaper-active .form-footer,
-html.wallpaper-active .exec-detail-actions,
 html.wallpaper-active .proxy-panel-content,
-html.wallpaper-active .settings-page__header,
-html.wallpaper-active .image-preview-body,
-html.wallpaper-active .audio-preview-body,
-html.wallpaper-active .pdf-preview-container,
-html.wallpaper-active .pdf-error,
-html.wallpaper-active .office-preview-container,
-html.wallpaper-active .usage-stats-panel,
-html.wallpaper-active .stats-header {
-    background: color-mix(in srgb, var(--bg-primary) var(--panel-alpha), transparent);
-}
-
-/* bg-secondary page-level bars / page roots (settings list surfaces) */
-html.wallpaper-active .proxy-header,
+html.wallpaper-active .settings-page,
 html.wallpaper-active .settings-index,
 html.wallpaper-active .settings-category,
 html.wallpaper-active .settings-agents-index,
 html.wallpaper-active .settings-agent-detail,
+html.wallpaper-active .usage-stats-panel,
+html.wallpaper-active .image-preview-body,
+html.wallpaper-active .audio-preview-body,
+html.wallpaper-active .pdf-preview-container,
+html.wallpaper-active .pdf-error,
+html.wallpaper-active .office-preview-container {
+    background: transparent;
+}
+
+/* Full-bleed cards / list rows inside those pages — translucent so cards keep
+   a subtle depth layer over the single .tab-panel surface. The page roots stay
+   transparent (above) so only this one card layer stacks on top of the panel;
+   card areas are thus a touch dimmer than bare gaps but never compounded three
+   layers deep. */
+html.wallpaper-active .task-item,
+html.wallpaper-active .execution-item,
+html.wallpaper-active .overview-card,
+html.wallpaper-active .proxy-port-item,
+html.wallpaper-active .form-section,
+html.wallpaper-active .stats-card-panel {
+    background: color-mix(in srgb, var(--bg-secondary) var(--panel-alpha), transparent);
+}
+html.wallpaper-active .settings-card__body,
+html.wallpaper-active .group-panel__card,
+html.wallpaper-active .settings-agents-index__row,
+html.wallpaper-active .settings-agents-index__rescan-row {
+    background: color-mix(in srgb, var(--bg-primary) var(--panel-alpha), transparent);
+}
+
+/* Page-level bars keep a translucent tint so chrome stays legible over the
+   wallpaper (same look as the file browser's dir-toolbar / dir-nav-bottom).
+   Headers whose page root is transparent in wallpaper mode get the unified
+   bg-primary tint (matching their own non-wallpaper base) so they still read
+   as a distinct bar — task, proxy, settings and stats headers all share it. */
+html.wallpaper-active .settings-page__header,
+html.wallpaper-active .stats-header,
+html.wallpaper-active .list-header,
+html.wallpaper-active .detail-header,
+html.wallpaper-active .exec-detail-header,
+html.wallpaper-active .form-header,
+html.wallpaper-active .proxy-header,
+html.wallpaper-active .detail-actions,
+html.wallpaper-active .form-footer,
+html.wallpaper-active .exec-detail-actions {
+    background: color-mix(in srgb, var(--bg-primary) var(--panel-alpha), transparent);
+}
 html.wallpaper-active .terminal-tab-bar,
 html.wallpaper-active .drilldown-header,
 html.wallpaper-active .manage-tabs,
 html.wallpaper-active .toc-dock {
     background: color-mix(in srgb, var(--bg-secondary) var(--panel-alpha), transparent);
 }
-
-/* bg-tertiary file-manager toolbar */
 html.wallpaper-active .dir-toolbar {
     background: color-mix(in srgb, var(--bg-tertiary) var(--panel-alpha), transparent);
 }
-
-/* file-browser bottom nav bar uses bg-primary */
 html.wallpaper-active .dir-nav-bottom {
     background: color-mix(in srgb, var(--bg-primary) var(--panel-alpha), transparent);
+}
+
+/* Section-title bands inside settings cards keep a translucent tint so the
+   grouping is still visible without blocking the wallpaper. */
+html.wallpaper-active .settings-card__header,
+html.wallpaper-active .group-panel__header,
+html.wallpaper-active .group-panel__section-header {
+    background: color-mix(in srgb, var(--bg-tertiary) var(--panel-alpha), transparent);
+}
+
+/* Interactive states on the translucent cards/rows re-tint the surface as
+   feedback. Where a scoped rule paints a solid var(--bg-*) (e.g. :hover,
+   :active, .completed) this higher-specificity scope overrides it with the
+   translucent equivalent; running states keep their green tint composited
+   over the translucent card base. */
+html.wallpaper-active .task-item:active,
+html.wallpaper-active .task-item.completed,
+html.wallpaper-active .execution-item:active:not(.running),
+html.wallpaper-active .group-panel__entry-row:hover,
+html.wallpaper-active .group-panel__entry-row:active,
+html.wallpaper-active .settings-index__row:hover,
+html.wallpaper-active .settings-index__row:active,
+html.wallpaper-active .settings-agents-index__row:hover,
+html.wallpaper-active .settings-agents-index__row:active,
+html.wallpaper-active .settings-agents-index__rescan-row:hover,
+html.wallpaper-active .settings-agents-index__rescan-row:active {
+    background: color-mix(in srgb, var(--bg-tertiary) var(--panel-alpha), transparent);
+}
+html.wallpaper-active .task-item.is-running,
+html.wallpaper-active .execution-item.running {
+    background: color-mix(in srgb, var(--success-color, #16a34a) 5%, color-mix(in srgb, var(--bg-secondary) var(--panel-alpha), transparent));
 }
 
 /* OfficePreview re-encodes its wrappers with !important deep overrides —
@@ -185,6 +246,25 @@ html.wallpaper-active .dir-nav-bottom {
 html.wallpaper-active .office-preview-body .docx-wrapper,
 html.wallpaper-active .office-preview-body .pptx-preview-wrapper {
     background: color-mix(in srgb, var(--bg-primary) var(--panel-alpha), transparent) !important;
+}
+
+/* CodeMirror source view — both browse (read-only preview) and edit mode let
+   the wallpaper show through the code canvas, gutters and the edit toolbar.
+   .cm-viewer is scoped CSS, while .cm-editor/.cm-gutters are injected by the
+   editor theme into .cm-host (global) — list every layer so none stays opaque.
+   The editable accent tint is preserved by mixing it over the translucent base. */
+html.wallpaper-active .cm-viewer,
+html.wallpaper-active .cm-viewer .cm-editor,
+html.wallpaper-active .cm-viewer .cm-gutters {
+    background: color-mix(in srgb, var(--code-bg) var(--panel-alpha), transparent);
+}
+html.wallpaper-active .cm-viewer.is-editable,
+html.wallpaper-active .cm-viewer.is-editable .cm-editor,
+html.wallpaper-active .cm-viewer.is-editable .cm-gutters {
+    background: color-mix(in srgb, var(--accent-color) 6%, color-mix(in srgb, var(--code-bg) var(--panel-alpha), transparent));
+}
+html.wallpaper-active .cm-viewer .code-editor-actions {
+    background: color-mix(in srgb, var(--bg-secondary) var(--panel-alpha), transparent);
 }
 
 /* Scrollbar styling */

--- a/web/src/assets/modal-footer-btn.css
+++ b/web/src/assets/modal-footer-btn.css
@@ -49,6 +49,14 @@
   text-decoration: none;
 }
 
+/* Dark themes: --bg-tertiary is dark, so the light-theme hover grey above would
+   flip the pill near-white while the text stays light (var(--text-primary)),
+   making the label blend into the hover background. Lighten the dark pill by a
+   text-primary tint instead — the standard theme-adaptive hover convention. */
+[data-theme-base="dark"] .fbtn:hover {
+  background: color-mix(in srgb, var(--text-primary, #e6edf3) 7%, var(--bg-tertiary, #f1f3f5));
+}
+
 .fbtn:active {
   transform: scale(0.96);
 }
@@ -109,4 +117,30 @@
   background: color-mix(in srgb, #16a34a 30%, var(--bg-tertiary, #f1f3f5));
   border-color: #16a34a;
   color: #15803d;
+}
+
+/* ── Dark-theme overrides ──
+   The tinted text colours above are deep light-theme shades (dark red/amber/
+   green). On dark themes --bg-tertiary is itself dark, so the same deep text
+   lands at ~2:1 contrast and disappears into the tinted pill. Lift the
+   foreground to the 300-level pastels (same convention as diff/badge text
+   elsewhere) so labels stay readable; the tinted backgrounds and borders are
+   already theme-aware via --bg-tertiary. */
+[data-theme-base="dark"] .fbtn-danger {
+  color: #fca5a5;
+}
+[data-theme-base="dark"] .fbtn-danger:hover {
+  color: #fecaca;
+}
+[data-theme-base="dark"] .fbtn-warn {
+  color: #fbbf24;
+}
+[data-theme-base="dark"] .fbtn-warn:hover {
+  color: #fde68a;
+}
+[data-theme-base="dark"] .fbtn-success {
+  color: #86efac;
+}
+[data-theme-base="dark"] .fbtn-success:hover {
+  color: #bbf7d0;
 }

--- a/web/src/components/common/__tests__/modalFooterBtn.theme.css.test.ts
+++ b/web/src/components/common/__tests__/modalFooterBtn.theme.css.test.ts
@@ -1,0 +1,60 @@
+import { describe, it, expect } from 'vitest'
+
+/**
+ * Theme-parity guards for the shared footer pill (.fbtn) stylesheet.
+ *
+ * Regression: when the per-dialog footer buttons were consolidated into the
+ * shared .fbtn pill system, the neutral hover background stayed hard-coded to
+ * the light-theme grey `#e5e7eb`. On dark themes the pill's rest background is
+ * `var(--bg-tertiary)` (a dark grey), so hovering flipped the pill near-white
+ * while the text stayed `var(--text-primary)` (light) — the label visually
+ * blended into the hover background (e.g. the "Open page" link in the file
+ * share dialog). A `[data-theme-base="dark"]` override now lightens the dark
+ * pill with a text-primary tint instead.
+ *
+ * The tinted variants (.fbtn-danger/warn/success) also carry dark-theme
+ * overrides so their deep light-theme text shades do not sink into the dark
+ * tinted backgrounds (~2:1 contrast otherwise).
+ */
+
+async function rawCss(): Promise<string> {
+  const mod = await import('@/assets/modal-footer-btn.css?raw')
+  return String(mod.default)
+}
+
+describe('modal-footer-btn.css theme-adaptive hover', () => {
+  it('keeps the light-theme hover grey but overrides it for dark themes with a theme-derived tint', async () => {
+    const css = await rawCss()
+    const lightHover = css.match(/\.fbtn:hover\s*\{[\s\S]*?\}/)?.[0]
+    expect(lightHover).toContain('background: #e5e7eb')
+
+    const darkHover = css.match(/\[data-theme-base="dark"\]\s*\.fbtn:hover\s*\{[\s\S]*?\}/)?.[0]
+    expect(darkHover).toBeTruthy()
+    expect(darkHover).toMatch(
+      /background:\s*color-mix\(in srgb,\s*var\(--text-primary[^)]*\)\s*[^,]*,\s*var\(--bg-tertiary/,
+    )
+  })
+
+  it('neutral .fbtn rest state keeps theme tokens for both background and foreground', async () => {
+    const css = await rawCss()
+    const restBlock = css.match(/\.fbtn\s*\{[\s\S]*?\}/)?.[0]
+    expect(restBlock).toContain('background: var(--bg-tertiary, #f1f3f5)')
+    expect(restBlock).toContain('color: var(--text-secondary, #4b5563)')
+  })
+
+  it('tinted variants carry dark-theme foreground overrides so labels stay readable', async () => {
+    const css = await rawCss()
+    for (const name of ['danger', 'warn', 'success']) {
+      const darkRest = css.match(
+        new RegExp(`\\[data-theme-base="dark"\\]\\s*\\.fbtn-${name}\\s*\\{[\\s\\S]*?\\}`),
+      )?.[0]
+      const darkHover = css.match(
+        new RegExp(`\\[data-theme-base="dark"\\]\\s*\\.fbtn-${name}:hover\\s*\\{[\\s\\S]*?\\}`),
+      )?.[0]
+      expect(darkRest, `dark override for .fbtn-${name} rest`).toBeTruthy()
+      expect(darkRest).toContain('color:')
+      expect(darkHover, `dark override for .fbtn-${name}:hover`).toBeTruthy()
+      expect(darkHover).toContain('color:')
+    }
+  })
+})

--- a/web/src/components/common/__tests__/wallpaperSurfaceTransparency.css.test.ts
+++ b/web/src/components/common/__tests__/wallpaperSurfaceTransparency.css.test.ts
@@ -1,0 +1,104 @@
+import { describe, it, expect } from 'vitest'
+import { readFileSync } from 'node:fs'
+import { join } from 'node:path'
+
+/**
+ * Guard tests for the wallpaper-active surface strategy in css/base.css.
+ *
+ * Regression: full-page tab roots previously stacked a SECOND translucent
+ * layer (color-mix over --panel-alpha) on top of the already-translucent
+ * .tab-panel. Compounding alphas (panel root → card → panel) dimmed the
+ * wallpaper so badly that low opacity settings nearly hid it. The fix makes
+ * whole-page roots AND the full-bleed card/list surfaces inside them fully
+ * transparent while the wallpaper is active — the .tab-panel becomes the
+ * single visible surface. Only narrow page-level bars keep a translucent
+ * tint, and interactive states re-add a tint as feedback.
+ *
+ * These are source-sniffing tests (jsdom has no CSS engine), the same
+ * pattern as flashReducedMotion.css.test.ts / modalFooterBtn.theme.css.test.ts.
+ * base.css lives outside the vitest source root (web/css), so it is read off
+ * disk — the cwd differs between a bare `vitest` run (web/) and the
+ * scripts/vitest-run.sh wrapper (repo root), so probe both.
+ */
+
+function readBaseCss(): string {
+  for (const base of [process.cwd(), join(process.cwd(), 'web')]) {
+    try {
+      return readFileSync(join(base, 'css/base.css'), 'utf8')
+    } catch {
+      // try the next candidate
+    }
+  }
+  throw new Error('css/base.css not found from cwd: ' + process.cwd())
+}
+
+const css = readBaseCss()
+
+// Extract the full rule (selector list + declaration block) that contains the
+// given selector. The wallpaper scope prefixes every selector with
+// html.wallpaper-active, so anchoring on a member selector returns the whole
+// grouped rule.
+function ruleContaining(anchor: string): string {
+  const idx = css.indexOf(anchor)
+  expect(idx, `selector "${anchor}" should exist`).toBeGreaterThan(-1)
+  const open = css.indexOf('{', idx)
+  const close = css.indexOf('}', open)
+  return css.slice(idx, close + 1)
+}
+
+describe('wallpaper-active single-surface transparency', () => {
+  it('keeps whole-page roots fully transparent (no second translucent scrim)', () => {
+    // Task / proxy / settings / stats / media-preview page roots must become
+    // fully transparent under wallpaper-active so only the .tab-panel surface
+    // shows through — NOT a translucent color-mix layer that compounds alphas.
+    const rule = ruleContaining('html.wallpaper-active .task-list-page')
+    expect(rule).toContain('background: transparent;')
+    for (const sel of ['.task-detail-page', '.settings-page', '.proxy-panel-content', '.usage-stats-panel', '.pdf-error']) {
+      expect(rule).toContain(`html.wallpaper-active ${sel}`)
+    }
+    // The whole-page roots group must not contain a translucent color-mix
+    // background — that would reintroduce the compounding-alpha regression.
+    expect(rule).not.toContain('color-mix')
+  })
+
+  it('applies exactly ONE translucent layer on full-bleed cards/list rows', () => {
+    const rule = ruleContaining('html.wallpaper-active .task-item')
+    expect(rule).toMatch(
+      /background:\s*color-mix\(in srgb,\s*var\(--bg-secondary\)\s*var\(--panel-alpha\),\s*transparent\);/,
+    )
+    for (const sel of ['.execution-item', '.overview-card', '.proxy-port-item', '.form-section', '.stats-card-panel']) {
+      expect(rule).toContain(`html.wallpaper-active ${sel}`)
+    }
+  })
+
+  it('keeps page-level bars translucent so chrome stays legible over the wallpaper', () => {
+    const rule = ruleContaining('html.wallpaper-active .settings-page__header')
+    expect(rule).toMatch(
+      /background:\s*color-mix\(in srgb,\s*var\(--bg-primary\)\s*var\(--panel-alpha\),\s*transparent\);/,
+    )
+    for (const sel of ['.stats-header', '.list-header', '.detail-header', '.proxy-header']) {
+      expect(rule).toContain(`html.wallpaper-active ${sel}`)
+    }
+  })
+
+  it('re-tints interactive states over the translucent card base as feedback', () => {
+    const rule = ruleContaining('html.wallpaper-active .task-item:active')
+    expect(rule).toMatch(
+      /background:\s*color-mix\(in srgb,\s*var\(--bg-tertiary\)\s*var\(--panel-alpha\),\s*transparent\);/,
+    )
+    // Running states keep their green tint composited over the translucent base.
+    const running = ruleContaining('html.wallpaper-active .task-item.is-running')
+    expect(running).toContain('var(--success-color, #16a34a) 5%')
+  })
+
+  it('lets the wallpaper show through the CodeMirror code canvas in browse AND edit modes', () => {
+    const browse = ruleContaining('html.wallpaper-active .cm-viewer')
+    expect(browse).toMatch(
+      /background:\s*color-mix\(in srgb,\s*var\(--code-bg\)\s*var\(--panel-alpha\),\s*transparent\);/,
+    )
+    // The editable accent tint must be preserved by mixing over the translucent base.
+    const edit = ruleContaining('html.wallpaper-active .cm-viewer.is-editable')
+    expect(edit).toContain('var(--accent-color) 6%')
+    expect(edit).toContain('var(--code-bg)')
+  })
+})

--- a/web/src/components/file/SharedFilesDrawer.vue
+++ b/web/src/components/file/SharedFilesDrawer.vue
@@ -356,4 +356,19 @@ defineExpose({ open: openDrawer })
 @media (hover: hover) {
   .shared-files-clear:not(:disabled):hover { background: #fef2f2; }
 }
+
+/* Dark themes: the light-pink hover surfaces above were tuned for light
+   themes. Keep the red tint but adapt it to the dark surface so the icon/text
+   stays legible (same convention as .context-menu-item.danger hover). */
+[data-theme-base="dark"] .shared-file-btn.danger:hover {
+  color: #fca5a5;
+  background: rgba(239, 68, 68, 0.15);
+}
+[data-theme-base="dark"] .shared-files-clear {
+  color: #fca5a5;
+}
+[data-theme-base="dark"] .shared-files-clear:not(:disabled):hover {
+  color: #fca5a5;
+  background: rgba(239, 68, 68, 0.15);
+}
 </style>

--- a/web/src/components/proxy/ProxyPanelContent.vue
+++ b/web/src/components/proxy/ProxyPanelContent.vue
@@ -490,14 +490,15 @@ async function handleRetryTunnel() {
   overflow: hidden;
 }
 
-/* Compact header — flush to panel edges, matches chat/app header style */
+/* Compact header — flush to panel edges, matches settings/stats header style */
 .proxy-header {
   display: flex;
   align-items: center;
-  padding: 4px 6px;
+  height: var(--header-height);
+  padding: 0 4px 0 12px;
   flex-shrink: 0;
   gap: 6px;
-  background: var(--bg-secondary, #f8f9fa);
+  background: var(--bg-primary);
   border-bottom: 1px solid var(--border-color, #e5e5e5);
 }
 

--- a/web/src/components/settings/SettingsPage.vue
+++ b/web/src/components/settings/SettingsPage.vue
@@ -177,7 +177,7 @@ watch(() => props.active, (val) => {
   border-bottom: 1px solid var(--border-color);
   flex-shrink: 0;
   background: var(--bg-primary);
-  gap: 8px;
+  gap: 6px;
 }
 
 .settings-page__back {

--- a/web/src/components/settings/WallpaperSetting.vue
+++ b/web/src/components/settings/WallpaperSetting.vue
@@ -42,7 +42,7 @@
           type="range"
           class="settings-item__slider"
           :value="panelOpacity"
-          min="0.7"
+          min="0.5"
           max="1"
           step="0.01"
           :disabled="!wallpaperHasImage"
@@ -139,7 +139,7 @@ const state = computed<WallpaperState>(() =>
 /** Whether a wallpaper image is actually set (enables the per-option rows). */
 const wallpaperHasImage = computed(() => state.value === 'set')
 
-/** Panel opacity from config (0.7..1.0). */
+/** Panel opacity from config (0.5..1.0). */
 const panelOpacity = computed(() => resolvePanelOpacity(serverConfig.value?.appearance as Record<string, unknown> | undefined))
 
 const opacityDisplay = computed(() => `${Math.round(panelOpacity.value * 100)}%`)

--- a/web/src/components/settings/__tests__/WallpaperSetting.test.ts
+++ b/web/src/components/settings/__tests__/WallpaperSetting.test.ts
@@ -199,6 +199,24 @@ describe('WallpaperSetting', () => {
     expect(mockPatchConfig).toHaveBeenCalledWith({ appearance: { panel_opacity: 0.75 } })
   })
 
+  it('accepts panel opacity below the old 0.7 floor (relaxed 0.5 lower bound)', async () => {
+    // Regression: the translucent-panel tuning range widened from 0.7–1.0 to
+    // 0.5–1.0. The slider must expose the relaxed floor and a 0.5x value must
+    // reach the server PATCH (settings.go validatePatchValues now allows it).
+    serverConfig.value = { appearance: { wallpaper_file: 'background.png', panel_opacity: 0.85 } }
+    const wrapper = mountSetting()
+    await nextTick()
+    const slider = wrapper.find('input[type="range"]')
+    expect(slider.attributes('min')).toBe('0.5')
+    expect(slider.attributes('max')).toBe('1')
+    await slider.setValue('0.55')
+    await slider.trigger('input')
+    await new Promise(r => setTimeout(r, 400))
+    expect(mockPatchConfig).toHaveBeenCalledWith({ appearance: { panel_opacity: 0.55 } })
+    expect(document.documentElement.style.getPropertyValue('--panel-alpha')).toBe('55%')
+  })
+
+
   it('does not change the wallpaper image URL while dragging the opacity slider', async () => {
     serverConfig.value = { appearance: { wallpaper_file: 'background.png', panel_opacity: 0.85 } }
     const wrapper = mountSetting()

--- a/web/src/components/settings/__tests__/settingsFieldMap.test.ts
+++ b/web/src/components/settings/__tests__/settingsFieldMap.test.ts
@@ -124,6 +124,28 @@ describe('settingsFieldMap', () => {
     expect(entry!.spec.sectionHeader).toBe('settings.items.fontSection')
   })
 
+  it('wallpaper panel-opacity slider allows the relaxed 0.5 lower bound', () => {
+    // Regression: the panel-opacity floor was relaxed from 0.7 to 0.5 (the
+    // wallpaper translucent-panel tuning range widened). Guard the slider spec
+    // so a future tighten does not silently diverge from the server-side
+    // PATCH validation (settings.go, validatePatchValues: 0.5–1.0).
+    const map = getServerFieldToLabelKey()
+    expect(map['appearance.panel_opacity']).toBe('settings.items.wallpaperPanelOpacity')
+
+    const appearanceEntries = categoryItems['appearance']
+    const entry = appearanceEntries.find(e => e.type === 'item' && e.spec.key === 'appearance.panel_opacity')
+    expect(entry).toBeDefined()
+    if (entry!.type !== 'item') throw new Error('expected item entry for appearance.panel_opacity')
+    expect(entry.spec.source).toBe('server')
+    expect(entry.spec.type).toBe('slider')
+    expect(entry.spec.min).toBe(0.5)
+    expect(entry.spec.max).toBe(1)
+    expect(entry.spec.step).toBe(0.01)
+    expect(entry.spec.defaultValue).toBe(0.85)
+    expect(entry.spec.displayFormat).toBe('percent')
+    expect(entry.spec.sectionHeader).toBe('settings.items.wallpaperSection')
+  })
+
   it('includes recent_projects.max_count', () => {
     const map = getServerFieldToLabelKey()
     expect(map['recent_projects.max_count']).toBeTruthy()

--- a/web/src/components/settings/settingsFieldMap.ts
+++ b/web/src/components/settings/settingsFieldMap.ts
@@ -206,7 +206,7 @@ export const categoryItems: Record<string, CategoryEntry[]> = {
     // slider item is NOT rendered through the generic row (its UI lives inside
     // WallpaperSetting) — it exists so the section groups correctly and the
     // value is readable in the config pipeline.
-    { type: 'item', spec: { labelKey: 'settings.items.wallpaperPanelOpacity', key: 'appearance.panel_opacity', type: 'slider', source: 'server', min: 0.7, max: 1, step: 0.01, defaultValue: 0.85, displayFormat: 'percent', sectionHeader: 'settings.items.wallpaperSection' }},
+    { type: 'item', spec: { labelKey: 'settings.items.wallpaperPanelOpacity', key: 'appearance.panel_opacity', type: 'slider', source: 'server', min: 0.5, max: 1, step: 0.01, defaultValue: 0.85, displayFormat: 'percent', sectionHeader: 'settings.items.wallpaperSection' }},
   ],
   agents: [],
   chat: [

--- a/web/src/components/stats/UsageStatsPanel.vue
+++ b/web/src/components/stats/UsageStatsPanel.vue
@@ -536,9 +536,9 @@ function onRefresh() {
 .stats-header {
   display: flex;
   align-items: center;
-  gap: 8px;
+  gap: 6px;
   height: var(--header-height, 36px);
-  padding: 0 8px 0 12px;
+  padding: 0 4px 0 12px;
   border-bottom: 1px solid var(--border-color);
   flex-shrink: 0;
   background: var(--bg-primary);

--- a/web/src/components/task/TaskDetailPage.vue
+++ b/web/src/components/task/TaskDetailPage.vue
@@ -138,8 +138,10 @@ async function onRefresh() {
 .detail-header {
   display: flex;
   align-items: center;
-  padding: 4px 8px;
+  height: var(--header-height);
+  padding: 0 4px 0 12px;
   flex-shrink: 0;
+  background: var(--bg-primary);
   border-bottom: 1px solid var(--border-color, #e5e5e5);
   gap: 6px;
 }

--- a/web/src/components/task/TaskExecDetail.vue
+++ b/web/src/components/task/TaskExecDetail.vue
@@ -616,7 +616,9 @@ onUnmounted(() => {
   display: flex;
   align-items: center;
   gap: 6px;
-  padding: 4px 8px;
+  height: var(--header-height);
+  padding: 0 4px 0 12px;
+  background: var(--bg-primary);
   border-bottom: 1px solid var(--border-color, #e5e5e5);
   flex-shrink: 0;
 }

--- a/web/src/components/task/TaskFormPage.vue
+++ b/web/src/components/task/TaskFormPage.vue
@@ -399,12 +399,15 @@ onMounted(() => {
   background: var(--bg-primary, #ffffff);
 }
 
-/* Compact header */
+/* Compact header — unified with list/detail/settings/proxy headers */
 .form-header {
   display: flex;
   align-items: center;
-  padding: 4px 8px;
+  height: var(--header-height);
+  padding: 0 4px 0 12px;
   flex-shrink: 0;
+  gap: 6px;
+  background: var(--bg-primary);
   border-bottom: 1px solid var(--border-color, #e5e5e5);
 }
 

--- a/web/src/components/task/TaskListPage.vue
+++ b/web/src/components/task/TaskListPage.vue
@@ -130,12 +130,14 @@ onMounted(refresh)
   background: var(--bg-primary, #ffffff);
 }
 
-/* Compact header — matches detail/form/history pages */
+/* Compact header — unified with detail/form/history/settings/proxy headers */
 .list-header {
   display: flex;
   align-items: center;
-  padding: 4px 8px;
+  height: var(--header-height);
+  padding: 0 4px 0 12px;
   flex-shrink: 0;
+  background: var(--bg-primary);
   border-bottom: 1px solid var(--border-color, #e5e5e5);
   gap: 6px;
 }

--- a/web/src/utils/__tests__/themeBackground.test.ts
+++ b/web/src/utils/__tests__/themeBackground.test.ts
@@ -88,7 +88,7 @@ describe('themeBackground', () => {
       applyWallpaper('background.png', 5, false)
       expect(document.documentElement.style.getPropertyValue('--panel-alpha')).toBe('100%')
       applyWallpaper('background.png', 0.1, false)
-      expect(document.documentElement.style.getPropertyValue('--panel-alpha')).toBe('70%')
+      expect(document.documentElement.style.getPropertyValue('--panel-alpha')).toBe('50%')
     })
 
     it('clears the effect when the wallpaper file is empty', () => {

--- a/web/src/utils/themeBackground.ts
+++ b/web/src/utils/themeBackground.ts
@@ -78,7 +78,7 @@ export function resolveWallpaperUrl(wallpaperFile: string, forceBust = false): s
 /**
  * Apply (or clear) the wallpaper effect for the given state.
  * `wallpaperFile` — active file name from server config ('' = none).
- * `panelOpacity`  — 0.7..1.0 opacity multiplier (clamped).
+ * `panelOpacity`  — 0.5..1.0 opacity multiplier (clamped).
  * `dark`          — current resolved theme is dark (drives scrim strength).
  * `forceBust`     — when true, regenerate the image URL even if the file name is
  *                   unchanged. Pass after an upload/replace that reuses the same
@@ -98,7 +98,7 @@ export function applyWallpaper(wallpaperFile: string, panelOpacity: number, dark
   el.style.setProperty('--wallpaper-url', url ? `url("${url}")` : 'none')
   el.style.setProperty('--wallpaper-scrim', active ? wallpaperScrim(dark) : 'transparent')
 
-  const alpha = Number.isFinite(panelOpacity) ? Math.min(1, Math.max(0.7, panelOpacity)) : 0.85
+  const alpha = Number.isFinite(panelOpacity) ? Math.min(1, Math.max(0.5, panelOpacity)) : 0.85
   // Store the panel opacity as a <percentage> so the CSS color-mix stops are
   // plain percentages (calc() inside color-mix trips some CSS minifiers).
   el.style.setProperty('--panel-alpha', `${Math.round(alpha * 1000) / 10}%`)


### PR DESCRIPTION
## 概述

3 提交批量合入：壁纸「半透明面板」策略重构、panel opacity 下限放宽 0.7→0.5、共享 footer 胶囊（.fbtn）与共享文件抽屉暗色主题修复，含完整回归测试与 Go lint/覆盖率补齐。

## 变更

### 1. 壁纸半透明策略重构 — 单层底透出（`web/css/base.css`）
- 全页 tab 根（task/proxy/settings/stats/媒体预览）在 wallpaper-active 下从「二次半透明 scrim」改为**完全透明**——.tab-panel 是唯一可见表面，消除叠加 alpha 导致的壁纸过度变暗
- 页内全出血卡片/列表行保持**单层** color-mix 半透明（depth 分层，不叠三层）
- 页级 bar（list/detail/form/proxy/settings/stats header）统一 `--header-height` + bg-primary 半透明 tint
- CodeMirror 源码视图 browse/编辑双模式让壁纸透出，editable accent tint 保留
- 新增 `wallpaperSurfaceTransparency.css.test.ts` 源码嗅探守卫该策略

### 2. Panel opacity 下限放宽 0.7 → 0.5
- Go: `validatePatchValues` 范围改 0.5–1.0（settings.go），默认 0.85 不变
- 前端: 滑块 min/clamp/字段元数据同步放宽
- 测试: Go 新增 lower-bound 接受用例；前端 settingsFieldMap 断言 min=0.5、WallpaperSetting 端到端断言 0.55 PATCH

### 3. 暗色主题修复
- `.fbtn` 共享胶囊: 暗色 hover 不再近白（用 text-primary tint over bg-tertiary）；danger/warn/success 前景色提亮至 300 级
- SharedFilesDrawer: danger 按钮/清除按钮暗色适配
- 测试: `modalFooterBtn.theme.css.test.ts` 守卫暗色覆盖

## CI/质量
- Go lint 0 issues，Go test/build 通过，Go 覆盖率 gate PASS（settings.go 豁免文件 2/2 覆盖）
- 前端 typecheck/ESLint/coverage gate/build 通过
- Android lint/coverage PASS（无 android 改动，Tier 2 跳过）
- 本地 pre-push 全部通过