### PR TITLE
fix(e2e): auth fixture 屏蔽首次欢迎页与升级弹窗，消除对点击的拦截

### DIFF
--- a/e2e/fixtures/auth.fixture.ts
+++ b/e2e/fixtures/auth.fixture.ts
@@ -30,6 +30,16 @@ const E2E_PORT = process.env.E2E_PORT || '20100'
  */
 export const test = base.extend({
   page: async ({ page }, use) => {
+    // Dismiss the first-run Welcome overlay BEFORE the page loads.
+    // Every test gets a fresh browser context (empty localStorage), so without
+    // this flag WelcomeOverlay.show() renders the full-screen overlay and
+    // intercepts pointer events on the send button etc. (the overlay is a
+    // first-run UX; real users dismiss it via "Don't show again").
+    // addInitScript runs before each navigation, covering page.reload() too.
+    await page.addInitScript(() => {
+      localStorage.setItem('clawbench_welcome_dismissed', 'true')
+    })
+
     // Navigate to the app root
     const response = await page.goto('/')
 

--- a/e2e/fixtures/auth.fixture.ts
+++ b/e2e/fixtures/auth.fixture.ts
@@ -40,6 +40,15 @@ export const test = base.extend({
       localStorage.setItem('clawbench_welcome_dismissed', 'true')
     })
 
+    // Block the upgrade check so the "New Version Available" overlay never
+    // appears and cannot intercept clicks. The E2E binary is a dev build
+    // (IsDevBuild=true, version is a git SHA), so the backend unconditionally
+    // reports has_upgrade=true whenever the registry is reachable — which
+    // would make UpgradePromptOverlay render over the app and block clicks.
+    await page.route('**/api/upgrade/**', (route) => {
+      route.fulfill({ status: 200, contentType: 'application/json', body: '{"has_upgrade":false,"latest_version":""}' })
+    })
+
     // Navigate to the app root
     const response = await page.goto('/')
 


### PR DESCRIPTION
## 背景

两个全屏覆盖层会拦截 e2e 测试的指针事件，导致点击发送按钮等操作超时：

1. **WelcomeOverlay（首次使用欢迎页）**：每次 e2e 测试都是新建 browser context（localStorage 为空），
   `WelcomeOverlay.show()` 因无 `clawbench_welcome_dismissed` 标记而全屏弹出并拦截点击。
2. **UpgradePromptOverlay（"New Version Available"）**：e2e 二进制为 dev build（`IsDevBuild=true`，
   版本号为 git SHA），后端 `/api/upgrade/check` 在网络可达时无条件返回 `has_upgrade=true`，
   前端弹出升级覆盖层拦截点击。

## 改动

仅修改 **`e2e/fixtures/auth.fixture.ts`**（+19 行），在 auth fixture 统一屏蔽两类覆盖层，
一处修复惠及所有 spec：

- `addInitScript` 在页面加载前写入 `clawbench_welcome_dismissed=true`（覆盖 reload）
- `page.route` 拦截 `/api/upgrade/**` 并伪造 `{"has_upgrade":false}` 响应

> 定位策略：本地状态（localStorage）与网络响应（API）双管齐下，互不干扰。

## 验证

- 相同测试子集（chat + chat-scroll-fab + navigation，chromium）下与 main 对照：
  - **main（无修复）**：19 failed / 1 passed
  - **本分支（有修复）**：15 failed / 5 passed
  - 通过数净增 4，失败集合无新增 → 修复消除弹窗拦截、无回归
- 改动文件与产品代码无交集（`git diff main..HEAD` 仅 1 文件）

## 重要声明：范围与遗留失败

**本 PR 仅修复 e2e fixture 中欢迎页/升级弹窗对点击的拦截问题。**

当前 e2e 套件仍有大量失败点（navigation / chat / chat-scroll-fab 等 spec），
在 main 分支上同样存在，属 **spec 与 UI 演进脱节的既有测试债**（dock 双形态布局、
溢出按钮动态渲染、消息计数等断言过时），与本 PR 无关，将作为后续工作单独修复。

CI 的 e2e job 需要 `run-e2e` label 且 `continue-on-error: true`，不阻塞合并。