### PR TITLE
fix(web): 消除 skill 命令在 slash 菜单的双斜杠，恢复单 "/" 渲染

### DIFF
--- a/internal/ai/codebuddy_skill_scanner.go
+++ b/internal/ai/codebuddy_skill_scanner.go
@@ -160,20 +160,20 @@ func collapseWhitespace(s string) string {
 }
 
 // SkillsToCommands converts SkillInfo slices to AvailableCommandInfo so skills
-// appear in the slash command menu (/) just like plugin commands. CodeBuddy
-// TUI mode exposes skills this way; we mirror it in ACP mode.
+// appear in the slash command menu (/) just like plugin commands.
+//
+// Command names are delivered as the RAW frontmatter name — no "/" prefix is
+// added here. The frontend prepends "/" when rendering the slash menu, exactly
+// as it does for plugin-command names. Adding "/" in both places would produce
+// "//name" in the menu and break IsACPSlashCommand on send.
 func SkillsToCommands(skills []SkillInfo) []AvailableCommandInfo {
 	if len(skills) == 0 {
 		return nil
 	}
 	cmds := make([]AvailableCommandInfo, 0, len(skills))
 	for _, s := range skills {
-		name := s.Name
-		if !strings.HasPrefix(name, "/") {
-			name = "/" + name
-		}
 		cmds = append(cmds, AvailableCommandInfo{
-			Name:        name,
+			Name:        s.Name,
 			Description: s.Description,
 		})
 	}

--- a/internal/ai/codebuddy_skill_scanner_test.go
+++ b/internal/ai/codebuddy_skill_scanner_test.go
@@ -473,7 +473,10 @@ func TestSkillsToCommands(t *testing.T) {
 			skills: []SkillInfo{
 				{Name: "skill-creator", Description: "Guide for creating skills"},
 			},
-			wantNames: []string{"/skill-creator"},
+			// Bare frontmatter name must be delivered as-is — the frontend adds
+			// the "/" prefix when rendering the slash menu. A backend-added "/"
+			// would double up to "//" in the menu and break IsACPSlashCommand.
+			wantNames: []string{"skill-creator"},
 			wantDescs: []string{"Guide for creating skills"},
 			wantLen:   1,
 		},
@@ -482,6 +485,9 @@ func TestSkillsToCommands(t *testing.T) {
 			skills: []SkillInfo{
 				{Name: "/skill-creator", Description: "Guide for creating skills"},
 			},
+			// A name that already carries a slash is preserved verbatim (no
+			// stripping, no re-adding). The frontend is responsible for
+			// rendering a single leading slash either way.
 			wantNames: []string{"/skill-creator"},
 			wantDescs: []string{"Guide for creating skills"},
 			wantLen:   1,
@@ -492,7 +498,7 @@ func TestSkillsToCommands(t *testing.T) {
 				{Name: "skill-creator", Description: "Guide for creating skills"},
 				{Name: "docx", Description: "Word doc manipulation"},
 			},
-			wantNames: []string{"/skill-creator", "/docx"},
+			wantNames: []string{"skill-creator", "docx"},
 			wantDescs: []string{"Guide for creating skills", "Word doc manipulation"},
 			wantLen:   2,
 		},

--- a/web/src/components/chat/ChatInputBar.vue
+++ b/web/src/components/chat/ChatInputBar.vue
@@ -810,13 +810,22 @@ const atMenuItems = computed(() => {
     .map(cmd => ({ ...cmd, query }))
 })
 
+// Slash-command menu item key/label: names arrive WITHOUT a leading slash
+// (plugin-command files, ACP built-ins), but pre-scanned user skills carry
+// their raw frontmatter name, which may ALREADY start with "/". Prepending
+// "/" unconditionally would render "//name" and break IsACPSlashCommand on
+// send — only add the slash when the name doesn't already have one.
+function slashCommandKey(name) {
+  return name.startsWith('/') ? name : '/' + name
+}
+
 const slashMenuItems = computed(() => {
   const text = inputText.value
   if (!text.startsWith('/')) return []
   const query = text.slice(1) // strip leading '/'
   if (!query) return availableCommands.value.map(cmd => ({
-    key: '/' + cmd.name,
-    label: '/' + cmd.name,
+    key: slashCommandKey(cmd.name),
+    label: slashCommandKey(cmd.name),
     description: cmd.description,
     inputHint: cmd.inputHint || '',
     query: '',
@@ -825,8 +834,8 @@ const slashMenuItems = computed(() => {
   return availableCommands.value
     .filter(cmd => cmd.name.toLowerCase().includes(lowerQ))
     .map(cmd => ({
-      key: '/' + cmd.name,
-      label: '/' + cmd.name,
+      key: slashCommandKey(cmd.name),
+      label: slashCommandKey(cmd.name),
       description: cmd.description,
       inputHint: cmd.inputHint || '',
       query,

--- a/web/src/components/chat/__tests__/ChatInputBar.test.ts
+++ b/web/src/components/chat/__tests__/ChatInputBar.test.ts
@@ -1221,6 +1221,49 @@ describe('ChatInputBar', () => {
     mockSupportsACP.mockReturnValue(false)
   })
 
+  it('Enter confirms a slash-prefixed skill name with a single slash', async () => {
+    // Skill commands carry their frontmatter name. A user skill whose SKILL.md
+    // name already starts with "/" (as pre-scanned skill commands used to) must
+    // NOT gain a second "/" in the slash menu — that would produce "//skill"
+    // and fail IsACPSlashCommand on send.
+    mockSupportsACP.mockReturnValue(true)
+    mockSessionTransport.value = 'acp-stdio'
+    mockAvailableCommands.value = [{ name: '/my-skill', description: 'My skill', inputHint: '' }]
+    const wrapper = mountBar()
+    wrapper.vm.inputText = '/'
+    await wrapper.vm.$nextTick()
+    // First item is pre-selected at index 0; Enter should confirm it
+    await wrapper.find('.chat-textarea').trigger('keydown', { key: 'Enter' })
+    await flushPromises()
+    await wrapper.vm.$nextTick()
+    expect(wrapper.vm.inputText).toBe('/my-skill ')
+    expect(wrapper.vm.showSlashMenu).toBe(false)
+    mockAvailableCommands.value = []
+    mockSessionTransport.value = ''
+    mockSupportsACP.mockReturnValue(false)
+  })
+
+  it('slash menu keeps a single slash when a bare-name and slash-prefixed command coexist', async () => {
+    // Plugin-command names are bare ("help"); skill names may already carry a
+    // slash ("/my-skill"). Both must render with exactly one leading slash.
+    mockSupportsACP.mockReturnValue(true)
+    mockSessionTransport.value = 'acp-stdio'
+    mockAvailableCommands.value = [
+      { name: 'help', description: 'Show help', inputHint: '' },
+      { name: '/my-skill', description: 'My skill', inputHint: '' },
+    ]
+    const wrapper = mountBar()
+    wrapper.vm.inputText = '/'
+    await wrapper.vm.$nextTick()
+    const labels = (wrapper.vm.slashMenuItems as Array<{ key: string; label: string }>).map(i => i.label)
+    expect(labels).toContain('/help')
+    expect(labels).toContain('/my-skill')
+    expect(labels.some(l => l.startsWith('//'))).toBe(false)
+    mockAvailableCommands.value = []
+    mockSessionTransport.value = ''
+    mockSupportsACP.mockReturnValue(false)
+  })
+
   it('ArrowUp from pre-selected first @ item wraps to last item', async () => {
     const wrapper = mountBar()
     wrapper.vm.inputText = '@'


### PR DESCRIPTION
## 背景

用户安装的 skill（`~/.codebuddy/skills/*/SKILL.md`）通过 `SkillsToCommands` 预扫描注册为 slash 命令后，输入 `/` 弹出的命令列表显示 **双斜杠**（如 `//skill-creator`），而插件 Cache 命令、ACP 内置命令都是单斜杠。

选中发送后问题更严重：后端 `IsACPSlashCommand`（`acp_conn_state.go`）判定 `//xxx` 非法，命令被当作普通文本发给 agent，slash 命令实际不生效。

## 根因

skill 扫描器在后端就为命令名补了 `/`，前端渲染时又补一次 → 双重叠加：

```go
// internal/ai/codebuddy_skill_scanner.go（修复前）
name := s.Name
if !strings.HasPrefix(name, "/") {
    name = "/" + name   // 第一次补 "/"
}
```

```ts
// ChatInputBar.vue slashMenuItems（渲染）
key: '/' + cmd.name,     // 第二次补 "/" → "//skill-creator"
label: '/' + cmd.name,
```

对比其他命令源：插件 Cache 扫描（`codebuddy_plugin_scanner.go`）和 CodeBuddy ACP 上报都以**裸名**交付命令，前端统一负责补 `/`。只有 skill 扫描器破坏了「命令名存裸名、前端加 `/`」的约定。

## 修复

- **后端**：`SkillsToCommands` 不再补 `/`，命令名按 frontmatter 原样交付（裸名），与插件 Cache 扫描一致
- **前端**：`slashMenuItems` 抽出 `slashCommandKey()`，仅在 name 不以 `/` 开头时才补 `/`——裸名（`help`）和已带前缀（`/my-skill`）都正确渲染为单个 `/`，对将来其他带前缀输入源也健壮

## 变更类型

- [x] fix: Bug 修复

## 关联 Issue

无

## 测试

- [x] 已通过现有测试
- [x] 已添加新测试覆盖
- [x] 手动验证

验证明细：

- **TDD**：先写失败测试（断言 `//my-skill` 应为 `/my-skill`，实际失败输出正是 `expected '//my-skill ' to be '/my-skill '`），再修复转绿
- **Go**：`TestSkillsToCommands` 期望改为裸名 + 保留已带 `/` 前缀输入的用例；`go test ./internal/ai/` 全绿
- **前端**：新增 2 个回归测试（Enter 确认带前缀 skill 命令输出单斜杠；裸名+带斜杠命令共存时无 `//`）；`ChatInputBar.test.ts` 146/146 通过；`useSessionIdentity` 118/118、`sessionIdentity` 45/45
- **非 root + Node 24 本地 CI**：`go test ./...`、`go build`、golangci-lint（0 issues）、eslint、vue-tsc typecheck 全部通过；前端 **Tier 2 diff coverage 100%**（5/5 变更行）

## 自检清单

- [x] 代码遵循项目现有风格
- [x] 无硬编码密钥或敏感信息
- [x] 变更已反映在文档中（如适用）

---

## 详细变更范围

| 文件 | 变更 | 说明 |
|---|---|---|
| `internal/ai/codebuddy_skill_scanner.go` | -7 | `SkillsToCommands` 删除后端补 `/` 逻辑，命令名按 frontmatter 裸名交付 |
| `internal/ai/codebuddy_skill_scanner_test.go` | +9/-4 | `TestSkillsToCommands` 期望改为裸名，注明裸名契约 |
| `web/src/components/chat/ChatInputBar.vue` | +10/-2 | 新增 `slashCommandKey()`，`slashMenuItems` 两处渲染统一使用 |
| `web/src/components/chat/__tests__/ChatInputBar.test.ts` | +43 | 新增 2 个单斜杠回归测试 |

## 影响范围 / 风险

- 仅影响 skill 命令在 slash 菜单的展示与发送，其他命令源（插件、ACP）行为不变
- 已持久化的旧 `//` 命令：registry 为内存态，连接重启会重新预扫刷新，无需迁移
- CI 说明：前端 Tier 1（`src/utils`）若出现覆盖率漂移属 vitest 进程池稳定性问题（与本 PR 改动无关），CI 对 Tier 1 exit code 2 为非阻塞 warning
