### PR TITLE
fix(web): 修复文件跳转返回时阅读位置不准与失效问题

### DIFF
--- a/web/src/App.vue
+++ b/web/src/App.vue
@@ -1679,6 +1679,9 @@ navCoordinator = useNavigationCoordinator({
     closeOverlayAndSync,
     handleOpenFileManager,
     isFileManagerMultiSelectActive: () => !!fileManagerRef.value?.multiSelectState?.active,
+    // FileOverlay forwards to FileViewer, which emits 'captureScroll' — so this
+    // also refreshes the module-level scroll cache for the file being left.
+    requestScrollCapture: () => fileOverlayRef.value?.captureScroll?.(),
   },
   backHooks: {
     hasTopmostOverlay,

--- a/web/src/components/file/FileOverlay.vue
+++ b/web/src/components/file/FileOverlay.vue
@@ -139,7 +139,11 @@ function focusSearchInput() {
   searchDrawerRef.value?.focusSearchInput?.()
 }
 
-defineExpose({ pdfScrollToPage, pdfOutline, focusSearchInput })
+function captureScroll() {
+  return fileViewerRef.value?.captureScroll?.()
+}
+
+defineExpose({ pdfScrollToPage, pdfOutline, focusSearchInput, captureScroll })
 
 // Intercept file-path link clicks inside the overlay content.
 // When a user clicks a .chat-file-open-btn, .chat-file-path, or .code-file-path,
@@ -151,6 +155,7 @@ function handleContentClick(event) {
   if (btn) {
     event.preventDefault()
     event.stopPropagation()
+    fileViewerRef.value?.captureScroll?.()
     const filePath = btn.getAttribute('data-file-path')
     const lineStart = btn.getAttribute('data-line-start')
     const lineEnd = btn.getAttribute('data-line-end')
@@ -165,6 +170,7 @@ function handleContentClick(event) {
   if (pathSpan) {
     event.preventDefault()
     event.stopPropagation()
+    fileViewerRef.value?.captureScroll?.()
     const filePath = pathSpan.getAttribute('data-file-path')
     const lineStart = pathSpan.getAttribute('data-line-start')
     const lineEnd = pathSpan.getAttribute('data-line-end')

--- a/web/src/components/file/FileViewer.vue
+++ b/web/src/components/file/FileViewer.vue
@@ -150,6 +150,7 @@
           @show-details="emit('showDetails')"
           @open-git-history="emit('openGitHistory')"
           @close-search="emit('closeSearch')"
+          @capture-scroll="(entry) => emit('captureScroll', entry)"
         />
         <!-- Source/raw mode: a single CodeMirrorViewer for both browse and edit
              (editable toggles), so scroll survives the edit toggle. -->
@@ -509,11 +510,30 @@ function handleToggleViewRequest() {
 
 // File navigation / closing all leave the current edit view, so they go through
 // the same dirty-save confirmation as the back gesture and toggle-view.
-function handleNavBack() {
-    const el = scrollRestore.currentScrollEl()
-    if (el && typeof el.scrollTop === 'number') {
-        emit('captureScroll', el.scrollTop)
+// Snapshot where the user is in the current file.
+//
+// Rendered markdown owns the authoritative capture: it holds the live
+// .markdown-body element and refreshes the module-level cache itself. Delegate
+// to it so the two paths cannot drift — it also emits 'captureScroll' up the
+// chain, so the caller must not emit again.
+function captureScroll() {
+    if (!editing.value && isMarkdown.value && props.markdownViewMode === 'rendered') {
+        const entry = mdPreviewRef.value?.captureCurrentScrollState?.()
+        if (entry) return entry
     }
+    const el = scrollRestore.currentScrollEl()
+    // captureScroll only comes back empty when there is no live pane at all,
+    // so there is no pixel-only fallback to emit here.
+    const saved = scrollRestore.captureScroll(el)
+    if (saved) {
+        emit('captureScroll', saved)
+        return saved
+    }
+    return null
+}
+
+function handleNavBack() {
+    captureScroll()
     return guardExitEdit(() => emit('navigateBack'))
 }
 function handleNavForward() {
@@ -705,6 +725,7 @@ defineExpose({
     pdfOutline,
     pdfScrollToPage,
     focusSearchInput,
+    captureScroll,
 })
 </script>
 

--- a/web/src/components/file/MarkdownPreview.vue
+++ b/web/src/components/file/MarkdownPreview.vue
@@ -1,7 +1,7 @@
 <template>
   <div class="markdown-preview">
     <!-- Rendered markdown -->
-    <div v-if="viewMode === 'rendered'" class="markdown-body" ref="bodyRef" :data-file-path="file?.path || ''" @click="handleClick" @mousedown="onTableMouseDown" @touchstart="onTableTouchStart">
+    <div v-if="viewMode === 'rendered'" class="markdown-body" ref="bodyRef" :data-file-path="file?.path || ''" @click="handleClick" @mousedown="onTableMouseDown" @touchstart="onTableTouchStart" @load.capture="onImageLoad">
       <div class="markdown-content" v-html="renderedHtml" />
       <!-- Diff markers: declarative v-for, positioned absolutely inside .markdown-body -->
       <button
@@ -62,6 +62,8 @@ import {
 } from '@/composables/useMarkdownDiff.ts'
 import { handleDiffMarkerClick } from '@/composables/useDiffMarkerClick.ts'
 import { useCodeLinkPreview, handleVerifiedFilePathClick } from '@/composables/useCodeLinkPreview.ts'
+import { captureMarkdownScroll } from '@/composables/useFileScrollRestore.ts'
+import { setFileScroll, type FileScrollEntry } from '@/utils/fileScrollCache.ts'
 import CodeLinkPreview from '@/components/file/CodeLinkPreview.vue'
 import '@/assets/diff-marker.css'
 
@@ -72,7 +74,7 @@ const props = defineProps<{
     wordWrap?: boolean
     showLineNumbers?: boolean
 }>()
-const emit = defineEmits(['closeSearch'])
+const emit = defineEmits(['closeSearch', 'captureScroll'])
 
 const renderedHtml = ref('')
 const bodyRef = ref<HTMLElement | null>(null)
@@ -129,9 +131,30 @@ const { handleDblClick } = useDoubleClickCopy({
     },
 })
 
+function captureCurrentScrollState(): FileScrollEntry | null {
+    const el = bodyRef.value
+    if (!el || !props.file?.path) return null
+    const entry = captureMarkdownScroll(el, props.file.content || '')
+    if (entry) {
+        setFileScroll(props.file.path, entry)
+        emit('captureScroll', entry)
+    }
+    return entry
+}
+
+function onImageLoad() {
+    window.dispatchEvent(new CustomEvent('realign-file-scroll'))
+}
+
 const { verifyFilePaths, resolveRelativePath, openFilePath, parseFileUri } = useFilePathAnnotation()
 const { isPC } = usePlatformDetect()
-const codeLinkPreview = useCodeLinkPreview({ containerRef: bodyRef, source: 'file' })
+const codeLinkPreview = useCodeLinkPreview({
+    containerRef: bodyRef,
+    source: 'file',
+    onBeforeOpen: () => {
+        captureCurrentScrollState()
+    },
+})
 
 function handleClick(event: MouseEvent) {
     // Code block header buttons (copy/wrap)
@@ -162,6 +185,7 @@ function handleClick(event: MouseEvent) {
         event.stopPropagation()
         const sha = commitEl.getAttribute('data-commit-sha')
         if (sha) {
+            captureCurrentScrollState()
             window.dispatchEvent(new CustomEvent('navigate-to-commit', { detail: { sha } }))
         }
         return
@@ -177,6 +201,7 @@ function handleClick(event: MouseEvent) {
         const lineStart = linkOrBtn.getAttribute('data-line-start')
         const lineEnd = linkOrBtn.getAttribute('data-line-end')
         if (filePath) {
+            captureCurrentScrollState()
             codeLinkPreview.close()
             openFilePath(filePath, lineStart ? parseInt(lineStart, 10) : undefined, lineEnd ? parseInt(lineEnd, 10) : undefined, 'file')
         }
@@ -207,6 +232,7 @@ function handleClick(event: MouseEvent) {
         // directly; otherwise resolve the relative href against the md's dir.
         const resolvedPath = annotatedPath
             || (href.startsWith('file://') ? parseFileUri(href).path : resolveRelativePath(href, currentDir))
+        captureCurrentScrollState()
         codeLinkPreview.close()
         openFilePath(resolvedPath, lineStart, lineEnd, 'file')
     })
@@ -295,6 +321,7 @@ async function doRender(f: { content: string; path?: string; error?: boolean }) 
     if (renderId === currentRenderId) {
         lastBlockList.value = extractBlocks(el.querySelector('.markdown-content') || el)
         computeMarkerPositions()
+        window.dispatchEvent(new CustomEvent('realign-file-scroll'))
     }
 }
 
@@ -322,6 +349,7 @@ watch(() => props.viewMode, async (mode) => {
     if (!el) return
     const mermaidTarget = el.querySelector('.markdown-content') as HTMLElement || el
     await renderMermaidInElement(mermaidTarget, 'md-preview')
+    window.dispatchEvent(new CustomEvent('realign-file-scroll'))
 })
 
 // Watch for marker changes and recompute positions
@@ -357,6 +385,7 @@ defineExpose({
     lastBlockList,
     bodyRef,
     focusSearchInput,
+    captureCurrentScrollState,
 })
 </script>
 

--- a/web/src/components/file/__tests__/FileViewer.test.ts
+++ b/web/src/components/file/__tests__/FileViewer.test.ts
@@ -517,6 +517,94 @@ describe('FileViewer', () => {
     })
   })
 
+  describe('captureScroll', () => {
+    const mdFile = {
+      name: 'readme.md',
+      path: '/tmp/readme.md',
+      content: '# Title\n\nsome text',
+      isMarkdown: true,
+      isHtml: false,
+      isImage: false,
+      isAudio: false,
+      isVideo: false,
+      isPdf: false,
+      isOffice: false,
+      isBinary: false,
+      tooLarge: false,
+    }
+
+    const mockCaptureCurrentScrollState = vi.fn(() => ({
+      scrollTop: 777,
+      anchor: null,
+      blockAnchor: null,
+      ratio: null,
+    }))
+
+    // MarkdownPreview owns the authoritative capture for rendered markdown —
+    // it holds the live .markdown-body and refreshes the cache itself.
+    const markdownPreviewStub = {
+      name: 'MarkdownPreview',
+      props: ['file', 'viewMode', 'searchOpen', 'wordWrap', 'showLineNumbers'],
+      emits: ['delete', 'showDetails', 'openGitHistory', 'closeSearch', 'captureScroll'],
+      template: '<div class="md-stub" />',
+      methods: {
+        captureCurrentScrollState: (...args: unknown[]) => mockCaptureCurrentScrollState(...args),
+        focusSearchInput: () => {},
+      },
+    }
+
+    // Renders a .cm-scroller so the generic capture path can resolve a
+    // container in raw mode.
+    const codeMirrorStubWithScroller = {
+      name: 'CodeMirrorViewer',
+      template: '<div class="cm-stub"><div class="cm-scroller" /></div>',
+      methods: {
+        handleExit: (...args: unknown[]) => mockHandleExit(...args),
+        openSearch: (...args: unknown[]) => mockOpenSearch(...args),
+      },
+    }
+
+    function mountMdViewer(props = {}) {
+      return mount(FileViewer, {
+        props: {
+          file: mdFile,
+          tocOpen: false,
+          searchOpen: false,
+          markdownViewMode: 'rendered',
+          externalLoading: false,
+          ...props,
+        },
+        global: {
+          plugins: [i18n],
+          stubs: { ...stubs, MarkdownPreview: markdownPreviewStub, CodeMirrorViewer: codeMirrorStubWithScroller },
+        },
+      })
+    }
+
+    it('delegates to MarkdownPreview for rendered markdown instead of capturing twice', () => {
+      mockCaptureCurrentScrollState.mockClear()
+      const wrapper = mountMdViewer()
+
+      const entry = (wrapper.vm as any).captureScroll()
+
+      expect(mockCaptureCurrentScrollState).toHaveBeenCalledTimes(1)
+      expect(entry).toEqual({ scrollTop: 777, anchor: null, blockAnchor: null, ratio: null })
+      // MarkdownPreview emits on its own; FileViewer must not emit again or the
+      // capture would be banked twice.
+      expect(wrapper.emitted('captureScroll')).toBeUndefined()
+    })
+
+    it('falls back to the generic capture when the preview is not mounted', () => {
+      mockCaptureCurrentScrollState.mockClear()
+      const wrapper = mountMdViewer({ markdownViewMode: 'raw' })
+
+      ;(wrapper.vm as any).captureScroll()
+
+      expect(mockCaptureCurrentScrollState).not.toHaveBeenCalled()
+      expect(wrapper.emitted('captureScroll')).toBeTruthy()
+    })
+  })
+
   describe('preview request while editing markdown', () => {
     const mdFile = {
       name: 'readme.md',

--- a/web/src/composables/__tests__/useFileBackTarget.test.ts
+++ b/web/src/composables/__tests__/useFileBackTarget.test.ts
@@ -109,6 +109,9 @@ it('wide screen jump: opening code file with source=file retains Markdown on sta
 
   // 1. User opens README.md from browse
   files.openFile('README.md', { viewMode: 'rendered' })
+  // The real store selects the file too; handleCaptureFileScroll only trusts a
+  // capture whose path matches the active file, so the fixture has to mirror it.
+  fakeStore.state.currentFile = { name: 'README.md', path: 'README.md' }
   expect(coord.fileBackTarget.value).toBe('browse')
   expect(files.canGoBack.value).toBe(false)
 
@@ -121,7 +124,14 @@ it('wide screen jump: opening code file with source=file retains Markdown on sta
 
   // 3. First back -> returns to README.md, restores scrollTop and viewMode
   expect(await coord.navigateBack('header')).toBe(true)
-  expect(files.currentLocation.value).toEqual({ path: 'README.md', scrollTop: 450, viewMode: 'rendered' })
+  // The visit banks the whole snapshot next to the pixel offset, so a rendered
+  // return can also restore its anchor once the layout settles.
+  expect(files.currentLocation.value).toEqual({
+    path: 'README.md',
+    scrollTop: 450,
+    viewMode: 'rendered',
+    scrollEntry: { scrollTop: 450 },
+  })
   expect(markdownViewMode.value).toBe('rendered')
   expect(coord.fileBackTarget.value).toBe('browse')
 

--- a/web/src/composables/__tests__/useFileScrollRestore.test.ts
+++ b/web/src/composables/__tests__/useFileScrollRestore.test.ts
@@ -1,10 +1,14 @@
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
-import { getFileScroll, setFileScroll, _resetFileScrollCache } from '@/utils/fileScrollCache'
+import { getFileScroll, getFileScrollEntry, setFileScroll, _resetFileScrollCache } from '@/utils/fileScrollCache'
+import { extractToc } from '@/utils/toc'
 import {
     useFileScrollRestore,
     isScrollable,
     isVisiblyAttached,
     pxCanApply,
+    getElementContentTop,
+    captureBlockAnchor,
+    restoreBlockAnchor,
     type FileScrollContext,
     type ScrollContainerLike,
 } from '@/composables/useFileScrollRestore'
@@ -79,6 +83,63 @@ describe('useFileScrollRestore', () => {
             expect(pxCanApply(el, 50)).toBe(true)
             expect(pxCanApply(el, 49)).toBe(true)
             expect(pxCanApply(el, 51)).toBe(false)
+        })
+    })
+
+    describe('getElementContentTop', () => {
+        it('walks the offsetTop chain up to the container', () => {
+            const container: any = { scrollTop: 0 }
+            const wrapper: any = { offsetTop: 40, offsetParent: container }
+            const child: any = { offsetTop: 60, offsetParent: wrapper }
+            expect(getElementContentTop(child, container)).toBe(100)
+        })
+
+        it('falls back to rect math and adds the scroll offset back', () => {
+            const container: any = {
+                scrollTop: 300,
+                getBoundingClientRect: () => ({ top: 10 }),
+            }
+            // 570px below the container's top edge in the scrolled viewport.
+            const below: any = { offsetTop: undefined, offsetParent: null, getBoundingClientRect: () => ({ top: 580 }) }
+            expect(getElementContentTop(below, container)).toBe(870)
+            // Scrolled past: above the container's top edge (diff = -70).
+            const above: any = { offsetTop: undefined, offsetParent: null, getBoundingClientRect: () => ({ top: -60 }) }
+            expect(getElementContentTop(above, container)).toBe(230)
+        })
+    })
+
+    describe('blockAnchor capture & restore', () => {
+        it('captures the topmost visible block and survives a layout shift', () => {
+            const el = makeEl({ scrollHeight: 3000, clientHeight: 500, scrollTop: 1200 })
+            const blocks = [100, 800, 1500, 2200].map((top) => ({ offsetTop: top, offsetParent: el, tagName: 'P' }))
+            el.children = blocks
+
+            const anchor = captureBlockAnchor(el)
+            // 800 is the last block at or above scrollTop (+4px tolerance).
+            expect(anchor?.index).toBe(1)
+            expect(anchor?.relTop).toBe(-400)
+            expect(anchor?.selector).toBe(':scope > :nth-child(2)')
+
+            // An image above finished loading and pushed the block down.
+            blocks[1].offsetTop = 1600
+            expect(restoreBlockAnchor(el, anchor!)).toBe(true)
+            expect(el.scrollTop).toBe(2000) // 1600 - (-400)
+        })
+
+        it('captures by id when the block has one', () => {
+            const el = makeEl({ scrollHeight: 2000, clientHeight: 500, scrollTop: 600 })
+            const blocks = [
+                { offsetTop: 0, offsetParent: el, tagName: 'H1', id: 'intro' },
+                { offsetTop: 900, offsetParent: el, tagName: 'P' },
+            ]
+            el.children = blocks
+
+            expect(captureBlockAnchor(el)?.selector).toBe('#intro')
+        })
+
+        it('returns null without children', () => {
+            const el = makeEl({ scrollHeight: 2000, clientHeight: 500 })
+            expect(captureBlockAnchor(el)).toBeNull()
         })
     })
 
@@ -260,8 +321,9 @@ describe('useFileScrollRestore', () => {
     describe('captureScroll markdown anchor branches', () => {
         it('captures a preview heading anchor from the markdown-body pane', () => {
             // Heading sits at content top 40, viewport scrolled past it (top 50):
-            // pickPreviewAnchor returns the heading as the anchor.
-            const headingEl = { id: 'intro', getBoundingClientRect: () => ({ top: 40 } as DOMRect) }
+            // its rect is 10px above the container's top edge, so the rect
+            // fallback must add the scroll offset back (−10 + 50 = 40).
+            const headingEl = { id: 'intro', getBoundingClientRect: () => ({ top: -10 } as DOMRect) }
             const el = makeEl({
                 scrollHeight: 300,
                 clientHeight: 50,
@@ -381,6 +443,399 @@ describe('useFileScrollRestore', () => {
             s.dispose()
 
             expect(getFileScroll('a.go')).toBe(700)
+        })
+    })
+
+    describe('cached anchor freshness', () => {
+        /**
+         * Headings at 1000/2000/3000px inside a 5000px-tall document.
+         * `offsetParent` points at the container so getElementContentTop() can
+         * walk up to it the way real DOM does.
+         */
+        function makeMarkdownEl(toc: { id: string; line: number }[]) {
+            const el = makeEl({ scrollHeight: 5000, clientHeight: 500, scrollTop: 0, _classes: ['markdown-body'] })
+            const headings = toc.map((item, i) => ({
+                id: item.id,
+                offsetTop: (i + 1) * 1000,
+                offsetParent: el as Element,
+            }))
+            el.querySelectorAll = () => headings as any
+            return el
+        }
+
+        it('recomputes the cached anchor after a scroll, instead of leaving the old heading', () => {
+            const md = '# One\n\nbody\n\n## Two\n\nbody\n\n## Three\n\nbody\n'
+            const toc = extractToc(md, 'markdown')
+            expect(toc.length).toBe(3)
+
+            const el = makeMarkdownEl(toc)
+            const ctx = makeContext({
+                contentRoot: () => el,
+                isMarkdown: () => true,
+                file: () => ({ path: 'a.md', content: md }),
+            })
+            const s = useFileScrollRestore(ctx)
+            s.start()
+
+            // A previous visit banked an anchor at the very first heading.
+            setFileScroll('a.md', { scrollTop: 0, anchor: { id: toc[0].id, line: toc[0].line, relTop: 0 } })
+            s.onFileChanged({ path: 'a.md' }, true)
+            vi.advanceTimersByTime(50) // attach the scroll listener
+
+            // User scrolls to the middle of section two.
+            el.scrollTop = 2500
+            el.fire('scroll')
+            expect(getFileScroll('a.md')).toBe(2500)
+            // Pixels land immediately; the anchor is still the stale heading.
+            expect(getFileScrollEntry('a.md')?.anchor?.id).toBe(toc[0].id)
+
+            vi.advanceTimersByTime(150) // debounce settles
+            const entry = getFileScrollEntry('a.md')
+            expect(entry?.anchor?.id).toBe(toc[1].id)
+            expect(entry?.anchor?.relTop).toBe(-500)
+            s.dispose()
+        })
+
+        it('drops a pending anchor refresh when the file is switched away', () => {
+            const md = '# One\n\nbody\n\n## Two\n'
+            const toc = extractToc(md, 'markdown')
+            const el = makeMarkdownEl(toc)
+            const ctx = makeContext({
+                contentRoot: () => el,
+                isMarkdown: () => true,
+                file: () => ({ path: 'a.md', content: md }),
+            })
+            const s = useFileScrollRestore(ctx)
+            s.start()
+            s.onFileChanged({ path: 'a.md' }, true)
+            vi.advanceTimersByTime(50)
+
+            el.scrollTop = 1500
+            el.fire('scroll')
+            setFileScroll('b.md', 0)
+            s.onFileWillChange()
+            s.onFileChanged({ path: 'b.md' }, true)
+
+            // The debounce must not resurrect a.md's position onto b.md.
+            vi.advanceTimersByTime(200)
+            expect(getFileScroll('b.md')).toBe(0)
+            s.dispose()
+        })
+    })
+
+    describe('preferPx restore', () => {
+        it('applies the pixel offset even when the entry carries an anchor', () => {
+            const el = makeEl({ scrollHeight: 2000, clientHeight: 500, scrollTop: 0, _classes: ['markdown-body'] })
+            const ctx = makeContext({
+                contentRoot: () => el,
+                isMarkdown: () => true,
+                file: () => ({ path: 'a.md', content: '# One\n' }),
+            })
+            const s = useFileScrollRestore(ctx)
+            s.start()
+            s.onFileChanged({ path: 'a.md' }, true)
+            vi.advanceTimersByTime(50)
+
+            window.dispatchEvent(new CustomEvent('restore-file-scroll', {
+                detail: {
+                    scrollTop: 1200,
+                    scrollEntry: { scrollTop: 1200, anchor: { id: 'stale', line: 1, relTop: 0 } },
+                    preferPx: true,
+                },
+            }))
+
+            expect(el.scrollTop).toBe(1200)
+            s.dispose()
+        })
+
+        it('defers to the anchor when the content cannot hold the offset yet', () => {
+            const el = makeEl({ scrollHeight: 600, clientHeight: 500, scrollTop: 0, _classes: ['markdown-body'] })
+            const ctx = makeContext({
+                contentRoot: () => el,
+                isMarkdown: () => true,
+                file: () => ({ path: 'a.md', content: '# One\n' }),
+            })
+            const s = useFileScrollRestore(ctx)
+            s.start()
+            s.onFileChanged({ path: 'a.md' }, true)
+            vi.advanceTimersByTime(50)
+
+            // 1200 is beyond maxScroll (100) → must not clamp to 100.
+            window.dispatchEvent(new CustomEvent('restore-file-scroll', {
+                detail: { scrollTop: 1200, preferPx: true },
+            }))
+            expect(el.scrollTop).toBe(0)
+
+            el.scrollHeight = 2000
+            vi.advanceTimersByTime(50)
+            expect(el.scrollTop).toBe(1200)
+            s.dispose()
+        })
+
+        it('without preferPx the anchor still wins (rendered ↔ raw alignment)', () => {
+            const el = makeEl({
+                scrollHeight: 2000,
+                clientHeight: 500,
+                scrollTop: 0,
+                _classes: ['markdown-body'],
+            })
+            // A heading the anchor can actually resolve to, at content-top 1000.
+            const target: any = { id: 'sec-two', offsetTop: 1000, offsetParent: el }
+            el.querySelector = (sel: string) =>
+                sel === '#sec-two' ? target : (sel === '.markdown-body' || sel === '.cm-scroller' ? el : null)
+            const ctx = makeContext({
+                contentRoot: () => el,
+                isMarkdown: () => true,
+                file: () => ({ path: 'a.md', content: '# One\n' }),
+            })
+            const s = useFileScrollRestore(ctx)
+            s.start()
+            s.onFileChanged({ path: 'a.md' }, true)
+            vi.advanceTimersByTime(50)
+
+            window.dispatchEvent(new CustomEvent('restore-file-scroll', {
+                detail: {
+                    scrollTop: 1200,
+                    scrollEntry: { scrollTop: 1200, anchor: { id: 'sec-two', line: 1, relTop: 0 } },
+                },
+            }))
+
+            // Heading alignment (1000), not the pixel offset (1200).
+            expect(el.scrollTop).toBe(1000)
+            s.dispose()
+        })
+    })
+
+    describe('cache entry replacement on scroll', () => {
+        it('replaces the entry object instead of mutating a banked snapshot', () => {
+            const el = makeEl({ scrollHeight: 2000, clientHeight: 500, scrollTop: 0 })
+            const ctx = makeContext({ contentRoot: () => el, file: () => ({ path: 'a.md', content: '' }) })
+            const s = useFileScrollRestore(ctx)
+            const seeded = { scrollTop: 0, anchor: { id: 'x', line: 1, relTop: 0 }, blockAnchor: null, ratio: null }
+            setFileScroll('a.md', seeded)
+            s.onFileChanged({ path: 'a.md' }, true)
+            vi.advanceTimersByTime(50) // listener attached
+
+            el.scrollTop = 300
+            el.fire('scroll')
+
+            const after = getFileScrollEntry('a.md')
+            // New object — a snapshot banked elsewhere must not move with it.
+            expect(after).not.toBe(seeded)
+            expect(getFileScroll('a.md')).toBe(300)
+            expect(after?.anchor).toEqual(seeded.anchor)
+            s.dispose()
+        })
+    })
+
+    describe('realign stabilizer', () => {
+        function makeAnchorEl() {
+            const el = makeEl({ scrollHeight: 3000, clientHeight: 500, scrollTop: 0, _classes: ['markdown-body'] })
+            const heading: any = { id: 'sec-two', offsetTop: 1000, offsetParent: el }
+            el.querySelectorAll = () => [heading]
+            el.querySelector = (sel: string) =>
+                sel === '#sec-two' ? heading : (sel === '.markdown-body' || sel === '.cm-scroller' ? el : null)
+            return { el, heading }
+        }
+
+        function setup(ctx: any) {
+            const s = useFileScrollRestore(ctx)
+            s.start()
+            setFileScroll('a.md', { scrollTop: 960, anchor: { id: 'sec-two', line: 3, relTop: -40 }, blockAnchor: null, ratio: null })
+            s.onFileChanged({ path: 'a.md' }, true)
+            vi.advanceTimersByTime(50)
+            return s
+        }
+
+        it('re-aligns to the anchor after a layout shift while armed', () => {
+            const { el, heading } = makeAnchorEl()
+            const ctx = makeContext({
+                contentRoot: () => el,
+                isMarkdown: () => true,
+                file: () => ({ path: 'a.md', content: '# One\n\n## Two\n' }),
+            })
+            const s = setup(ctx)
+
+            // Heading aligned: contentTop 1000, relTop -40 → scrollTop 1040.
+            expect(el.scrollTop).toBe(1040)
+
+            // A real browser fires a scroll event for that programmatic restore —
+            // an echo carrying the armed offset; it must NOT disarm.
+            el.fire('scroll')
+
+            heading.offsetTop = 1400 // an image above finished loading
+            window.dispatchEvent(new CustomEvent('realign-file-scroll'))
+            expect(el.scrollTop).toBe(1440)
+
+            // The correction's own echo must not be read as user scrolling.
+            el.fire('scroll')
+
+            // Re-armed: a second shift within the window realigns again.
+            heading.offsetTop = 1800
+            window.dispatchEvent(new CustomEvent('realign-file-scroll'))
+            expect(el.scrollTop).toBe(1840)
+            s.dispose()
+        })
+
+        it('a user scroll away from the armed offset disarms the stabilizer', () => {
+            const { el, heading } = makeAnchorEl()
+            const ctx = makeContext({
+                contentRoot: () => el,
+                isMarkdown: () => true,
+                file: () => ({ path: 'a.md', content: '# One\n\n## Two\n' }),
+            })
+            const s = setup(ctx)
+            expect(el.scrollTop).toBe(1040)
+
+            el.scrollTop = 1600 // user scrolls on
+            el.fire('scroll')
+
+            heading.offsetTop = 1400
+            window.dispatchEvent(new CustomEvent('realign-file-scroll'))
+            // Disarmed — the realign must not fight the user's scroll.
+            expect(el.scrollTop).toBe(1600)
+            s.dispose()
+        })
+
+        it('stays armed long enough for a very late load', () => {
+            // No time limit: an image that finishes 30s after the restore must
+            // still be corrected.
+            const { el, heading } = makeAnchorEl()
+            const ctx = makeContext({
+                contentRoot: () => el,
+                isMarkdown: () => true,
+                file: () => ({ path: 'a.md', content: '# One\n\n## Two\n' }),
+            })
+            const s = setup(ctx)
+            expect(el.scrollTop).toBe(1040)
+
+            vi.advanceTimersByTime(30000)
+            heading.offsetTop = 1400
+            window.dispatchEvent(new CustomEvent('realign-file-scroll'))
+            expect(el.scrollTop).toBe(1440)
+            s.dispose()
+        })
+
+        it('disarms when an explicit jump takes over positioning', () => {
+            const { el, heading } = makeAnchorEl()
+            const ctx = makeContext({
+                contentRoot: () => el,
+                isMarkdown: () => true,
+                file: () => ({ path: 'a.md', content: '# One\n\n## Two\n' }),
+            })
+            const s = setup(ctx)
+            expect(el.scrollTop).toBe(1040)
+
+            // Every explicit jump (scroll-to-line, TOC, code link) cancels the
+            // pending restore — the realign must not fight it afterwards.
+            window.dispatchEvent(new CustomEvent('cancel-scroll-restore'))
+            heading.offsetTop = 1400
+            window.dispatchEvent(new CustomEvent('realign-file-scroll'))
+            expect(el.scrollTop).toBe(1040)
+            s.dispose()
+        })
+
+        it('arms stabilizer on preferPx restore when anchor is present', () => {
+            const { el, heading } = makeAnchorEl()
+            const ctx = makeContext({
+                contentRoot: () => el,
+                isMarkdown: () => true,
+                file: () => ({ path: 'a.md', content: '# One\n\n## Two\n' }),
+            })
+            const s = useFileScrollRestore(ctx)
+            s.start()
+            s.onFileChanged({ path: 'a.md' }, true)
+            vi.advanceTimersByTime(50)
+
+            window.dispatchEvent(new CustomEvent('restore-file-scroll', {
+                detail: {
+                    scrollTop: 1040,
+                    scrollEntry: { scrollTop: 1040, anchor: { id: 'sec-two', line: 3, relTop: -40 } },
+                    preferPx: true,
+                },
+            }))
+
+            expect(el.scrollTop).toBe(1040)
+            // Programmatic scroll echo does not disarm
+            el.fire('scroll')
+
+            heading.offsetTop = 1500 // late image loaded
+            window.dispatchEvent(new CustomEvent('realign-file-scroll'))
+            expect(el.scrollTop).toBe(1540)
+            s.dispose()
+        })
+
+        it('realigns for each successive late load', () => {
+            // Image after image: every late load gets its own correction, with
+            // no window to expire. Each correction moves scrollTop, so a real
+            // browser hands it back as a scroll echo — that echo must be
+            // tolerated, otherwise the first late load would be the last one
+            // ever corrected.
+            const { el, heading } = makeAnchorEl()
+            const ctx = makeContext({
+                contentRoot: () => el,
+                isMarkdown: () => true,
+                file: () => ({ path: 'a.md', content: '# One\n\n## Two\n' }),
+            })
+            const s = setup(ctx)
+            expect(el.scrollTop).toBe(1040)
+
+            vi.advanceTimersByTime(2000)
+            heading.offsetTop = 1400
+            window.dispatchEvent(new CustomEvent('realign-file-scroll'))
+            expect(el.scrollTop).toBe(1440)
+            el.fire('scroll') // echo of the correction itself
+
+            vi.advanceTimersByTime(2000)
+            heading.offsetTop = 1800
+            window.dispatchEvent(new CustomEvent('realign-file-scroll'))
+            expect(el.scrollTop).toBe(1840)
+            el.fire('scroll')
+
+            // Still armed after two echoes: a third load is corrected too.
+            vi.advanceTimersByTime(2000)
+            heading.offsetTop = 2200
+            window.dispatchEvent(new CustomEvent('realign-file-scroll'))
+            expect(el.scrollTop).toBe(2240)
+            s.dispose()
+        })
+
+        it('arms the stabilizer when a polled pixel restore lands late', () => {
+            // The content is still growing, so the pixel offset cannot be
+            // applied on the first tick and lands through the poll instead.
+            // That is exactly when images are still coming, so the anchor must
+            // be armed to pull the position back afterwards.
+            const { el, heading } = makeAnchorEl()
+            el.scrollHeight = 600 // max scroll = 100, target 1000 does not fit
+            const ctx = makeContext({
+                contentRoot: () => el,
+                isMarkdown: () => true,
+                file: () => ({ path: 'a.md', content: '# One\n\n## Two\n' }),
+            })
+            const s = useFileScrollRestore(ctx)
+            s.start()
+            s.onFileChanged({ path: 'a.md' }, true)
+            vi.advanceTimersByTime(50)
+
+            window.dispatchEvent(new CustomEvent('restore-file-scroll', {
+                detail: {
+                    scrollTop: 1000,
+                    scrollEntry: { scrollTop: 1000, anchor: { id: 'sec-two', line: 3, relTop: -40 } },
+                    preferPx: true,
+                },
+            }))
+            expect(el.scrollTop).toBe(0) // deferred, content too short
+
+            el.scrollHeight = 3000
+            vi.advanceTimersByTime(50)
+            expect(el.scrollTop).toBe(1000)
+
+            // Echo of the programmatic scroll must not disarm.
+            el.fire('scroll')
+            heading.offsetTop = 1400 // an image above finished loading
+            window.dispatchEvent(new CustomEvent('realign-file-scroll'))
+            expect(el.scrollTop).toBe(1440)
+            s.dispose()
         })
     })
 

--- a/web/src/composables/__tests__/useNavigationCoordinator.test.ts
+++ b/web/src/composables/__tests__/useNavigationCoordinator.test.ts
@@ -5,6 +5,7 @@ import { useFileNavStack, _resetForTesting as resetFileNavStack } from '../useFi
 import { useDirectoryReturn, _resetForTesting as resetDirectoryReturn } from '../useDirectoryReturn'
 import { useNavigationCoordinator } from '../useNavigationCoordinator'
 import { PANE_LEFT, PANE_RIGHT, type ActivePane } from '../useWideScreenLayout'
+import { setFileScroll } from '@/utils/fileScrollCache'
 
 describe('useNavigationCoordinator', () => {
   const navigation = useNavigationContext()
@@ -34,6 +35,7 @@ describe('useNavigationCoordinator', () => {
     closeOverlayAndSync: vi.fn(),
     handleOpenFileManager: vi.fn(),
     isFileManagerMultiSelectActive: vi.fn().mockReturnValue(false),
+    requestScrollCapture: vi.fn(),
   }
 
   const mockBackHooks = {
@@ -238,6 +240,27 @@ describe('useNavigationCoordinator', () => {
       expect(handled).toBe(true)
       expect(mockToast.show).toHaveBeenCalled()
       expect(navigation.hasOrigin.value).toBe(false)
+    })
+
+    it('keeps the origin line when the banked position is 0', async () => {
+      // Opened from a line link, jumped away before scroll-to-line landed.
+      navigation.start({
+        surface: 'file',
+        tab: 'view',
+        label: 'Back to A.md',
+        filePath: 'src/A.md',
+        lineStart: 42,
+        viewMode: 'raw',
+        scrollTop: 0,
+      })
+      const coord = createCoordinator()
+      const spy = vi.spyOn(window, 'dispatchEvent')
+      await coord.returnToOrigin()
+      const dispatched = spy.mock.calls.some(([e]) => (e as CustomEvent).type === 'restore-file-scroll')
+      spy.mockRestore()
+
+      expect(dispatched).toBe(false)
+      expect(mockViewActions.scrollToLine).toHaveBeenCalledWith(42, undefined, 'src/A.md')
     })
   })
 
@@ -595,6 +618,182 @@ describe('useNavigationCoordinator', () => {
       expect(coord.canHandleBack('header')).toBe(true)
       await coord.handleNavigateBack()
       expect(mockBackHooks.handleBackNavigation).toHaveBeenCalled()
+    })
+  })
+
+  describe('scroll capture on jump', () => {
+    it('snapshots the live viewer before pushing a linked file', async () => {
+      fakeStore.state.currentFile = { name: 'A.md', path: 'src/A.md' }
+      activeTab.value = 'view'
+      fileNav.openFile('src/A.md', { viewMode: 'rendered' })
+
+      const coord = createCoordinator()
+      await coord.handleOpenFileOverlay({ path: 'src/B.md', source: 'file' })
+
+      expect(mockViewActions.requestScrollCapture).toHaveBeenCalled()
+      expect(fileNav.previousLocation.value?.path).toBe('src/A.md')
+    })
+
+    it('banks the position the live capture reported, not a stale cache read', async () => {
+      fakeStore.state.currentFile = { name: 'A.md', path: 'src/A.md' }
+      activeTab.value = 'view'
+      // Cache holds an old offset from an earlier moment in the file.
+      fileNav.openFile('src/A.md', { viewMode: 'rendered', scrollTop: 40 })
+      setFileScroll('src/A.md', 40)
+
+      const coord = createCoordinator()
+      // Mirrors the real wiring: FileViewer captures the live pane, FileOverlay
+      // re-emits it, App forwards it back into the coordinator.
+      mockViewActions.requestScrollCapture.mockImplementation(() => {
+        coord.handleCaptureFileScroll({
+          scrollTop: 2400,
+          anchor: { id: 'sec-two', line: 12, relTop: -30 },
+          blockAnchor: null,
+          ratio: null,
+        })
+      })
+
+      await coord.handleOpenFileOverlay({ path: 'src/B.md', source: 'file' })
+
+      expect(fileNav.previousLocation.value?.scrollTop).toBe(2400)
+      expect(fileNav.previousLocation.value?.scrollEntry?.scrollTop).toBe(2400)
+      expect(fileNav.previousLocation.value?.scrollEntry?.anchor).toEqual({ id: 'sec-two', line: 12, relTop: -30 })
+    })
+  })
+
+  describe('return restore strategy', () => {
+    function restoreDetailFrom(spy: ReturnType<typeof vi.spyOn>) {
+      const call = spy.mock.calls.find(([e]) => (e as CustomEvent).type === 'restore-file-scroll')
+      return (call?.[0] as CustomEvent | undefined)?.detail
+    }
+
+    it('leads with the pixel offset when the view mode is unchanged', async () => {
+      fakeStore.state.currentFile = { name: 'B.md', path: 'src/B.md' }
+      activeTab.value = 'view'
+      fileNav.openFile('src/A.md', { viewMode: 'rendered', scrollTop: 1200 })
+      fileNav.openFile('src/B.md', { viewMode: 'rendered' })
+      markdownViewMode.value = 'rendered'
+
+      const coord = createCoordinator()
+      const spy = vi.spyOn(window, 'dispatchEvent')
+      const ok = await coord.goBackFile()
+      const detail = restoreDetailFrom(spy)
+      spy.mockRestore()
+
+      expect(ok).toBe(true)
+      expect(detail).toEqual(expect.objectContaining({ scrollTop: 1200, preferPx: true }))
+    })
+
+    it('leads with the pixel offset when returning from a raw file back to a rendered file', async () => {
+      fakeStore.state.currentFile = { name: 'B.md', path: 'src/B.md' }
+      activeTab.value = 'view'
+      fileNav.openFile('src/A.md', { viewMode: 'rendered', scrollTop: 1200 })
+      fileNav.openFile('src/B.md', { viewMode: 'raw' })
+      markdownViewMode.value = 'raw'
+
+      const coord = createCoordinator()
+      const spy = vi.spyOn(window, 'dispatchEvent')
+      await coord.goBackFile()
+      const detail = restoreDetailFrom(spy)
+      spy.mockRestore()
+
+      // A is restored in rendered mode, so pixels match and preferPx is true.
+      expect(markdownViewMode.value).toBe('rendered')
+      expect(detail).toEqual(expect.objectContaining({ scrollTop: 1200, preferPx: true }))
+    })
+
+    it('sets markdownViewMode before store.selectFile on return so no spurious mode switch occurs', async () => {
+      fakeStore.state.currentFile = { name: 'target.go', path: 'src/target.go' }
+      activeTab.value = 'view'
+      fileNav.openFile('README.md', { viewMode: 'rendered', scrollTop: 1800 })
+      fileNav.openFile('src/target.go', { lineStart: 50, lineEnd: 60, viewMode: 'raw' })
+      markdownViewMode.value = 'raw'
+
+      let viewModeDuringSelectFile: string | undefined
+      fakeStore.selectFile = vi.fn(async () => {
+        viewModeDuringSelectFile = markdownViewMode.value
+        return true
+      })
+
+      const coord = createCoordinator()
+      const spy = vi.spyOn(window, 'dispatchEvent')
+      const ok = await coord.goBackFile()
+      const detail = restoreDetailFrom(spy)
+      spy.mockRestore()
+
+      expect(ok).toBe(true)
+      expect(viewModeDuringSelectFile).toBe('rendered')
+      expect(markdownViewMode.value).toBe('rendered')
+      expect(detail).toEqual(expect.objectContaining({ scrollTop: 1800, preferPx: true }))
+    })
+
+    it('does not request live scroll capture or overwrite currentLocation when pathOverride is not currentFile', async () => {
+      fakeStore.state.currentFile = { name: 'B.go', path: 'src/B.go' }
+      activeTab.value = 'view'
+      fileNav.openFile('src/A.md', { viewMode: 'rendered', scrollTop: 1500 })
+      setFileScroll('src/A.md', 1500)
+
+      mockViewActions.requestScrollCapture.mockClear()
+      const coord = createCoordinator()
+
+      // In openFilePath, store.selectFile('src/B.go') runs before open-file-overlay.
+      // So currentFile is already B.go, but handleOpenFileOverlay is called with prevPath = A.md.
+      await coord.handleOpenFileOverlay({ path: 'src/B.go', source: 'file' })
+
+      // Live capture on B.go DOM must NOT be requested for A.md
+      expect(mockViewActions.requestScrollCapture).not.toHaveBeenCalled()
+      // A.md's saved position must NOT have been corrupted
+      expect(fileNav.previousLocation.value?.scrollTop).toBe(1500)
+    })
+
+    it('restores the reading position instead of the original line for a line-linked visit', async () => {
+      fakeStore.state.currentFile = { name: 'B.md', path: 'src/B.md' }
+      activeTab.value = 'view'
+      // A was opened via a line-numbered link (line 42), then the user read on.
+      fileNav.openFile('src/A.md', { lineStart: 42, viewMode: 'raw', scrollTop: 2400 })
+      fileNav.openFile('src/B.md', { viewMode: 'rendered' })
+      markdownViewMode.value = 'rendered'
+
+      const coord = createCoordinator()
+      const spy = vi.spyOn(window, 'dispatchEvent')
+      await coord.goBackFile()
+      const detail = restoreDetailFrom(spy)
+      spy.mockRestore()
+
+      expect(detail).toEqual(expect.objectContaining({ scrollTop: 2400 }))
+      expect(mockViewActions.scrollToLine).not.toHaveBeenCalled()
+    })
+
+    it('falls back to scrollToLine when no position was ever recorded', async () => {
+      fakeStore.state.currentFile = { name: 'B.md', path: 'src/B.md' }
+      activeTab.value = 'view'
+      fileNav.openFile('src/A.md', { lineStart: 42, viewMode: 'raw' })
+      fileNav.openFile('src/B.md', { viewMode: 'rendered' })
+      markdownViewMode.value = 'rendered'
+
+      const coord = createCoordinator()
+      await coord.goBackFile()
+
+      expect(mockViewActions.scrollToLine).toHaveBeenCalledWith(42, undefined, 'src/A.md')
+    })
+
+    it('treats a recorded 0 as "not captured" and keeps the line', async () => {
+      fakeStore.state.currentFile = { name: 'B.md', path: 'src/B.md' }
+      activeTab.value = 'view'
+      // A was opened via a line link; the async scroll-to-line had not landed
+      // when the user jumped away, so the capture banked 0.
+      fileNav.openFile('src/A.md', { lineStart: 42, viewMode: 'raw', scrollTop: 0 })
+      fileNav.openFile('src/B.md', { viewMode: 'rendered' })
+      markdownViewMode.value = 'rendered'
+
+      const coord = createCoordinator()
+      const spy = vi.spyOn(window, 'dispatchEvent')
+      await coord.goBackFile()
+      const detail = restoreDetailFrom(spy)
+      spy.mockRestore()
+
+      expect(detail).toBeUndefined()
+      expect(mockViewActions.scrollToLine).toHaveBeenCalledWith(42, undefined, 'src/A.md')
     })
   })
 

--- a/web/src/composables/useCodeLinkPreview.ts
+++ b/web/src/composables/useCodeLinkPreview.ts
@@ -59,6 +59,8 @@ export interface UseCodeLinkPreviewOptions {
   /** Surface the preview was opened from — threaded into the full-screen open
    *  so the navigation origin records the right return target. */
   source?: NavigationSurface
+  /** Called synchronously before opening the target file in full view. */
+  onBeforeOpen?: () => void
 }
 
 // Only one preview surface should be visible across chat/file panes. Keep the
@@ -399,6 +401,7 @@ export function useCodeLinkPreview(options: UseCodeLinkPreviewOptions = {}) {
   const openFull = () => {
     if (!target.value) return
     const { filePath, lineStart, lineEnd } = target.value
+    options.onBeforeOpen?.()
     openFilePath(filePath, lineStart, lineEnd, options.source)
     close()
   }

--- a/web/src/composables/useFileNavStack.ts
+++ b/web/src/composables/useFileNavStack.ts
@@ -1,5 +1,6 @@
 import { ref, computed, type Ref, type ComputedRef } from 'vue'
 import { recordRecentFile } from '@/composables/useRecentFiles'
+import type { FileScrollEntry } from '@/utils/fileScrollCache'
 
 const MAX_STACK_DEPTH = 20
 
@@ -13,6 +14,7 @@ export interface FileNavLocation {
   lineEnd?: number
   viewMode?: string
   scrollTop?: number
+  scrollEntry?: FileScrollEntry
 }
 
 const _overlayOpen = ref(false)
@@ -64,11 +66,25 @@ export function useFileNavStack() {
     _historyIndex.value = _history.value.length - 1
   }
 
-  /** Update the current visit's metadata (e.g. markdown view mode) without adding history. */
+  /**
+   * Update the current visit's metadata (e.g. markdown view mode) without adding history.
+   *
+   * Fields explicitly set to `undefined` are ignored. Callers build these from
+   * caches that legitimately hold nothing yet (`scrollEntry` is absent until the
+   * first scroll), and spreading that in would erase a position this visit
+   * already recorded — returning would then land wherever the fallback pointed.
+   * When adding a field to FileNavLocation, add it here too.
+   */
   function updateCurrent(location: Partial<Omit<FileNavLocation, 'path'>>) {
     const current = _currentLocation.value
     if (!current) return
-    _history.value[_historyIndex.value] = { ...current, ...location }
+    const next = { ...current }
+    if (location.lineStart !== undefined) next.lineStart = location.lineStart
+    if (location.lineEnd !== undefined) next.lineEnd = location.lineEnd
+    if (location.viewMode !== undefined) next.viewMode = location.viewMode
+    if (location.scrollTop !== undefined) next.scrollTop = location.scrollTop
+    if (location.scrollEntry !== undefined) next.scrollEntry = location.scrollEntry
+    _history.value[_historyIndex.value] = next
   }
 
   function goBack(): string | null {

--- a/web/src/composables/useFileScrollRestore.ts
+++ b/web/src/composables/useFileScrollRestore.ts
@@ -31,7 +31,16 @@ import {
     relTopFor,
     scrollTopFor,
 } from '@/utils/markdownScroll'
-import { getFileScroll, setFileScroll } from '@/utils/fileScrollCache'
+import {
+    getFileScroll,
+    getFileScrollEntry,
+    setFileScroll,
+    type FileScrollEntry,
+    type ScrollAnchorState,
+    type BlockAnchorState,
+} from '@/utils/fileScrollCache'
+
+export type { ScrollAnchorState, BlockAnchorState, FileScrollEntry } from '@/utils/fileScrollCache'
 
 /** Structural element shape — tests inject plain objects, no real DOM needed. */
 export interface ScrollContainerLike {
@@ -47,15 +56,21 @@ export interface ScrollContainerLike {
     getBoundingClientRect?: () => DOMRect
 }
 
-export interface ScrollAnchorState {
-    id: string
-    line: number
-    relTop: number
-}
-
 export interface SavedScroll {
-    anchor: ScrollAnchorState | null
-    ratio: { ratio: number } | null
+    scrollTop?: number
+    anchor?: ScrollAnchorState | null
+    blockAnchor?: BlockAnchorState | null
+    ratio?: { ratio: number } | null
+    /**
+     * Restore by pixel offset first, treating the anchor as a fallback.
+     *
+     * Anchors exist so a rendered↔raw swap can align two panes of different
+     * heights. Returning to a file in the *same* view mode needs no such
+     * translation — the pixel offset is the exact place — and preferring a
+     * possibly stale anchor there is what made back-navigation jump to an
+     * unrelated heading.
+     */
+    preferPx?: boolean
 }
 
 export interface FileScrollContext {
@@ -90,13 +105,27 @@ export interface UseFileScrollRestore {
     restoreAfterContainerSwitch(saved: SavedScroll | null): void
     /** Cancel a pending pixel restore (scroll-to-line takes precedence). */
     cancelPendingRestore(): void
+    /** Re-align to the active anchor if layout shifted (e.g. after Mermaid or image load). */
+    realignAnchor(): void
 }
 
 const POLL_MS = 50
 const MAX_PX_ATTEMPTS = 100 // 100 * 50ms = 5s
 const MAX_ANCHOR_ATTEMPTS = 60 // 60 * 50ms = 3s
+/**
+ * Delay after the last scroll event before the cached anchor is recomputed.
+ *
+ * Scroll events only carry a pixel offset, so a naive handler leaves the
+ * cached anchor pointing at whatever heading was current when the file was
+ * opened. Since anchors outrank pixels in restoreScroll(), returning to a file
+ * later would snap back to that stale heading instead of where the user
+ * actually stopped reading. Recomputing the whole snapshot once scrolling
+ * settles keeps pixels and anchors describing the same place.
+ */
+const SNAPSHOT_DEBOUNCE_MS = 120
 const CANCEL_EVENT = 'cancel-scroll-restore'
 const RESTORE_EVENT = 'restore-file-scroll'
+const REALIGN_EVENT = 'realign-file-scroll'
 
 /** CSS.escape with a fallback for environments without it (jsdom in tests). */
 function escapeCssIdentifier(id: string): string {
@@ -121,13 +150,204 @@ export function pxCanApply(
     return target <= el.scrollHeight - el.clientHeight
 }
 
+export function getElementContentTop(target: Element, container: HTMLElement): number {
+    let top = 0
+    let curr: HTMLElement | null = target as HTMLElement
+    let reached = false
+    while (curr && curr !== container) {
+        if (typeof curr.offsetTop === 'number') {
+            top += curr.offsetTop
+            reached = true
+        }
+        curr = curr.offsetParent as HTMLElement | null
+        if (curr === container) {
+            reached = true
+            break
+        }
+    }
+    if (reached && curr === container) return top
+
+    const tRect = (target as HTMLElement).getBoundingClientRect?.()
+    const cRect = (container as HTMLElement).getBoundingClientRect?.()
+    if (tRect && cRect) {
+        // The rect diff already excludes the container's scroll offset, so add
+        // it back: contentTop is where the target sits in the unscrolled
+        // content (diff + scrollTop, regardless of the sign of diff).
+        return tRect.top - cRect.top + (container.scrollTop || 0)
+    }
+    return 0
+}
+
+export function captureBlockAnchor(el: HTMLElement): BlockAnchorState | null {
+    const root = (el.querySelector?.('.markdown-content') || el) as HTMLElement
+    if (!root?.children) return null
+    const children = Array.from(root.children) as HTMLElement[]
+    if (children.length === 0) return null
+
+    let bestBlock: HTMLElement | null = null
+    let bestIndex = -1
+    let bestContentTop = 0
+
+    for (let i = 0; i < children.length; i++) {
+        const child = children[i]
+        const top = getElementContentTop(child, el)
+        if (top <= el.scrollTop + 4) {
+            bestBlock = child
+            bestIndex = i
+            bestContentTop = top
+        } else {
+            break
+        }
+    }
+
+    if (!bestBlock) {
+        bestBlock = children[0]
+        bestIndex = 0
+        bestContentTop = getElementContentTop(bestBlock, el)
+    }
+
+    const relTop = bestContentTop - el.scrollTop
+    const id = bestBlock.id ? `#${escapeCssIdentifier(bestBlock.id)}` : undefined
+    const selector = id || `:scope > :nth-child(${bestIndex + 1})`
+
+    return {
+        selector,
+        index: bestIndex,
+        tag: bestBlock.tagName ? bestBlock.tagName.toLowerCase() : 'div',
+        relTop,
+    }
+}
+
+export function restoreBlockAnchor(el: HTMLElement, blockAnchor: BlockAnchorState): boolean {
+    const root = (el.querySelector?.('.markdown-content') || el) as HTMLElement
+    if (!root) return false
+    let target: HTMLElement | null = null
+
+    if (blockAnchor.selector && !blockAnchor.selector.startsWith(':scope')) {
+        target = root.querySelector?.(blockAnchor.selector) as HTMLElement | null
+    }
+    if (!target && typeof blockAnchor.index === 'number' && root.children) {
+        const children = root.children
+        if (blockAnchor.index >= 0 && blockAnchor.index < children.length) {
+            target = children[blockAnchor.index] as HTMLElement
+        }
+    }
+    if (!target) return false
+
+    const contentTop = getElementContentTop(target, el)
+    el.scrollTop = scrollTopFor(contentTop, blockAnchor.relTop)
+    return true
+}
+
+export function captureMarkdownScroll(el: HTMLElement, content: string): FileScrollEntry {
+    const max = el.scrollHeight - el.clientHeight
+    const ratio = max > 0 ? { ratio: el.scrollTop / max } : null
+    let anchor: ScrollAnchorState | null = null
+    const toc = extractToc(content, 'markdown')
+    if (toc.length > 0 && el.querySelectorAll) {
+        const idToMeta = new Map(toc.map((i) => [i.id, i]))
+        const headings: { id: string; line: number; contentTop: number }[] = []
+        for (const h of el.querySelectorAll('h1, h2, h3, h4, h5, h6')) {
+            const id = h.id
+            const meta = id ? idToMeta.get(id) : undefined
+            if (!meta) continue
+            const contentTop = getElementContentTop(h, el)
+            headings.push({ id, line: meta.line, contentTop })
+        }
+        anchor = pickPreviewAnchor(headings, el.scrollTop)
+    }
+    const blockAnchor = captureBlockAnchor(el)
+    return {
+        scrollTop: el.scrollTop,
+        anchor,
+        blockAnchor,
+        ratio,
+    }
+}
+
 export function useFileScrollRestore(ctx: FileScrollContext): UseFileScrollRestore {
     let attachedEl: HTMLElement | null = null
+    let attachedPath: string | null = null
     let scrollHandler: ((e: Event) => void) | null = null
+    let snapshotTimer: ReturnType<typeof setTimeout> | null = null
     let currentPath: string | null = null
     let pollTimer: ReturnType<typeof setInterval> | null = null
-    let pendingPx: { path: string; scrollTop: number; attempts: number } | null = null
+    let pendingPx: { path: string; scrollTop: number; attempts: number; entry?: SavedScroll | null } | null = null
     let pendingAnchor: { saved: SavedScroll; attempts: number } | null = null
+    let activeAnchor: ScrollAnchorState | null = null
+    let activeBlockAnchor: BlockAnchorState | null = null
+    let stabilizeArmedPx: number | null = null
+
+    function disarmStabilizer(): void {
+        activeAnchor = null
+        activeBlockAnchor = null
+        stabilizeArmedPx = null
+    }
+
+    /**
+     * Remember the anchor a restore just landed on so late layout shifts can be
+     * corrected (see realignAnchor).
+     *
+     * Stays armed until one of the three things that mean "the restore's
+     * position is no longer where the user is":
+     *  - the user scrolls (scroll handler, below);
+     *  - the file changes (onFileWillChange / onFileChanged / dispose);
+     *  - something else takes over positioning — every explicit jump
+     *    (scroll-to-line, TOC, code link) dispatches 'cancel-scroll-restore'.
+     *
+     * There is deliberately no timeout: images and Mermaid diagrams can finish
+     * long after the restore, and a time limit would silently drop the
+     * correction exactly when it is still needed.
+     */
+    function armStabilizer(anchor: ScrollAnchorState | null, blockAnchor: BlockAnchorState | null, el: HTMLElement): void {
+        activeAnchor = anchor
+        activeBlockAnchor = blockAnchor
+        // The programmatic scroll that positions the anchor fires a scroll
+        // event asynchronously. Remember the applied offset so that echo is
+        // not mistaken for user scrolling (which must disarm the stabilizer).
+        stabilizeArmedPx = el.scrollTop
+    }
+
+    /**
+     * Arm the anchor after a *pixel* restore, so a late layout shift can still
+     * be corrected.
+     *
+     * Pixels and anchors describe the same place only while the layout is
+     * stable. A markdown pane that is still growing (images, Mermaid) shifts
+     * the content under a pixel offset, so the anchor has to be able to pull
+     * the position back. Restores that land through the poll (content not tall
+     * enough yet) are the ones most likely to be followed by late loads, so
+     * they arm too.
+     */
+    function armStabilizerForEntry(el: HTMLElement, entry?: SavedScroll | null): void {
+        if (!entry) return
+        if (!(entry.anchor || entry.blockAnchor)) return
+        if (!ctx.isMarkdown() || !el.classList?.contains('markdown-body')) return
+        armStabilizer(entry.anchor || null, entry.blockAnchor || null, el)
+    }
+
+    function realignAnchor(): void {
+        if (!activeAnchor && !activeBlockAnchor) return
+        const el = currentScrollEl()
+        if (!el || !isScrollable(el)) return
+        if (!ctx.isMarkdown() || !el.classList?.contains('markdown-body')) return
+
+        // Heading anchor first; the block anchor is the fallback for markdown
+        // without TOC headings.
+        //
+        // A correction moves scrollTop, and that move comes back through the
+        // scroll handler as an echo. Re-arm on the new offset, otherwise the
+        // echo reads as "the user scrolled" and disarms the stabilizer — the
+        // first late image would then be the last one ever corrected, which is
+        // exactly what dropping the timeout was meant to avoid.
+        if (activeAnchor && restorePreviewAnchor(el, activeAnchor)) {
+            stabilizeArmedPx = el.scrollTop
+            return
+        }
+        if (activeBlockAnchor && restoreBlockAnchor(el, activeBlockAnchor)) {
+            stabilizeArmedPx = el.scrollTop
+        }
+    }
 
     // ── container resolution ──────────────────────────────────────────────
 
@@ -155,27 +375,85 @@ export function useFileScrollRestore(ctx: FileScrollContext): UseFileScrollResto
 
     // ── scroll listener (writes px positions to the cache) ───────────────
 
+    /** Write a full { scrollTop, anchor, blockAnchor, ratio } snapshot now. */
+    function refreshSnapshot(): void {
+        if (!currentPath || !attachedEl || !isVisiblyAttached(attachedEl)) return
+        const saved = captureScroll(attachedEl)
+        if (!saved) return
+        setFileScroll(currentPath, {
+            scrollTop: attachedEl.scrollTop,
+            anchor: saved.anchor,
+            blockAnchor: saved.blockAnchor,
+            ratio: saved.ratio,
+        })
+    }
+
+    function cancelSnapshotRefresh(): void {
+        if (snapshotTimer) {
+            clearTimeout(snapshotTimer)
+            snapshotTimer = null
+        }
+    }
+
+    function scheduleSnapshotRefresh(): void {
+        if (snapshotTimer) clearTimeout(snapshotTimer)
+        snapshotTimer = setTimeout(() => {
+            snapshotTimer = null
+            refreshSnapshot()
+        }, SNAPSHOT_DEBOUNCE_MS)
+    }
+
     function attachScrollListener(): void {
-        detachScrollListener()
         const el = currentScrollEl()
         if (!el || !currentPath) return
+        // Idempotent on purpose: the poll calls this on every tick, and a
+        // blind re-attach would tear down the pending anchor refresh together
+        // with the previous listener, so the debounce would never fire.
+        if (attachedEl === el && scrollHandler && attachedPath === currentPath) return
+        detachScrollListener()
         attachedEl = el
+        attachedPath = currentPath
         scrollHandler = () => {
             // Ignore events fired while hidden: display:none resets CodeMirror's
             // scrollTop to 0 and later re-measuring can fire spurious scroll
             // events — writing 0 would overwrite the trusted position.
             if (el.offsetParent === null) return
-            setFileScroll(currentPath!, el.scrollTop)
+            const existing = getFileScrollEntry(currentPath!)
+            // Replace the entry wholesale instead of mutating it: the cached
+            // object is shared with the navigation history / origin, and an
+            // in-place scrollTop write would retroactively move snapshots
+            // those visitors banked earlier.
+            if (existing) {
+                setFileScroll(currentPath!, {
+                    scrollTop: el.scrollTop,
+                    anchor: existing.anchor,
+                    blockAnchor: existing.blockAnchor,
+                    ratio: existing.ratio,
+                })
+            } else {
+                setFileScroll(currentPath!, el.scrollTop)
+            }
+            // The anchor restore's own programmatic scroll arrives here as an
+            // echo carrying the armed offset — keep the realign window open for
+            // that one; only a real user scroll (different offset) disarms it.
+            if (stabilizeArmedPx === null || Math.abs(el.scrollTop - stabilizeArmedPx) > 1) {
+                disarmStabilizer()
+            }
+            // Pixels are authoritative right away; the anchor catches up once
+            // the fling settles so the cache never holds a stale heading.
+            scheduleSnapshotRefresh()
         }
         el.addEventListener('scroll', scrollHandler, { passive: true })
     }
 
     function detachScrollListener(): void {
+        cancelSnapshotRefresh()
         if (scrollHandler && attachedEl) {
             attachedEl.removeEventListener('scroll', scrollHandler)
         }
         scrollHandler = null
         attachedEl = null
+        attachedPath = null
     }
 
     // ── shared poll ───────────────────────────────────────────────────────
@@ -194,32 +472,39 @@ export function useFileScrollRestore(ctx: FileScrollContext): UseFileScrollResto
     function tick(): void {
         const el = currentScrollEl()
 
+        // Anchor/ratio restore (rendered↔raw / edit toggle / cross-file anchor).
+        if (pendingAnchor) {
+            if (++pendingAnchor.attempts > MAX_ANCHOR_ATTEMPTS) {
+                if (el && isScrollable(el)) {
+                    restoreScroll(pendingAnchor.saved, el, true)
+                }
+                pendingAnchor = null
+            } else if (el && isScrollable(el)) {
+                const ok = restoreScroll(pendingAnchor.saved, el, false)
+                if (ok) {
+                    pendingAnchor = null
+                    pendingPx = null
+                }
+            }
+        }
+
         // Pixel restore (cross-file / reopen). Requires content loaded and the
         // container tall enough to actually hold the target (else deferred).
         if (pendingPx) {
             if (++pendingPx.attempts > MAX_PX_ATTEMPTS) {
-                // Give up waiting. Original code attaches the listener here even
-                // if the content is not scrollable yet — mirror that so future
-                // user scrolls are tracked.
+                // Content never grew enough to hold the offset (file shrunk?).
+                // Fall back to the anchor rather than dropping the user at 0.
+                if (pendingPx.entry && el && isScrollable(el)) {
+                    restoreScroll(pendingPx.entry, el, true)
+                }
                 pendingPx = null
                 attachScrollListener()
             } else if (!ctx.loading() && el && isScrollable(el)) {
                 if (pxCanApply(el, pendingPx.scrollTop)) {
                     el.scrollTop = pendingPx.scrollTop
+                    armStabilizerForEntry(el, pendingPx.entry)
                     pendingPx = null
                 }
-                // else: content not tall enough yet — wait for the next tick.
-            }
-        }
-
-        // Anchor/ratio restore (rendered↔raw / edit toggle). No loading gate —
-        // it only needs a laid-out scrollable container.
-        if (pendingAnchor) {
-            if (++pendingAnchor.attempts > MAX_ANCHOR_ATTEMPTS) {
-                pendingAnchor = null
-            } else if (el && isScrollable(el)) {
-                restoreScroll(pendingAnchor.saved, el)
-                pendingAnchor = null
             }
         }
 
@@ -236,26 +521,6 @@ export function useFileScrollRestore(ctx: FileScrollContext): UseFileScrollResto
     }
 
     // ── anchor/ratio capture & restore ────────────────────────────────────
-
-    function capturePreviewAnchor(el: HTMLElement): ScrollAnchorState | null {
-        const content = ctx.file()?.content || ''
-        const toc = extractToc(content, 'markdown')
-        if (toc.length === 0) return null
-        const idToMeta = new Map(toc.map((i) => [i.id, i]))
-        const headings: { id: string; line: number; contentTop: number }[] = []
-        if (el.querySelectorAll) {
-            for (const h of el.querySelectorAll('h1, h2, h3, h4, h5, h6')) {
-                const id = h.id
-                const meta = id ? idToMeta.get(id) : undefined
-                if (!meta) continue
-                const contentTop =
-                    (h as Element).getBoundingClientRect?.().top -
-                    (el as Element).getBoundingClientRect?.().top
-                headings.push({ id, line: meta.line, contentTop })
-            }
-        }
-        return pickPreviewAnchor(headings, el.scrollTop)
-    }
 
     function captureCmAnchor(el: HTMLElement): ScrollAnchorState | null {
         const view = el instanceof Element ? EditorView.findFromDOM(el) : null
@@ -284,26 +549,23 @@ export function useFileScrollRestore(ctx: FileScrollContext): UseFileScrollResto
 
     function captureScroll(el: HTMLElement | null): SavedScroll | null {
         if (!el) return null
+        if (ctx.isMarkdown() && el.classList?.contains('markdown-body')) {
+            return captureMarkdownScroll(el, ctx.file()?.content || '')
+        }
         const max = el.scrollHeight - el.clientHeight
         const ratio = max > 0 ? { ratio: el.scrollTop / max } : null
         let anchor: ScrollAnchorState | null = null
-        if (ctx.isMarkdown()) {
-            if (el.classList?.contains('markdown-body')) {
-                anchor = capturePreviewAnchor(el)
-            } else if (el.classList?.contains('cm-scroller')) {
-                anchor = captureCmAnchor(el)
-            }
+        if (ctx.isMarkdown() && el.classList?.contains('cm-scroller')) {
+            anchor = captureCmAnchor(el)
         }
-        return { anchor, ratio }
+        return { scrollTop: el.scrollTop, anchor, ratio }
     }
 
     function restorePreviewAnchor(el: HTMLElement, anchor: ScrollAnchorState): boolean {
         const sel = `#${escapeCssIdentifier(anchor.id)}`
         const target = el.querySelector?.(sel)
         if (!target) return false
-        const contentTop =
-            (target as Element).getBoundingClientRect?.().top -
-            (el as Element).getBoundingClientRect?.().top
+        const contentTop = getElementContentTop(target, el)
         el.scrollTop = scrollTopFor(contentTop, anchor.relTop)
         return true
     }
@@ -322,16 +584,51 @@ export function useFileScrollRestore(ctx: FileScrollContext): UseFileScrollResto
         return true
     }
 
-    function restoreScroll(saved: SavedScroll, el: HTMLElement): void {
-        // TOC heading alignment first, percentage ratio as fallback.
-        if (saved.anchor && ctx.isMarkdown()) {
-            if (el.classList?.contains('markdown-body') && restorePreviewAnchor(el, saved.anchor)) return
-            if (el.classList?.contains('cm-scroller') && restoreCmAnchor(el, saved.anchor)) return
+    function restoreScroll(saved: SavedScroll, el: HTMLElement, allowFallback = true): boolean {
+        // 0. Pixel restore when the caller knows the offset is directly
+        //    comparable (same file, same view mode).
+        if (saved.preferPx && typeof saved.scrollTop === 'number' && pxCanApply(el, saved.scrollTop)) {
+            el.scrollTop = saved.scrollTop
+            if (ctx.isMarkdown() && el.classList?.contains('markdown-body') && (saved.anchor || saved.blockAnchor)) {
+                armStabilizer(saved.anchor || null, saved.blockAnchor || null, el)
+            }
+            return true
         }
+        // 1. TOC heading alignment first
+        if (saved.anchor && ctx.isMarkdown()) {
+            if (el.classList?.contains('markdown-body') && restorePreviewAnchor(el, saved.anchor)) {
+                armStabilizer(saved.anchor, saved.blockAnchor || null, el)
+                return true
+            }
+            if (el.classList?.contains('cm-scroller') && restoreCmAnchor(el, saved.anchor)) {
+                return true
+            }
+        }
+        // 2. Block anchor alignment
+        if (saved.blockAnchor && ctx.isMarkdown() && el.classList?.contains('markdown-body')) {
+            if (restoreBlockAnchor(el, saved.blockAnchor)) {
+                armStabilizer(saved.anchor || null, saved.blockAnchor, el)
+                return true
+            }
+        }
+        // If an anchor was provided but not found yet, don't fall back until timeout
+        const hasAnchor = !!(saved.anchor || saved.blockAnchor)
+        if (hasAnchor && !allowFallback) return false
+
+        // 3. Pixel restore
+        if (typeof saved.scrollTop === 'number' && pxCanApply(el, saved.scrollTop)) {
+            el.scrollTop = saved.scrollTop
+            return true
+        }
+        // 4. Percentage ratio as fallback
         if (saved.ratio) {
             const max = el.scrollHeight - el.clientHeight
-            if (max > 0) el.scrollTop = Math.round(saved.ratio.ratio * max)
+            if (max > 0) {
+                el.scrollTop = Math.round(saved.ratio.ratio * max)
+                return true
+            }
         }
+        return false
     }
 
     // ── window cancel-scroll-restore (scroll-to-line takes precedence) ────
@@ -341,9 +638,38 @@ export function useFileScrollRestore(ctx: FileScrollContext): UseFileScrollResto
     }
 
     function handleRestoreFileScroll(e: Event): void {
-        const ce = e as CustomEvent<{ scrollTop?: number }>
-        if (typeof ce?.detail?.scrollTop === 'number') {
-            const target = ce.detail.scrollTop
+        const ce = e as CustomEvent<{ scrollTop?: number; scrollEntry?: FileScrollEntry; preferPx?: boolean }>
+        const entry = ce?.detail?.scrollEntry
+        const preferPx = ce?.detail?.preferPx === true
+        const target = typeof ce?.detail?.scrollTop === 'number' ? ce.detail.scrollTop : entry?.scrollTop
+
+        // Same view mode: the pixel offset is the exact place, so lead with it
+        // and keep the anchor purely as a fallback for when the content can no
+        // longer hold that offset.
+        if (preferPx && typeof target === 'number') {
+            const el = currentScrollEl()
+            if (el && isScrollable(el) && pxCanApply(el, target)) {
+                el.scrollTop = target
+                if (ctx.isMarkdown() && el.classList?.contains('markdown-body') && (entry?.anchor || entry?.blockAnchor)) {
+                    armStabilizer(entry.anchor || null, entry.blockAnchor || null, el)
+                }
+                return
+            }
+            pendingAnchor = null
+            pendingPx = { path: currentPath || '', scrollTop: target, attempts: 0, entry: entry ?? null }
+            startPoll()
+            kick()
+            return
+        }
+
+        if (entry && (entry.anchor || entry.blockAnchor)) {
+            pendingAnchor = { saved: entry, attempts: 0 }
+            pendingPx = typeof target === 'number' ? { path: currentPath || '', scrollTop: target, attempts: 0, entry } : null
+            startPoll()
+            kick()
+            return
+        }
+        if (typeof target === 'number') {
             const el = currentScrollEl()
             if (el && isScrollable(el) && pxCanApply(el, target)) {
                 el.scrollTop = target
@@ -357,6 +683,8 @@ export function useFileScrollRestore(ctx: FileScrollContext): UseFileScrollResto
 
     function cancelPendingRestore(): void {
         pendingPx = null
+        pendingAnchor = null
+        disarmStabilizer()
     }
 
     // ── public orchestration ──────────────────────────────────────────────
@@ -364,6 +692,7 @@ export function useFileScrollRestore(ctx: FileScrollContext): UseFileScrollResto
     function start(): void {
         window.addEventListener(CANCEL_EVENT, handleCancelScrollRestore)
         window.addEventListener(RESTORE_EVENT, handleRestoreFileScroll)
+        window.addEventListener(REALIGN_EVENT, realignAnchor)
     }
 
     function dispose(): void {
@@ -371,22 +700,45 @@ export function useFileScrollRestore(ctx: FileScrollContext): UseFileScrollResto
         // v-if removal does not run the props.file watcher). Skip when hidden —
         // its scrollTop has been reset to 0 and must not overwrite the cache.
         if (currentPath && attachedEl && isVisiblyAttached(attachedEl)) {
-            setFileScroll(currentPath, attachedEl.scrollTop)
+            const saved = captureScroll(attachedEl)
+            if (saved) {
+                setFileScroll(currentPath, {
+                    scrollTop: attachedEl.scrollTop,
+                    anchor: saved.anchor,
+                    blockAnchor: saved.blockAnchor,
+                    ratio: saved.ratio,
+                })
+            } else {
+                setFileScroll(currentPath, attachedEl.scrollTop)
+            }
         }
         detachScrollListener()
         stopPoll()
+        disarmStabilizer()
         window.removeEventListener(CANCEL_EVENT, handleCancelScrollRestore)
         window.removeEventListener(RESTORE_EVENT, handleRestoreFileScroll)
+        window.removeEventListener(REALIGN_EVENT, realignAnchor)
     }
 
     function onFileWillChange(): void {
         // Save the pane being left synchronously. Relying only on scroll events
         // can miss the final position when navigation follows a smooth scroll.
         if (currentPath && attachedEl && isVisiblyAttached(attachedEl)) {
-            setFileScroll(currentPath, attachedEl.scrollTop)
+            const saved = captureScroll(attachedEl)
+            if (saved) {
+                setFileScroll(currentPath, {
+                    scrollTop: attachedEl.scrollTop,
+                    anchor: saved.anchor,
+                    blockAnchor: saved.blockAnchor,
+                    ratio: saved.ratio,
+                })
+            } else {
+                setFileScroll(currentPath, attachedEl.scrollTop)
+            }
         }
         detachScrollListener()
         stopPoll()
+        disarmStabilizer()
         // Do NOT clear pendingPx here: a same-path content refresh relies on the
         // content watcher (onContentReady) to re-kick the restore.
     }
@@ -395,18 +747,27 @@ export function useFileScrollRestore(ctx: FileScrollContext): UseFileScrollResto
         if (!file) {
             currentPath = null
             pendingPx = null
+            pendingAnchor = null
+            disarmStabilizer()
             return
         }
         currentPath = file.path
         if (pathChanged) {
-            const savedScroll = getFileScroll(file.path)
-            pendingPx = { path: file.path, scrollTop: savedScroll ?? 0, attempts: 0 }
+            const entry = getFileScrollEntry(file.path)
+            const savedScroll = entry?.scrollTop ?? getFileScroll(file.path)
+            if (entry && (entry.anchor || entry.blockAnchor)) {
+                pendingAnchor = { saved: entry, attempts: 0 }
+            } else {
+                pendingAnchor = null
+            }
+            pendingPx = { path: file.path, scrollTop: savedScroll ?? 0, attempts: 0, entry: entry ?? null }
             startPoll()
             kick()
         }
     }
 
     function onContentReady(): void {
+        realignAnchor()
         kick()
     }
 
@@ -428,5 +789,6 @@ export function useFileScrollRestore(ctx: FileScrollContext): UseFileScrollResto
         captureScroll,
         restoreAfterContainerSwitch,
         cancelPendingRestore,
+        realignAnchor,
     }
 }

--- a/web/src/composables/useNavigationContext.ts
+++ b/web/src/composables/useNavigationContext.ts
@@ -1,4 +1,5 @@
 import { ref, computed, type ComputedRef } from 'vue'
+import type { FileScrollEntry } from '@/utils/fileScrollCache'
 
 export type NavigationSurface = 'chat' | 'task' | 'file' | 'browse' | 'history'
 
@@ -11,6 +12,7 @@ export interface NavigationOrigin {
   lineEnd?: number
   viewMode?: string
   scrollTop?: number
+  scrollEntry?: FileScrollEntry
   dirPath?: string
   sessionId?: string
 }

--- a/web/src/composables/useNavigationCoordinator.ts
+++ b/web/src/composables/useNavigationCoordinator.ts
@@ -4,7 +4,7 @@ import { appLog } from '@/utils/appLog'
 import { isAbsolutePath } from '@/utils/path'
 import { getFileType } from '@/utils/fileType'
 import { openRecentFile } from '@/composables/useRecentFiles'
-import { getFileScroll, setFileScroll } from '@/utils/fileScrollCache'
+import { getFileScroll, getFileScrollEntry, setFileScroll, type FileScrollEntry } from '@/utils/fileScrollCache'
 import { gt as defaultGt } from '@/composables/useLocale'
 import { useToast } from '@/composables/useToast'
 import { PANE_LEFT, PANE_RIGHT, type ActivePane } from '@/composables/useWideScreenLayout'
@@ -57,6 +57,16 @@ export interface NavigationCoordinatorOptions {
     closeOverlayAndSync?: () => void
     handleOpenFileManager?: () => void
     isFileManagerMultiSelectActive?: () => boolean
+    /**
+     * Ask the mounted file viewer for a fresh { scrollTop, anchor } snapshot of
+     * the file being left, synchronously.
+     *
+     * Without it, captures read the module-level scroll cache, which only
+     * refreshes on debounced scroll — a jump taken immediately after a fling
+     * (or before any scroll at all) would bank a position from an earlier
+     * moment and return the user there.
+     */
+    requestScrollCapture?: () => void
   }
   backHooks?: {
     hasTopmostOverlay?: () => boolean
@@ -99,6 +109,7 @@ export function useNavigationCoordinator(options: NavigationCoordinatorOptions) 
   const closeOverlayAndSync = options.viewActions?.closeOverlayAndSync ?? (() => {})
   const handleOpenFileManager = options.viewActions?.handleOpenFileManager ?? (() => {})
   const isFileManagerMultiSelectActive = options.viewActions?.isFileManagerMultiSelectActive ?? (() => false)
+  const requestScrollCapture = options.viewActions?.requestScrollCapture ?? (() => {})
 
   const hasTopmostOverlay = options.backHooks?.hasTopmostOverlay ?? (() => false)
   const closeTopmostOverlay = options.backHooks?.closeTopmostOverlay ?? (() => false)
@@ -109,7 +120,6 @@ export function useNavigationCoordinator(options: NavigationCoordinatorOptions) 
   const exitEdit = options.fileEditor?.exitEdit ?? (() => {})
 
   let applyingOriginReturn = false
-  let lastFileScrollTop = 0
   let directoryRequestId = 0
 
   function isApplyingOriginReturn(): boolean {
@@ -124,22 +134,53 @@ export function useNavigationCoordinator(options: NavigationCoordinatorOptions) 
     return t('common.back')
   }
 
-  function captureCurrentFileState(): void {
-    if (store.state.currentFile?.path) {
-      const cached = getFileScroll(store.state.currentFile.path)
-      const scrollTop = typeof cached === 'number' ? cached : lastFileScrollTop
+  /**
+   * Bank where the user is in the current file before leaving it.
+   *
+   * Reads the live viewer first: the module-level scroll cache only refreshes on
+   * debounced scroll, so on its own it can be a fling behind. Falls back to the
+   * cache when no viewer is mounted, and leaves the recorded position untouched
+   * when neither has anything — never to another file's leftover offset.
+   */
+  function captureCurrentFileState(pathOverride?: string | null): void {
+    const currentPath = store.state.currentFile?.path
+    const path = pathOverride ?? currentPath
+    if (!path) return
+    if (!pathOverride || pathOverride === currentPath) {
+      requestScrollCapture()
+    }
+    // Only borrow the nav stack's own entry when it describes the same file —
+    // banking another visit's snapshot here would send the user to the wrong
+    // place on return.
+    const isCurrentFile = fileNav.currentLocation.value?.path === path
+    const navEntry = isCurrentFile
+      ? fileNav.currentLocation.value?.scrollEntry
+      : undefined
+    const cachedEntry = getFileScrollEntry(path) ?? navEntry
+    const cachedScroll = getFileScroll(path) ?? (isCurrentFile ? fileNav.currentLocation.value?.scrollTop : undefined)
+    // Pass `undefined` (not 0) when the cache holds nothing: updateCurrent
+    // skips undefined, keeping a position this visit already recorded from a
+    // live capture. Writing 0 here would silently discard it.
+    if (isCurrentFile) {
       fileNav.updateCurrent({
         viewMode: markdownViewMode.value,
-        scrollTop,
+        scrollTop: cachedScroll,
+        scrollEntry: cachedEntry,
       })
     }
   }
 
-  function handleCaptureFileScroll(scrollTop: number): void {
-    if (typeof scrollTop === 'number') {
-      lastFileScrollTop = scrollTop
-      fileNav.updateCurrent({ scrollTop })
+  function handleCaptureFileScroll(scroll: number | FileScrollEntry): void {
+    const currentPath = store.state.currentFile?.path
+    if (!currentPath) return
+    if (fileNav.currentLocation.value?.path === currentPath) {
+      if (typeof scroll === 'number') {
+        fileNav.updateCurrent({ scrollTop: scroll })
+      } else if (scroll && typeof scroll === 'object') {
+        fileNav.updateCurrent({ scrollTop: scroll.scrollTop, scrollEntry: scroll })
+      }
     }
+    setFileScroll(currentPath, scroll)
   }
 
   function settleOriginForTab(tab: string): void {
@@ -192,8 +233,14 @@ export function useNavigationCoordinator(options: NavigationCoordinatorOptions) 
     if (!location?.path) return false
     const previousPath = location.path
 
-    if (location.scrollTop !== undefined) {
+    if (location.scrollEntry !== undefined) {
+      setFileScroll(previousPath, location.scrollEntry)
+    } else if (location.scrollTop !== undefined) {
       setFileScroll(previousPath, location.scrollTop)
+    }
+    const targetViewMode = location.viewMode ?? (getFileType(previousPath).isMarkdown ? 'rendered' : undefined)
+    if (targetViewMode) {
+      markdownViewMode.value = targetViewMode
     }
     const ok = await store.selectFile(previousPath)
     if (!ok) {
@@ -203,11 +250,31 @@ export function useNavigationCoordinator(options: NavigationCoordinatorOptions) 
     fileNav.goBack()
 
     await nextTick()
-    if (location.viewMode) markdownViewMode.value = location.viewMode
-    if (location.lineStart) {
+    // The recorded reading position wins over lineStart: a visit opened via a
+    // line-numbered link keeps its original line forever, but by return time
+    // the user has usually scrolled elsewhere — jumping back to the landing
+    // line would discard that. scrollToLine stays as the fallback for visits
+    // that never captured a position (jumped away before any scroll).
+    //
+    // A recorded 0 does not count as "captured": it is what a viewer reports
+    // before the async scroll-to-line has landed, so treating it as a real
+    // position would dump the user at the top of the file instead of the line
+    // they were sent to.
+    const recordedTop = location.scrollEntry?.scrollTop ?? location.scrollTop
+    if (typeof recordedTop === 'number' && recordedTop > 0) {
+      // Pixels are only comparable when the pane layout is unchanged. Leaving
+      // and returning in the same view mode means content heights match, so
+      // pixel offset directly applies.
+      const sameView = !location.viewMode || location.viewMode === markdownViewMode.value
+      window.dispatchEvent(new CustomEvent('restore-file-scroll', {
+        detail: {
+          scrollTop: recordedTop,
+          scrollEntry: location.scrollEntry,
+          preferPx: sameView,
+        },
+      }))
+    } else if (location.lineStart) {
       scrollToLine(location.lineStart, location.lineEnd, previousPath)
-    } else if (location.scrollTop !== undefined) {
-      window.dispatchEvent(new CustomEvent('restore-file-scroll', { detail: { scrollTop: location.scrollTop } }))
     }
     return true
   }
@@ -230,8 +297,14 @@ export function useNavigationCoordinator(options: NavigationCoordinatorOptions) 
       }
 
       if (origin.filePath) {
-        if (origin.scrollTop !== undefined) {
+        if (origin.scrollEntry !== undefined) {
+          setFileScroll(origin.filePath, origin.scrollEntry)
+        } else if (origin.scrollTop !== undefined) {
           setFileScroll(origin.filePath, origin.scrollTop)
+        }
+        const targetViewMode = origin.viewMode ?? (getFileType(origin.filePath).isMarkdown ? 'rendered' : undefined)
+        if (targetViewMode) {
+          markdownViewMode.value = targetViewMode
         }
         const ok = await store.selectFile(origin.filePath)
         if (!ok) {
@@ -241,11 +314,20 @@ export function useNavigationCoordinator(options: NavigationCoordinatorOptions) 
           return true
         }
         await nextTick()
-        if (origin.viewMode) markdownViewMode.value = origin.viewMode
-        if (origin.lineStart) {
+        // Reading position wins over lineStart — same rationale as goBackFile,
+        // including the "0 is not a captured position" rule.
+        const recordedTop = origin.scrollEntry?.scrollTop ?? origin.scrollTop
+        if (typeof recordedTop === 'number' && recordedTop > 0) {
+          const sameView = !origin.viewMode || origin.viewMode === markdownViewMode.value
+          window.dispatchEvent(new CustomEvent('restore-file-scroll', {
+            detail: {
+              scrollTop: recordedTop,
+              scrollEntry: origin.scrollEntry,
+              preferPx: sameView,
+            },
+          }))
+        } else if (origin.lineStart) {
           scrollToLine(origin.lineStart, origin.lineEnd, origin.filePath)
-        } else if (origin.scrollTop !== undefined) {
-          window.dispatchEvent(new CustomEvent('restore-file-scroll', { detail: { scrollTop: origin.scrollTop } }))
         }
       } else if (origin.surface !== 'file') {
         closeOverlayAndSync()
@@ -334,7 +416,8 @@ export function useNavigationCoordinator(options: NavigationCoordinatorOptions) 
         viewMode: markdownViewMode.value,
         lineStart: location?.lineStart,
         lineEnd: location?.lineEnd,
-        scrollTop: location?.scrollTop ?? getFileScroll(file.path) ?? lastFileScrollTop,
+        scrollTop: location?.scrollTop ?? getFileScroll(file.path) ?? 0,
+        scrollEntry: location?.scrollEntry ?? getFileScrollEntry(file.path),
       }, store.state.currentDir)
     } else if (surface === 'chat' || surface === 'task' || surface === 'tasks' || surface === 'history') {
       const normSurface: NavigationSurface = surface === 'tasks' ? 'task' : (surface as NavigationSurface)
@@ -430,12 +513,8 @@ export function useNavigationCoordinator(options: NavigationCoordinatorOptions) 
   async function handleOverlayOpenFile(payload: string | { path: string; lineStart?: number; lineEnd?: number }): Promise<void> {
     const { path, lineStart, lineEnd } = typeof payload === 'string' ? { path: payload, lineStart: undefined, lineEnd: undefined } : payload
     const prevPath = fileNav.currentFilePath.value
-    const cachedScroll = prevPath ? getFileScroll(prevPath) : undefined
-    const scrollTop = typeof cachedScroll === 'number' ? cachedScroll : lastFileScrollTop
-    fileNav.updateCurrent({
-      viewMode: markdownViewMode.value,
-      scrollTop,
-    })
+    // Snapshot the outgoing file from the live DOM before pushing the new one.
+    captureCurrentFileState(prevPath)
 
     if (!path.startsWith('/')) {
       try {
@@ -524,12 +603,7 @@ export function useNavigationCoordinator(options: NavigationCoordinatorOptions) 
       }
     } else {
       const prevPath = fileNav.currentFilePath.value
-      const cachedScroll = prevPath ? getFileScroll(prevPath) : undefined
-      const scrollTop = typeof cachedScroll === 'number' ? cachedScroll : lastFileScrollTop
-      fileNav.updateCurrent({
-        viewMode: markdownViewMode.value,
-        scrollTop,
-      })
+      captureCurrentFileState(prevPath)
     }
 
     switchTab('view')
@@ -544,6 +618,7 @@ export function useNavigationCoordinator(options: NavigationCoordinatorOptions) 
     settleOriginForTab,
     handleCaptureFileScroll,
     openFileInViewer,
+    goBackFile,
     returnToOrigin,
     fileBackTarget,
     canNavigateBackInView,

--- a/web/src/utils/fileScrollCache.ts
+++ b/web/src/utils/fileScrollCache.ts
@@ -11,17 +11,42 @@
  * scrollTop reset to 0 by display:none, so callers must not overwrite a good
  * value with a 0 read from a hidden container (see FileViewer).
  */
-const fileScrollCache = new Map<string, number>()
+export interface ScrollAnchorState {
+    id: string
+    line: number
+    relTop: number
+}
+
+export interface BlockAnchorState {
+    selector?: string
+    index?: number
+    tag?: string
+    relTop: number
+}
+
+export interface FileScrollEntry {
+    scrollTop: number
+    anchor?: ScrollAnchorState | null
+    blockAnchor?: BlockAnchorState | null
+    ratio?: { ratio: number } | null
+}
+
+const fileScrollCache = new Map<string, FileScrollEntry>()
 
 /** Maximum entries to keep (oldest evicted first) — prevents unbounded growth. */
 const MAX_ENTRIES = 100
 
 export function getFileScroll(path: string): number | undefined {
+    return fileScrollCache.get(path)?.scrollTop
+}
+
+export function getFileScrollEntry(path: string): FileScrollEntry | undefined {
     return fileScrollCache.get(path)
 }
 
-export function setFileScroll(path: string, scrollTop: number): void {
-    fileScrollCache.set(path, scrollTop)
+export function setFileScroll(path: string, val: number | FileScrollEntry): void {
+    const entry: FileScrollEntry = typeof val === 'number' ? { scrollTop: val } : val
+    fileScrollCache.set(path, entry)
     if (fileScrollCache.size > MAX_ENTRIES) {
         const oldest = fileScrollCache.keys().next().value
         if (oldest !== undefined) fileScrollCache.delete(oldest)


### PR DESCRIPTION
## 变更说明

### 要解决的问题

在文件浏览器中滑动阅读一个 Markdown / 代码文件后，点击**带行号的链接**（如 `README.md#L10-L20`、`src/app.ts:10-20`）或**跨文件跳转**，再点返回回到原文件时，阅读位置会丢失。用户侧的失效表现为三种：

1. **跳回顶部** —— 明明读到文档中部，返回后从第一行开始；
2. **落到错误标题** —— 返回后停在另一个 heading 上，不是离开时读到的那一段；
3. **视图模式抖动** —— rendered 模式的 Markdown 先以 raw（CodeMirror）短暂挂载、紧接着切回 rendered，闪一下之后位置归零。

另有一个同源缺陷：Markdown 里的**图片 / Mermaid 图表延迟加载**完成后，内容高度增长会把已恢复的位置推移走，而修正只会生效一次 —— 第一张图修完就再也不修了。

复现路径（对应症状 1、3）：打开一个较长的 `.md` → 切到 rendered 模式 → 下滑到中部 → 点击文中一个带行号的文件链接跳转 → 点返回。

### 根因与修复

根因不是单点 bug，而是"恢复链路"上 6 处时序 / 判定 / 守卫问题的叠加：

| # | 根因 | 修复 |
|---|------|------|
| 1 | `selectFile` **之后**才恢复 `markdownViewMode`。带行号跳转会强制把视图置为 `raw`，返回时先按 raw 挂载 CodeMirror，紧接着切回 rendered 触发 `markdownViewMode` 的 pre-flush watcher，抓到刚挂载容器的 `scrollTop: 0` 并调用 `restoreAfterContainerSwitch` 把位置重置 | 在 `selectFile` **之前**提前恢复 `targetViewMode`，挂载即为正确模式，消除模式抖动与零值覆盖 |
| 2 | `sameView` / `preferPx` 拿源文件 recorded 的 viewMode 与**被离开的跳转目标文件**（raw）作比较，导致同为 rendered 返回时被误判为跨模式（`preferPx: false`），丢掉精确像素、强行降级到最近标题锚点（即症状 2） | 改为基于源文件**实际恢复的** viewMode 比较，同模式返回始终优先精确像素 |
| 3 | `openFilePath` 先 `store.selectFile` 再派发 overlay 事件，`captureCurrentFileState(pathOverride)` 之前无条件 `requestScrollCapture`，抓到的是**新文件**的 DOM（0），并经 `handleCaptureFileScroll` 冲掉导航栈中源文件的有效位置 | 增加路径一致性守卫：仅当 `pathOverride` 与当前激活文件一致时才请求实时 DOM 捕获；`handleCaptureFileScroll` 仅在当前文件与导航栈顶匹配时更新 `currentLocation` |
| 4 | 滚动事件只写像素，缓存里的 anchor 仍是"打开文件时"那个 heading，而 anchor 在恢复时优先级高于像素 → 落到旧标题；`attachScrollListener` 被 poll 反复重挂，导致 debounce 永远不触发 | 滚动停止后 120ms debounce 重算完整 `anchor/blockAnchor/ratio` 快照；`attachScrollListener` 幂等化；`updateCurrent` 忽略 `undefined` 字段，避免缓存空值擦掉本次访问已记录的位置 |
| 5 | stabilizer 有 2500ms 超时，图片 / Mermaid 晚于该窗口加载完成就永久失去修正机会 | 移除超时，改由"用户主动滚动 / 文件切换 / 主动跳转取消"三态精确判定何时卸载 |
| 6 | `realignAnchor()` 靠给 `el.scrollTop` 赋值完成修正，但 `stabilizeArmedPx` 仍停留在首次 arm 的旧值；真实浏览器中该赋值会异步触发一个 scroll 回声，与旧值相差 > 1 被 handler 判定为"用户滚动"而 `disarmStabilizer()` —— 第一张图片修正完 stabilizer 就自我卸载 | 修正成功后用新的 `el.scrollTop` 重新 arm，容忍修正自身的回声 |

顺带清理：移除 `FileViewer.captureScroll` 中一个不可达的纯像素回退分支（`scrollRestore.captureScroll` 仅在容器为 `null` 时返回 `null`，该分支永不执行）。

### 数据结构变更

`fileScrollCache` 由 `Map<string, number>` 升级为 `Map<string, FileScrollEntry>`：

```ts
interface FileScrollEntry {
    scrollTop: number
    anchor?: ScrollAnchorState | null      // 最近的 TOC heading + 相对视口偏移
    blockAnchor?: BlockAnchorState | null  // 无 TOC heading 时的块级兜底
    ratio?: { ratio: number } | null       // 内容高度突变时的比例兜底
}
```

恢复优先级：`preferPx` 精确像素（同文件同视图）→ heading anchor → block anchor → 像素 → ratio。`FileNavLocation` 同步新增 `scrollEntry` 字段，使导航栈中每次访问都携带完整快照，而不只是一个像素值。

## 变更类型

- [ ] feat: 新功能
- [x] fix: Bug 修复
- [ ] refactor: 重构
- [ ] perf: 性能优化
- [ ] docs: 文档
- [ ] test: 测试
- [ ] chore/ci/build: 构建/工具

## 关联 Issue

暂无 —— 本 PR 未关联 Issue。完整的问题描述、复现路径与根因分析已写在上方「变更说明」中，如需补 Issue 可直接据此建立。

## 测试

- [x] 已通过现有测试（`go test ./...` / `npm test`）
- [x] 已添加新测试覆盖
- [ ] 手动验证（描述验证方式）

**全量前端测试**：`npm test` → 388 test files passed，0 failed（改前该分支存在 1 个失败用例，见下方"顺带修复"）。
本 PR 为纯前端改动，未触及 Go 代码，`go test ./...` 未重跑。

**类型与 lint**：`npm run typecheck`（vue-tsc）干净通过；`eslint` 对改动源文件 0 error。

**新增测试**：

- `useFileScrollRestore.test.ts`（+461）：像素 / anchor / blockAnchor / ratio 四级恢复、视图模式恢复时序、120ms debounce 快照、stabilizer 三态卸载与多次延迟加载修正、`getElementContentTop` 等纯函数
- `useNavigationCoordinator.test.ts`（+199）：路径一致性守卫、`captureCurrentFileState` 与实时捕获接线
- `FileViewer.test.ts`（+88）：rendered Markdown 的捕获委托给 `MarkdownPreview` 且不重复 emit

**回归有效性验证**：第 6 条修复对应的两个用例在**移除该修复后会失败**（`expected 1440 to be 1840`，即第一次修正后再也不动），确认测试真正咬住了缺陷而非空跑。原有用例从不派发 scroll 回声，因此无法暴露它 —— jsdom 假容器不会自动派发 scroll 事件，现已在每次 realign 后手动 `el.fire('scroll')` 复现真实浏览器行为，并把延迟加载场景扩展到三轮。

**顺带修复的存量红测试**：`useFileBackTarget.test.ts` 的 `wide screen jump` 用例在本 PR 之前就是失败的 —— 其 `fakeStore.state.currentFile` 始终为 `null`（该用例直接调 `files.openFile` 绕过 store），在上表第 3 条新增的路径守卫下 `handleCaptureFileScroll` 变成空操作、`scrollTop: 450` 丢失。已补齐夹具以对齐真实接线，并断言新增的 `scrollEntry` 字段。

**手动验证**：未做浏览器手动验证，建议 reviewer 按上方复现路径确认：长 Markdown → rendered → 下滑到中部 → 带行号链接跳转 → 返回；以及含大图 / Mermaid 的文档返回后等待其加载完成，确认位置不被布局推移带偏。

## 自检清单

- [x] 代码遵循项目现有风格
- [x] 无硬编码密钥或敏感信息
- [x] 变更已反映在文档中（不适用 —— 纯 Bug 修复，无配置项或用户可见设置变更）
