### PR TITLE
feat: 批量合入 4 提交 — ACP 子智能体分组 + Docker 自升级 + 附件抽屉修复

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,11 +5,17 @@
 #
 # Or manually:
 #   docker build -t clawbench .
-#   docker run -p 20000:20000 -v clawbench-data:/data clawbench
+#   docker run -d --restart unless-stopped -p 20000:20000 -v clawbench-data:/data clawbench
 #
 # Pull from GitHub Container Registry:
 #   docker pull ghcr.io/clawbench-dev/clawbench:latest
-#   docker run -d -p 20000:20000 -v clawbench-data:/data ghcr.io/clawbench-dev/clawbench:latest
+#   docker run -d --restart unless-stopped -p 20000:20000 -v clawbench-data:/data ghcr.io/clawbench-dev/clawbench:latest
+#
+# --restart always / unless-stopped is required for in-app upgrades: the
+# container replaces its own binary and exits (code 0), and the restart policy
+# brings the new version back up. `--restart on-failure` does NOT work — a
+# graceful shutdown exits 0, so it never triggers. Prefer `docker pull` +
+# recreate over an in-place upgrade.
 
 FROM ubuntu:24.04
 

--- a/README.md
+++ b/README.md
@@ -123,10 +123,14 @@ cd clawbench
 
 ```bash
 docker pull ghcr.io/clawbench-dev/clawbench:latest
-docker run -d -p 20000:20000 -v clawbench-data:/data ghcr.io/clawbench-dev/clawbench:latest
+docker run -d --restart unless-stopped -p 20000:20000 -v clawbench-data:/data ghcr.io/clawbench-dev/clawbench:latest
 ```
 
-Customize the host port with `-p` (e.g., `-p 20300:20000`). The `clawbench-data` volume persists all data. To view the auto-generated password:
+Customize the host port with `-p` (e.g., `-p 20300:20000`). The `clawbench-data` volume persists all data.
+
+> `--restart unless-stopped` (or `always`) is required for in-app upgrades: the container replaces its own binary and exits with code 0, and Docker's restart policy brings the new version back up. Do **not** use `--restart on-failure` — a graceful shutdown exits 0, so it never triggers and the container stays stopped. The recommended upgrade path is still `docker pull` + recreate the container, since rebuilding from an unchanged image reverts the in-place replacement.
+
+To view the auto-generated password:
 
 ```bash
 docker exec $(docker ps -qf ancestor=ghcr.io/clawbench-dev/clawbench) cat /data/.clawbench/auto-password

--- a/README.zh.md
+++ b/README.zh.md
@@ -135,10 +135,12 @@ cd clawbench
 
 ```bash
 docker pull ghcr.io/clawbench-dev/clawbench:latest
-docker run -d -p 20000:20000 -v clawbench-data:/data ghcr.io/clawbench-dev/clawbench:latest
+docker run -d --restart unless-stopped -p 20000:20000 -v clawbench-data:/data ghcr.io/clawbench-dev/clawbench:latest
 ```
 
 修改 `-p` 可自定义端口（如 `-p 20300:20000`），`clawbench-data` 卷持久化数据。
+
+> `--restart unless-stopped`（或 `always`）是应用内升级的必要条件：容器会替换自身二进制并以退出码 0 退出，依赖 Docker 重启策略把新版本拉起来。请勿使用 `--restart on-failure`——优雅退出的退出码为 0，不会触发重启，容器会停在停止状态。推荐的升级方式仍是 `docker pull` 后重建容器——用未更新的镜像重建会回退就地替换的结果。
 
 > 首次启动会自动生成32位随机密码，以字符框突出打印到控制台，请妥善保存。
 

--- a/build.sh
+++ b/build.sh
@@ -290,7 +290,7 @@ if [[ -n "$DO_RESTART" ]]; then
     # which would otherwise propagate to the new server and make it look like an
     # orphan AI subprocess to another instance's CleanupOrphans (leading to the
     # new server being killed on startup).
-    env -u CLAWBENCH_CHILD -u CLAWBENCH_NO_SUPERVISOR setsid "$BIN" $PORT_ARGS >> "$LOG" 2>&1 &
+    env -u CLAWBENCH_CHILD setsid "$BIN" $PORT_ARGS >> "$LOG" 2>&1 &
     NEW_PID=$!
     echo "  New PID: $NEW_PID"
 

--- a/docs/spec/README.md
+++ b/docs/spec/README.md
@@ -48,7 +48,7 @@ ClawBench 是移动端交互适配优先、桌面端完整支持的多端 AI 工
 | [事件体系](infra/event-system.md) | ws.Manager 系统广播、StreamHub 会话扇出、断线缓冲重放、摘要与权限事件推送 |
 | [应用自升级](infra/self-upgrade.md) | 版本检查、备份替换、进度推送、服务重启与断线轮询 |
 | [本地文件服务](infra/local-file-serving.md) | `/api/local-file/` 路径编码、媒体预览、下载与访问边界、目录树列表、批量文件存在检查、批量图片 Base64 |
-| [Docker 部署](infra/docker-deployment.md) | 单阶段运行时镜像、数据卷持久化、GHCR 双架构发布、容器内禁用自升级 |
+| [Docker 部署](infra/docker-deployment.md) | 单阶段运行时镜像、数据卷持久化、GHCR 双架构发布、容器内升级提示镜像优先 |
 | [系统资源监控](infra/system-resources.md) | CPU/内存/磁盘/磁盘 I/O/网络/系统负载实时采集、gopsutil 采样、500ms 缓存、前台/后台双速轮询、AppHeader 压力指示图标、WS 断线状态展示、Gauge 弹出面板 |
 | [CLI 子命令](infra/cli-reference.md) | HTTP API 路由架构、task/rag/upgrade-replace 子命令、@path 文件语法、防递归守卫、Cookie Token 认证 |
 | [Bugfix 工作流](infra/bugfix-workflow.md) | 自动化 bugfix 生命周期：扫描分类→worktree 隔离修复→测试验证→PR+CI→合并关闭 |

--- a/docs/spec/infra/docker-deployment.md
+++ b/docs/spec/infra/docker-deployment.md
@@ -1,6 +1,6 @@
 # Docker 部署
 
-ClawBench 提供单二进制 + 嵌入前端的 Docker 镜像，一条 `docker compose up` 即可运行。所有运行时状态写入 Docker 卷，容器销毁后数据不丢失。容器内自升级被禁用，升级通过拉取新镜像完成——这与[应用自升级](self-upgrade.md)的二进制替换策略形成互补。
+ClawBench 提供单二进制 + 嵌入前端的 Docker 镜像，一条 `docker compose up` 即可运行。所有运行时状态写入 Docker 卷，容器销毁后数据不丢失。容器内自升级可用但**不推荐**：升级界面会提示优先拉取新镜像，因为镜像才是版本的权威来源——这与[应用自升级](self-upgrade.md)的二进制替换策略形成互补。
 
 ## 流程图
 
@@ -38,7 +38,8 @@ flowchart LR
 ### 设计要点
 
 - **单阶段运行时镜像**：运行时镜像基于 Ubuntu 24.04，包含 Node.js（11/12 个 AI Agent 通过 npm 安装）、git（AI Agent 常用）、ca-certificates（HTTPS 通信）和 curl。前端已嵌入 Go 二进制，无需额外前端层
-- **容器内禁用自升级**：检测到 Docker 环境（`/.dockerenv` 或 `container` 环境变量）时，升级服务拒绝二进制替换，提示用户拉取新镜像——容器应该是不可变镜像，不应在运行时替换自身
+- **容器内自升级（不推荐）**：检测到 Docker/Podman 环境（`/.dockerenv`、`/run/.containerenv` 或 `container` 环境变量）时，升级界面显示提示，建议改用 `docker pull` + `docker compose up -d` 更新镜像。就地升级本身仍可执行（替换容器可写层的二进制并触发重启），但用未更新的镜像重建容器会回退到旧版本，因此镜像拉取才是权威升级路径。`/api/upgrade/check` 返回 `is_docker` 供前端展示该提示
+- **容器内强制走就地替换 + 重启策略**：容器（含 Kubernetes）一律按"受托管"处理，跳过自重启子进程路径。该路径在容器里必然失败——PID 1 退出时运行时拆除命名空间，会杀掉等待替换的 `upgrade-replace` 子进程。检测统一由 `platform.IsContainer` / `platform.IsDockerLike` 提供
 - **密码通过卷持久化**：auto-password 写入 `/data/.clawbench/auto-password`（卷内），容器重启后密码不变
-- **重启策略 unless-stopped**：主机重启或 Docker daemon 重启后容器自动恢复，但 `docker compose stop` 后不自动启动
+- **重启策略必须是 always / unless-stopped**：主机重启或 Docker daemon 重启后容器自动恢复（`docker compose stop` 后不自动启动）。该策略同时是**应用内升级的前提**：升级会替换容器可写层中的二进制并以退出码 0 优雅退出，依赖重启策略拉起新版本。`--restart on-failure` 不满足——退出码为 0 不会触发重启，容器会停在停止状态
 - **docker-build.sh 一键构建**：本地开发时自动编译二进制、构建镜像、启动容器并显示密码。`--clean` 选项可清除数据卷做干净重置

--- a/docs/spec/infra/self-upgrade.md
+++ b/docs/spec/infra/self-upgrade.md
@@ -44,4 +44,7 @@ sequenceDiagram
 - **检查与执行分离**：检查端点只提供版本决策，执行阶段重新完成必要校验，避免检查与替换之间的状态变化
 - **备份优先于替换**：升级状态暴露备份路径，使失败恢复和人工排障有明确落点
 - **WS 优先、轮询兜底**：正常阶段使用低延迟事件，进程重启阶段使用无状态 HTTP 查询，两种通道覆盖升级的完整生命周期
+- **容器内强制走就地替换路径**：容器（Docker / Podman / Kubernetes，经 `platform.IsContainer` 判定）一律视为"受托管"，走就地替换 + 退出，由容器重启策略拉起新版本。该判定优先于 supervisor 探测——k8s / runit / supervisord 探测不到时会错误地指向自重启子进程路径，而该路径在容器中必然失败：PID 1 退出时运行时会拆除命名空间并杀掉 `upgrade-replace` 子进程，替换永远执行不到，服务静默回到旧二进制。同样的强制也适用于 `IsRunningUnderSupervisor()`，从而覆盖配置面板重启（哨兵进程同样会被容器拆除杀掉）
+- **容器类型区分提示与决策**：`platform.IsDockerLike`（Docker/Podman）用于 UI 提示，`platform.IsContainer`（含 k8s）用于路径决策。k8s Pod 是容器（自重启不可行）但 Docker CLI 建议不适用，故 `/api/upgrade/check` 的 `is_docker` 只对 Docker/Podman 为真
+- **Docker 环境提示而非拒绝**：`/api/upgrade/check` 返回 `is_docker` 时，升级界面提示改用 `docker pull` + `docker compose up -d`。就地升级仍可执行，但镜像重建会回退版本，因此镜像拉取才是权威路径。就地升级依赖容器重启策略拉起新版本，且必须为 `always` / `unless-stopped`——优雅退出码为 0，`on-failure` 不会触发（详见 [Docker 部署](docker-deployment.md)）
 - **所有升级端点均鉴权**：二进制替换是高权限操作，不能使用公开状态接口

--- a/docs/timer/deploy.md
+++ b/docs/timer/deploy.md
@@ -158,6 +158,7 @@ cd "$NPM_DIR"
 docker build -t clawbench-npm:latest .
 docker run -d \
   --name clawbench-npm \
+  --restart unless-stopped \
   -p 20500:20500 \
   -v clawbench-npm-data:/data \
   clawbench-npm:latest
@@ -198,6 +199,7 @@ docker stop clawbench-image 2>/dev/null && docker rm clawbench-image 2>/dev/null
 docker pull ghcr.io/clawbench-dev/clawbench:$NEW_TAG
 docker run -d \
   --name clawbench-image \
+  --restart unless-stopped \
   -p 20400:20000 \
   -v clawbench-image-data:/data \
   ghcr.io/clawbench-dev/clawbench:$NEW_TAG
@@ -243,3 +245,4 @@ echo "Docker 镜像版 (port 20400) 密码: $IMG_PASS"
 - NPM 安装使用官方 registry `https://registry.npmjs.org`（不使用国内镜像，因 npmmirror 同步延迟可能导致平台包 404）
 - NPM 安装需显式安装平台包 `@xulongzhe/clawbench-linux-x64`，主包不会自动安装可选依赖
 - Docker 镜像的 GHCR 地址是 `ghcr.io/clawbench-dev/clawbench`（GitHub 仓库的 organization 是 `clawbench-dev`）
+- Docker 容器必须带 `--restart unless-stopped`（或 `always`）：应用内升级会替换自身二进制并以退出码 0 退出，靠重启策略拉起新版本。`--restart on-failure` 不生效（退出码为 0 不触发重启）

--- a/internal/ai/accumulate.go
+++ b/internal/ai/accumulate.go
@@ -23,9 +23,14 @@ import (
 //nolint:gocognit,gocyclo // complex stream parsing logic
 func AccumulateBlock(blocks *[]model.ContentBlock, event StreamEvent) {
 	// findLastBlockOfType searches backward for the most recent block of the
-	// given type, but stops at tool_use boundaries (they are natural separators).
-	findLastBlockOfType := func(typ string) (int, bool) {
+	// given type, but stops at tool_use boundaries (they are natural separators)
+	// and at a sub-agent parent boundary (a block belonging to a different
+	// parent — or top-level — must not absorb a sub-agent's deltas).
+	findLastBlockOfType := func(typ, parent string) (int, bool) {
 		for i := len(*blocks) - 1; i >= 0; i-- {
+			if (*blocks)[i].ParentToolCallID != parent {
+				return -1, false
+			}
 			if (*blocks)[i].Type == typ {
 				return i, true
 			}
@@ -39,18 +44,20 @@ func AccumulateBlock(blocks *[]model.ContentBlock, event StreamEvent) {
 
 	switch event.Type {
 	case "content":
+		parent := event.ParentToolCallID
 		// Coalesce incremental content deltas into the most recent text block.
-		if idx, found := findLastBlockOfType("text"); found {
+		if idx, found := findLastBlockOfType("text", parent); found {
 			(*blocks)[idx].Text += event.Content
 		} else {
-			*blocks = append(*blocks, model.ContentBlock{Type: "text", Text: event.Content})
+			*blocks = append(*blocks, model.ContentBlock{Type: "text", Text: event.Content, ParentToolCallID: parent})
 		}
 	case "thinking":
+		parent := event.ParentToolCallID
 		// Coalesce incremental thinking deltas into the most recent thinking block.
-		if idx, found := findLastBlockOfType("thinking"); found {
+		if idx, found := findLastBlockOfType("thinking", parent); found {
 			(*blocks)[idx].Text += event.Content
 		} else {
-			*blocks = append(*blocks, model.ContentBlock{Type: "thinking", Text: event.Content})
+			*blocks = append(*blocks, model.ContentBlock{Type: "thinking", Text: event.Content, ParentToolCallID: parent})
 		}
 	case "thinking_done":
 		// Mark the last thinking block as done — the thinking content is complete.
@@ -115,14 +122,15 @@ func AccumulateBlock(blocks *[]model.ContentBlock, event StreamEvent) {
 					input = make(map[string]any)
 				}
 				*blocks = append(*blocks, model.ContentBlock{
-					Type:       "tool_use",
-					Name:       event.Tool.Name,
-					ID:         event.Tool.ID,
-					Input:      input,
-					Done:       event.Tool.Done,
-					Output:     event.Tool.Output,
-					Status:     event.Tool.Status,
-					DurationMs: event.Tool.DurationMs,
+					Type:             "tool_use",
+					Name:             event.Tool.Name,
+					ID:               event.Tool.ID,
+					Input:            input,
+					Done:             event.Tool.Done,
+					Output:           event.Tool.Output,
+					Status:           event.Tool.Status,
+					DurationMs:       event.Tool.DurationMs,
+					ParentToolCallID: event.Tool.ParentToolCallID,
 				})
 				upsertToolCallMeta(&(*blocks)[len(*blocks)-1])
 			}
@@ -205,6 +213,12 @@ func MergeConsecutiveThinkingBlocks(blocks []model.ContentBlock) []model.Content
 
 	for _, b := range blocks {
 		if b.Type == "thinking" {
+			// Do not merge across a sub-agent parent boundary: a top-level
+			// thinking block and a sub-agent thinking block (or two different
+			// sub-agents) are distinct and must stay separate for grouping.
+			if currentThinking != nil && currentThinking.ParentToolCallID != b.ParentToolCallID {
+				flushThinking()
+			}
 			if currentThinking != nil {
 				currentThinking.Text += b.Text
 				// If any merged block is done, the combined block is done

--- a/internal/ai/accumulate_test.go
+++ b/internal/ai/accumulate_test.go
@@ -6,6 +6,7 @@ import (
 	"clawbench/internal/model"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestAccumulateBlock_Content(t *testing.T) {
@@ -774,4 +775,72 @@ func TestMergeConsecutiveThinkingBlocks_TwoBlocks(t *testing.T) {
 	result := MergeConsecutiveThinkingBlocks(blocks)
 	assert.Len(t, result, 1)
 	assert.Equal(t, "ab", result[0].Text)
+}
+
+// --- Sub-agent parent boundary tests ---
+
+func TestAccumulateBlock_SubAgentThinkingDoesNotMergeIntoParent(t *testing.T) {
+	var blocks []model.ContentBlock
+	// Parent thinking
+	AccumulateBlock(&blocks, StreamEvent{Type: "thinking", Content: "parent think"})
+	// Child thinking (different parent) must start a NEW block
+	AccumulateBlock(&blocks, StreamEvent{Type: "thinking", Content: "child think", ParentToolCallID: "call_a"})
+	// More child thinking merges into the child block
+	AccumulateBlock(&blocks, StreamEvent{Type: "thinking", Content: " more", ParentToolCallID: "call_a"})
+
+	require.Len(t, blocks, 2)
+	assert.Equal(t, "", blocks[0].ParentToolCallID)
+	assert.Equal(t, "parent think", blocks[0].Text)
+	assert.Equal(t, "call_a", blocks[1].ParentToolCallID)
+	assert.Equal(t, "child think more", blocks[1].Text)
+}
+
+func TestAccumulateBlock_TwoSubAgentsStaySeparate(t *testing.T) {
+	var blocks []model.ContentBlock
+	AccumulateBlock(&blocks, StreamEvent{Type: "content", Content: "A", ParentToolCallID: "call_a"})
+	AccumulateBlock(&blocks, StreamEvent{Type: "content", Content: "B", ParentToolCallID: "call_b"})
+	AccumulateBlock(&blocks, StreamEvent{Type: "content", Content: "A2", ParentToolCallID: "call_a"})
+	// call_a's second chunk must NOT merge back into its first block (blocked by
+	// the interleaved call_b block + parent boundary), so a third block is made.
+	require.Len(t, blocks, 3)
+	assert.Equal(t, "call_a", blocks[0].ParentToolCallID)
+	assert.Equal(t, "call_b", blocks[1].ParentToolCallID)
+	assert.Equal(t, "call_a", blocks[2].ParentToolCallID)
+}
+
+func TestAccumulateBlock_ToolCallCarriesParent(t *testing.T) {
+	var blocks []model.ContentBlock
+	AccumulateBlock(&blocks, StreamEvent{Type: "tool_use", Tool: &ToolCall{
+		Name: "Read", ID: "t1", ParentToolCallID: "call_parent",
+	}})
+	require.Len(t, blocks, 1)
+	assert.Equal(t, "call_parent", blocks[0].ParentToolCallID)
+}
+
+func TestMergeConsecutiveThinkingBlocks_DoesNotMergeAcrossParent(t *testing.T) {
+	blocks := []model.ContentBlock{
+		{Type: "thinking", Text: "p1"},
+		{Type: "tool_use", Name: "Read", ID: "t1"},
+		{Type: "thinking", Text: "c1", ParentToolCallID: "call_a"},
+		{Type: "tool_use", Name: "Grep", ID: "t2"},
+		{Type: "thinking", Text: "p2"},
+	}
+	merged := MergeConsecutiveThinkingBlocks(blocks)
+	// p1 and p2 are top-level but separated by tool_use blocks → stay separate.
+	// c1 stays distinct (different parent). Verify no parent-crossing merge.
+	for _, b := range merged {
+		if b.Type == "thinking" {
+			assert.NotEqual(t, "p1c1", b.Text)
+			assert.NotEqual(t, "c1p2", b.Text)
+		}
+	}
+	// The sub-agent thinking block keeps its parent.
+	var found bool
+	for _, b := range merged {
+		if b.Type == "thinking" && b.Text == "c1" {
+			found = true
+			assert.Equal(t, "call_a", b.ParentToolCallID)
+		}
+	}
+	assert.True(t, found, "sub-agent thinking block should survive")
 }

--- a/internal/ai/acp_debounce.go
+++ b/internal/ai/acp_debounce.go
@@ -71,6 +71,11 @@ func (d *toolCallDebouncer) handleToolCallUpdate(tcu acp.SessionToolCallUpdate) 
 			if event.Tool.Input == "" && existing.event.Tool.Input != "" {
 				event.Tool.Input = existing.event.Tool.Input
 			}
+			// Preserve the sub-agent parent link if this delta omitted it (some
+			// ACP updates carry only toolResponse/_meta without the parent key).
+			if event.Tool.ParentToolCallID == "" && existing.event.Tool.ParentToolCallID != "" {
+				event.Tool.ParentToolCallID = existing.event.Tool.ParentToolCallID
+			}
 		}
 		if event.ToolMeta == nil && existing.event.ToolMeta != nil {
 			event.ToolMeta = existing.event.ToolMeta

--- a/internal/ai/acp_debounce_test.go
+++ b/internal/ai/acp_debounce_test.go
@@ -648,3 +648,35 @@ func assertNoEvents(t *testing.T, ch <-chan StreamEvent) {
 		// expected — slightly longer than debounce interval to be sure
 	}
 }
+
+// --- handleToolCallUpdate: sub-agent parent link survives merging ---
+
+func TestHandleToolCallUpdate_PreservesParentAcrossMerge(t *testing.T) {
+	d, ch := newTestDebouncer()
+
+	// First update carries the parent link.
+	status := acp.ToolCallStatusInProgress
+	tcu1 := acp.SessionToolCallUpdate{
+		ToolCallId: acp.ToolCallId("tool-sub"),
+		Status:     &status,
+		Meta:       map[string]any{"codebuddy.ai/parentToolCallId": "call_parent"},
+	}
+	d.handleToolCallUpdate(tcu1)
+
+	// Second update for the same tool OMITS the parent key (some ACP updates
+	// carry only toolResponse/_meta without it). The merge must preserve it.
+	tcu2 := acp.SessionToolCallUpdate{
+		ToolCallId: acp.ToolCallId("tool-sub"),
+		Status:     &status,
+	}
+	d.handleToolCallUpdate(tcu2)
+
+	select {
+	case evt := <-ch:
+		require.NotNil(t, evt.Tool)
+		assert.Equal(t, "call_parent", evt.Tool.ParentToolCallID,
+			"parent link must survive a merge that omits it")
+	case <-time.After(500 * time.Millisecond):
+		t.Fatal("event was not forwarded after debounce interval")
+	}
+}

--- a/internal/ai/acp_events.go
+++ b/internal/ai/acp_events.go
@@ -77,8 +77,9 @@ func mapACPSessionUpdate(update acp.SessionUpdate, ch chan<- StreamEvent, ctx co
 			}
 		}
 		if !replayed {
+			parentID := extractParentToolCallID(backendID, update.AgentMessageChunk.Meta)
 			if content.Text != nil {
-				forwardACPEvent(ch, StreamEvent{Type: "content", Content: content.Text.Text})
+				forwardACPEvent(ch, StreamEvent{Type: "content", Content: content.Text.Text, ParentToolCallID: parentID})
 			}
 			// Per-agent _meta on the chunk (e.g. CodeBuddy OpenAI-style usage +
 			// codebuddy.ai/* trace) — accumulate onto the connection so the
@@ -91,7 +92,8 @@ func mapACPSessionUpdate(update acp.SessionUpdate, ch chan<- StreamEvent, ctx co
 	case update.AgentThoughtChunk != nil:
 		content := update.AgentThoughtChunk.Content
 		if content.Text != nil {
-			forwardACPEvent(ch, StreamEvent{Type: "thinking", Content: content.Text.Text})
+			parentID := extractParentToolCallID(backendID, update.AgentThoughtChunk.Meta)
+			forwardACPEvent(ch, StreamEvent{Type: "thinking", Content: content.Text.Text, ParentToolCallID: parentID})
 		}
 
 	case update.ToolCall != nil:

--- a/internal/ai/acp_events_test.go
+++ b/internal/ai/acp_events_test.go
@@ -1550,3 +1550,96 @@ func TestMapACPSessionUpdate_UsageUpdate_WithoutCost(t *testing.T) {
 	}
 	assert.True(t, foundUsage, "usage_update event not found")
 }
+
+// --- Sub-agent parent linkage threading ---
+
+func TestMapACPSessionUpdate_ThinkingCarriesParentLink(t *testing.T) {
+	ch := make(chan StreamEvent, 10)
+	text := "child reasoning"
+	update := acp.SessionUpdate{
+		AgentThoughtChunk: &acp.SessionUpdateAgentThoughtChunk{
+			Meta:          map[string]any{"codebuddy.ai/parentToolCallId": "call_parent_1"},
+			Content:       acp.ContentBlock{Text: &acp.ContentBlockText{Text: text, Type: "text"}},
+			SessionUpdate: "agent_thought_chunk",
+		},
+	}
+	mapACPSessionUpdate(update, ch, context.Background(), nil, nil)
+	evt := <-ch
+	assert.Equal(t, "thinking", evt.Type)
+	assert.Equal(t, text, evt.Content)
+	assert.Equal(t, "call_parent_1", evt.ParentToolCallID)
+}
+
+func TestMapACPSessionUpdate_ContentCarriesParentLink(t *testing.T) {
+	ch := make(chan StreamEvent, 10)
+	text := "child text"
+	update := acp.SessionUpdate{
+		AgentMessageChunk: &acp.SessionUpdateAgentMessageChunk{
+			Meta:          map[string]any{"codebuddy.ai/parentToolCallId": "call_parent_2"},
+			Content:       acp.ContentBlock{Text: &acp.ContentBlockText{Text: text, Type: "text"}},
+			SessionUpdate: "agent_message_chunk",
+		},
+	}
+	mapACPSessionUpdate(update, ch, context.Background(), nil, nil)
+	// First event may be thinking_done; drain until content.
+	var got *StreamEvent
+	for len(ch) > 0 {
+		e := <-ch
+		if e.Type == "content" {
+			got = &e
+		}
+	}
+	require.NotNil(t, got)
+	assert.Equal(t, text, got.Content)
+	assert.Equal(t, "call_parent_2", got.ParentToolCallID)
+}
+
+func TestMapACPSessionUpdate_TopLevelContentHasNoParent(t *testing.T) {
+	ch := make(chan StreamEvent, 10)
+	text := "parent text"
+	update := acp.SessionUpdate{
+		AgentMessageChunk: &acp.SessionUpdateAgentMessageChunk{
+			Meta:          map[string]any{"codebuddy.ai/requestId": "r1"},
+			Content:       acp.ContentBlock{Text: &acp.ContentBlockText{Text: text, Type: "text"}},
+			SessionUpdate: "agent_message_chunk",
+		},
+	}
+	mapACPSessionUpdate(update, ch, context.Background(), nil, nil)
+	for len(ch) > 0 {
+		e := <-ch
+		if e.Type == "content" {
+			assert.Equal(t, "", e.ParentToolCallID)
+		}
+	}
+}
+
+func TestMapACPToolCallUpdate_CarriesParentLink(t *testing.T) {
+	id := "call_child_tool"
+	tcu := acp.SessionToolCallUpdate{
+		ToolCallId: acp.ToolCallId(id),
+		Meta:       map[string]any{"codebuddy.ai/parentToolCallId": "call_parent_3", "codebuddy.ai/toolName": "Read"},
+	}
+	evt := mapACPToolCallUpdate(tcu, "codebuddy")
+	require.NotNil(t, evt.Tool)
+	assert.Equal(t, "call_parent_3", evt.Tool.ParentToolCallID)
+}
+
+func TestMapACPToolCall_CarriesParentLink(t *testing.T) {
+	tc := acp.SessionUpdateToolCall{
+		ToolCallId: acp.ToolCallId("call_child_start"),
+		Meta:       map[string]any{"codebuddy.ai/parentToolCallId": "call_parent_4", "codebuddy.ai/toolName": "Grep"},
+	}
+	evt := mapACPToolCall(tc, "codebuddy")
+	require.NotNil(t, evt.Tool)
+	assert.Equal(t, "call_parent_4", evt.Tool.ParentToolCallID)
+}
+
+func TestMapACPToolCall_ClaudeParentToolUseID(t *testing.T) {
+	tc := acp.SessionUpdateToolCall{
+		ToolCallId: acp.ToolCallId("call_child_claude"),
+		Meta:       map[string]any{"claudeCode": map[string]any{"parentToolUseId": "toolu_parent_9", "toolName": "Read"}},
+	}
+	evt := mapACPToolCall(tc, "claude")
+	require.NotNil(t, evt.Tool)
+	assert.Equal(t, "toolu_parent_9", evt.Tool.ParentToolCallID)
+}

--- a/internal/ai/acp_parent_link.go
+++ b/internal/ai/acp_parent_link.go
@@ -1,0 +1,60 @@
+package ai
+
+// ---------------------------------------------------------------------------
+// Sub-agent parent linkage
+// ---------------------------------------------------------------------------
+//
+// Several ACP agents tag content produced *by a sub-agent* with a `_meta` key
+// pointing at the parent tool call that spawned it. ClawBench uses this to group
+// a sub-agent's thinking/text/tool calls under the parent Agent card in the UI.
+//
+// Known encodings (verified against real wire captures):
+//   - codebuddy: flat key `codebuddy.ai/parentToolCallId` on every child
+//     agent_thought_chunk / agent_message_chunk / tool_call(_update). The parent
+//     agent's own content carries no such key. (session cfe979e6: 963 child
+//     thinking + 3484 child text + 111 child tools all tagged; parent content
+//     untagged.)
+//   - claude/qoder: nested `_meta.claudeCode.parentToolUseId` (stamped by
+//     claude-agent-acp's toAcpNotifications). The bridge currently filters most
+//     sub-agent text/thinking out of the parent wire, so this mostly surfaces on
+//     child tool calls / images, but the field is the generic analog.
+//
+// The extracted value is the parent tool-call id (e.g. "call_00_..."), or "" when
+// the event is not sub-agent content. An empty value means "top-level".
+
+const (
+	// metaKeyCodeBuddyParentToolCallID is the flat codebuddy key stamped on
+	// sub-agent content.
+	metaKeyCodeBuddyParentToolCallID = "codebuddy.ai/parentToolCallId"
+	// metaKeyClaudeParentToolUseID is the nested claudeCode key stamped on
+	// sub-agent content.
+	metaKeyClaudeParentToolUseID = "parentToolUseId"
+)
+
+// extractParentToolCallID returns the id of the parent tool call that spawned
+// the sub-agent which produced this event, or "" for top-level (non-sub-agent)
+// content. backendID selects the per-agent meta encoding.
+func extractParentToolCallID(backendID string, meta map[string]any) string {
+	if len(meta) == 0 {
+		return ""
+	}
+	switch backendID {
+	case "codebuddy":
+		return metaString(meta[metaKeyCodeBuddyParentToolCallID])
+	case "claude", "qoder":
+		if ns, ok := meta["claudeCode"].(map[string]any); ok {
+			return metaString(ns[metaKeyClaudeParentToolUseID])
+		}
+		return ""
+	default:
+		// Unknown/other backends: best-effort — accept either encoding so a new
+		// agent reusing one of the conventions still groups correctly.
+		if v := metaString(meta[metaKeyCodeBuddyParentToolCallID]); v != "" {
+			return v
+		}
+		if ns, ok := meta["claudeCode"].(map[string]any); ok {
+			return metaString(ns[metaKeyClaudeParentToolUseID])
+		}
+		return ""
+	}
+}

--- a/internal/ai/acp_parent_link_test.go
+++ b/internal/ai/acp_parent_link_test.go
@@ -1,0 +1,55 @@
+package ai
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestExtractParentToolCallID(t *testing.T) {
+	t.Run("codebuddy flat key", func(t *testing.T) {
+		meta := map[string]any{"codebuddy.ai/parentToolCallId": "call_00_abc"}
+		assert.Equal(t, "call_00_abc", extractParentToolCallID("codebuddy", meta))
+	})
+
+	t.Run("codebuddy no parent key is top-level", func(t *testing.T) {
+		meta := map[string]any{"codebuddy.ai/toolName": "Read", "codebuddy.ai/requestId": "r1"}
+		assert.Equal(t, "", extractParentToolCallID("codebuddy", meta))
+	})
+
+	t.Run("claude nested claudeCode.parentToolUseId", func(t *testing.T) {
+		meta := map[string]any{"claudeCode": map[string]any{"parentToolUseId": "toolu_123", "toolName": "Read"}}
+		assert.Equal(t, "toolu_123", extractParentToolCallID("claude", meta))
+	})
+
+	t.Run("qoder shares claude encoding", func(t *testing.T) {
+		meta := map[string]any{"claudeCode": map[string]any{"parentToolUseId": "toolu_456"}}
+		assert.Equal(t, "toolu_456", extractParentToolCallID("qoder", meta))
+	})
+
+	t.Run("claude without parent is top-level", func(t *testing.T) {
+		meta := map[string]any{"claudeCode": map[string]any{"toolName": "Bash"}}
+		assert.Equal(t, "", extractParentToolCallID("claude", meta))
+	})
+
+	t.Run("claude claudeCode wrong shape does not panic", func(t *testing.T) {
+		meta := map[string]any{"claudeCode": "not-a-map"}
+		assert.Equal(t, "", extractParentToolCallID("claude", meta))
+	})
+
+	t.Run("nil and empty meta", func(t *testing.T) {
+		assert.Equal(t, "", extractParentToolCallID("codebuddy", nil))
+		assert.Equal(t, "", extractParentToolCallID("claude", map[string]any{}))
+	})
+
+	t.Run("unknown backend best-effort accepts either encoding", func(t *testing.T) {
+		assert.Equal(t, "call_x", extractParentToolCallID("grok", map[string]any{"codebuddy.ai/parentToolCallId": "call_x"}))
+		assert.Equal(t, "toolu_y", extractParentToolCallID("grok", map[string]any{"claudeCode": map[string]any{"parentToolUseId": "toolu_y"}}))
+		assert.Equal(t, "", extractParentToolCallID("grok", map[string]any{"other": "v"}))
+	})
+
+	t.Run("codex has no parent encoding", func(t *testing.T) {
+		meta := map[string]any{"codex": map[string]any{"subagent": map[string]any{"threadId": "t1"}}}
+		assert.Equal(t, "", extractParentToolCallID("codex", meta))
+	})
+}

--- a/internal/ai/acp_tool.go
+++ b/internal/ai/acp_tool.go
@@ -194,6 +194,7 @@ func acpRemapsForBackend(backendID string) map[string]string {
 // Delegates to parseACPToolCall for per-agent routing.
 func mapACPToolCall(tc acp.SessionUpdateToolCall, backendID string) StreamEvent {
 	tool := parseACPToolCall(backendID, tc)
+	attachParentToolCallIDToTool(tool, backendID, tc.Meta)
 	return StreamEvent{Type: "tool_use", Tool: tool}
 }
 
@@ -201,6 +202,7 @@ func mapACPToolCall(tc acp.SessionUpdateToolCall, backendID string) StreamEvent 
 // Delegates to parseACPToolCallUpdate for per-agent routing.
 func mapACPToolCallUpdate(tcu acp.SessionToolCallUpdate, backendID string) StreamEvent {
 	tool := parseACPToolCallUpdate(backendID, tcu)
+	attachParentToolCallIDToTool(tool, backendID, tcu.Meta)
 
 	eventType := "tool_use"
 	if tool.Done {
@@ -212,4 +214,16 @@ func mapACPToolCallUpdate(tcu acp.SessionToolCallUpdate, backendID string) Strea
 		"raw_input", fmt.Sprintf("%v", tcu.RawInput))
 
 	return StreamEvent{Type: eventType, Tool: tool}
+}
+
+// attachParentToolCallIDToTool stamps the sub-agent parent link (if any) onto a
+// parsed tool call. Shared by the start/update mappers so the debouncer path
+// (which also routes through mapACPToolCallUpdate) carries the link too.
+func attachParentToolCallIDToTool(tool *ToolCall, backendID string, meta map[string]any) {
+	if tool == nil {
+		return
+	}
+	if id := extractParentToolCallID(backendID, meta); id != "" {
+		tool.ParentToolCallID = id
+	}
 }

--- a/internal/ai/interface.go
+++ b/internal/ai/interface.go
@@ -343,6 +343,11 @@ type StreamEvent struct {
 	ToolMeta       *ToolCallMeta          // Extracted tool metadata for WS forwarding (Type=tool_use, Type=tool_result)
 	UserMessage    *UserMessageData       // User message for cross-device sync (Type=user_message)
 	StreamStart    *StreamStartData       // Stream start (Type=stream_start) — carries streaming message DB id
+	// ParentToolCallID is the parent Agent tool-call id for sub-agent content
+	// (Type=content, Type=thinking). Empty for top-level content. Extracted from
+	// the backend's _meta parent-link key; lets the frontend group a sub-agent's
+	// thinking/text under the Agent card that spawned it.
+	ParentToolCallID string `json:"parent_tool_call_id,omitempty"`
 }
 
 // StreamStartData carries the streaming message DB id for the stream_start event.
@@ -376,6 +381,11 @@ type ToolCall struct {
 	// Injected by SessionExecutor when the tool completes; backend parsers
 	// leave it 0 (unknown).
 	DurationMs int `json:"duration_ms,omitempty"`
+	// ParentToolCallID is the id of the parent Agent tool call that spawned the
+	// sub-agent which produced this tool call, or "" for top-level calls. Set
+	// by the ACP parse layer from the backend's _meta parent-link key (see
+	// acp_parent_link.go). Used to group sub-agent content in the UI.
+	ParentToolCallID string `json:"parent_tool_call_id,omitempty"`
 }
 
 // maxToolOutputBytes limits tool output stored per tool call to prevent

--- a/internal/ai/orphan.go
+++ b/internal/ai/orphan.go
@@ -24,10 +24,6 @@ import (
 // as a marker for orphan detection.
 const OrphanChildEnvVar = "CLAWBENCH_CHILD=1"
 
-// OrphanSupervisorVar is an older marker used by previous ClawBench versions.
-// Some long-running processes from before the env var rename may still carry it.
-const OrphanSupervisorVar = "CLAWBENCH_NO_SUPERVISOR=1"
-
 // orphanCmdlinePatterns are patterns that identify an orphan ACP agent process
 // by its command line. Each pattern is a pair of (binarySubstring, argSubstring).
 // Both must be present in the cmdline for a match. Used as a fallback when
@@ -41,9 +37,9 @@ var orphanCmdlinePatterns = [][2]string{
 // CleanupOrphans kills any AI subprocess left running after a previous
 // server crash. Called once at startup, before any new subprocesses spawn.
 //
-// On Linux: scans /proc/<pid>/environ for CLAWBENCH_CHILD=1 or
-// CLAWBENCH_NO_SUPERVISOR=1, and also checks /proc/<pid>/cmdline for
-// known ACP agent patterns (e.g., "--acp") as a fallback.
+// On Linux: scans /proc/<pid>/environ for CLAWBENCH_CHILD=1, and also checks
+// /proc/<pid>/cmdline for known ACP agent patterns (e.g., "--acp") as a
+// fallback.
 // Processes whose parent is still alive are skipped — they are actively
 // managed, not orphans.
 // On macOS/Windows: no-op (orphaned processes exit when stdin pipe closes).
@@ -54,7 +50,6 @@ func CleanupOrphans() {
 	// marker), strip it now so it does not propagate to our own children
 	// (terminals, agents) and does not mark this server as an orphan later.
 	_ = os.Unsetenv(strings.SplitN(OrphanChildEnvVar, "=", 2)[0])
-	_ = os.Unsetenv(strings.SplitN(OrphanSupervisorVar, "=", 2)[0])
 
 	if runtime.GOOS != "linux" {
 		return
@@ -119,7 +114,7 @@ func isOrphanProcess(entryName string) (isOrphan, parentAlive bool) {
 		return false, false // permission denied or process exited
 	}
 
-	matched := hasClawBenchChildMarker(data) || hasClawBenchSupervisorMarker(data)
+	matched := hasClawBenchChildMarker(data)
 
 	if !matched {
 		// Fallback: check cmdline for known ACP agent patterns
@@ -240,12 +235,6 @@ func isClawBenchServerProcess(cmdData []byte) bool {
 // null bytes (\0) as delimiters between entries.
 func hasClawBenchChildMarker(environData []byte) bool {
 	return bytesContainsSep(environData, []byte(OrphanChildEnvVar), 0)
-}
-
-// hasClawBenchSupervisorMarker checks for the older CLAWBENCH_NO_SUPERVISOR=1
-// marker used by previous ClawBench versions.
-func hasClawBenchSupervisorMarker(environData []byte) bool {
-	return bytesContainsSep(environData, []byte(OrphanSupervisorVar), 0)
 }
 
 // hasOrphanCmdlinePattern checks if the /proc/<pid>/cmdline data contains

--- a/internal/handler/settings.go
+++ b/internal/handler/settings.go
@@ -24,6 +24,7 @@ import (
 	"unicode/utf8"
 
 	"clawbench/internal/model"
+	"clawbench/internal/platform"
 	"clawbench/internal/speech"
 	"clawbench/internal/version"
 
@@ -1695,10 +1696,15 @@ func LaunchSentinelProcess() (*exec.Cmd, error) {
 	return launchSentinel()
 }
 
-// IsRunningUnderSupervisor detects if the process is managed by systemd, Docker, etc.
+// IsRunningUnderSupervisor detects if the process is managed by a supervisor
+// that will restart it after exit: systemd, Docker/Podman, Kubernetes, etc.
+//
+// A container is reported as supervised unconditionally: the runtime destroys
+// the namespace when PID 1 exits, so a sentinel child would be killed before it
+// could restart anything — the runtime's restart policy is the only recovery.
 func IsRunningUnderSupervisor() bool {
-	if os.Getenv("CLAWBENCH_NO_SUPERVISOR") != "" {
-		return false
+	if isContainerized() {
+		return true
 	}
 	// systemd: only a process that IS the MainPID of its unit is actually
 	// supervised. Merely inheriting INVOCATION_ID is not enough — a process
@@ -1711,14 +1717,7 @@ func IsRunningUnderSupervisor() bool {
 		if mainPID != "" && mainPID == strconv.Itoa(os.Getpid()) {
 			return true
 		}
-		// Member of a unit but not its MainPID → not supervised. Keep going
-		// so the container branches below get a chance to decide.
-	}
-	if os.Getenv("container") != "" {
-		return true
-	}
-	if _, err := os.Stat("/.dockerenv"); err == nil {
-		return true
+		// Member of a unit but not its MainPID → not supervised.
 	}
 	// NOTE: PPid==1 (re-parented to init) is NOT evidence of a supervisor. It
 	// happens whenever the parent dies — e.g. a server launched by the restart
@@ -1727,6 +1726,11 @@ func IsRunningUnderSupervisor() bool {
 	// shut down, leaving the service permanently down.
 	return false
 }
+
+// isContainerized reports whether the process runs inside a container. It is a
+// package-level var so tests can force the container branch without a real
+// container.
+var isContainerized = platform.IsContainer
 
 // systemdCgroupPath points at the cgroup file used to discover the current
 // systemd unit. It is a package-level var so tests can point it at fixtures.

--- a/internal/handler/settings_coverage_test.go
+++ b/internal/handler/settings_coverage_test.go
@@ -43,7 +43,6 @@ func TestShellQuote_EmptyVal(t *testing.T) {
 // --- IsRunningUnderSupervisor: container env var ---
 
 func TestIsRunningUnderSupervisor_ContainerEnvVar(t *testing.T) {
-	t.Setenv("CLAWBENCH_NO_SUPERVISOR", "")
 	t.Setenv("container", "docker")
 	assert.True(t, IsRunningUnderSupervisor())
 }

--- a/internal/handler/settings_sentinel_test.go
+++ b/internal/handler/settings_sentinel_test.go
@@ -18,10 +18,23 @@ import (
 
 // ---------- IsRunningUnderSupervisor ----------
 
-func TestIsRunningUnderSupervisor_CLAWBENCH_NO_SUPERVISOR(t *testing.T) {
-	t.Setenv("CLAWBENCH_NO_SUPERVISOR", "1")
+// The container signal alone must be enough for an unrecognized runtime
+// (k8s, runit, supervisord): no systemd unit, no other indicator.
+func TestIsRunningUnderSupervisor_ContainerWithoutSystemdUnit(t *testing.T) {
+	orig := isContainerized
+	isContainerized = func() bool { return true }
+	defer func() { isContainerized = orig }()
+	t.Setenv("INVOCATION_ID", "")
+	t.Setenv("container", "")
+	systemdCgroupPath = filepath.Join(testdataDir(), "cgroup-empty")
+	systemctlShowFunc = func(string) string { return "" }
+	defer func() {
+		systemdCgroupPath = "/proc/self/cgroup"
+		systemctlShowFunc = systemctlShowMainPID
+	}()
 
-	assert.False(t, IsRunningUnderSupervisor(), "CLAWBENCH_NO_SUPERVISOR=1 should return false")
+	assert.True(t, IsRunningUnderSupervisor(),
+		"container with no systemd unit must still be supervised")
 }
 
 // INVOCATION_ID alone must NOT imply supervision: a process started from a
@@ -35,7 +48,6 @@ func TestIsRunningUnderSupervisor_INVOCATION_ID(t *testing.T) {
 		systemdCgroupPath = "/proc/self/cgroup"
 		systemctlShowFunc = systemctlShowMainPID
 	}()
-	t.Setenv("CLAWBENCH_NO_SUPERVISOR", "")
 	t.Setenv("INVOCATION_ID", "test-id")
 	t.Setenv("container", "")
 
@@ -43,14 +55,12 @@ func TestIsRunningUnderSupervisor_INVOCATION_ID(t *testing.T) {
 }
 
 func TestIsRunningUnderSupervisor_ContainerEnv(t *testing.T) {
-	t.Setenv("CLAWBENCH_NO_SUPERVISOR", "")
 	t.Setenv("container", "docker")
 
 	assert.True(t, IsRunningUnderSupervisor(), "container env set should return true")
 }
 
 func TestIsRunningUnderSupervisor_NoIndicators(t *testing.T) {
-	t.Setenv("CLAWBENCH_NO_SUPERVISOR", "")
 	t.Setenv("INVOCATION_ID", "")
 	t.Setenv("container", "")
 
@@ -63,7 +73,6 @@ func TestIsRunningUnderSupervisor_NoIndicators(t *testing.T) {
 }
 
 func TestIsRunningUnderSupervisor_DockerenvFile(t *testing.T) {
-	t.Setenv("CLAWBENCH_NO_SUPERVISOR", "")
 	t.Setenv("INVOCATION_ID", "")
 	t.Setenv("container", "")
 
@@ -130,9 +139,9 @@ func TestIsRunningUnderSupervisorHelper(t *testing.T) {
 	// Give the intermediate sh time to exit so we are truly re-parented to PID 1.
 	time.Sleep(500 * time.Millisecond)
 
-	os.Unsetenv("CLAWBENCH_NO_SUPERVISOR")
 	os.Unsetenv("INVOCATION_ID")
 	os.Unsetenv("container")
+	os.Unsetenv("KUBERNETES_SERVICE_HOST")
 
 	result := "not_supervised"
 	if IsRunningUnderSupervisor() {

--- a/internal/handler/settings_supervisor_test.go
+++ b/internal/handler/settings_supervisor_test.go
@@ -34,8 +34,8 @@ func stubSupervisorProbe(cgroupFixture string, mainPID func(unit string) string)
 
 func clearSupervisorEnv(t *testing.T) {
 	t.Helper()
-	t.Setenv("CLAWBENCH_NO_SUPERVISOR", "")
 	t.Setenv("container", "")
+	t.Setenv("KUBERNETES_SERVICE_HOST", "")
 }
 
 // ---------- currentSystemdUnit ----------

--- a/internal/handler/settings_test.go
+++ b/internal/handler/settings_test.go
@@ -1462,12 +1462,6 @@ func TestServeConfigPatch_NoExistingConfig(t *testing.T) {
 
 // --- IsRunningUnderSupervisor ---
 
-func TestIsRunningUnderSupervisor_EnvOverride(t *testing.T) {
-	t.Setenv("CLAWBENCH_NO_SUPERVISOR", "1")
-
-	assert.False(t, IsRunningUnderSupervisor())
-}
-
 // INVOCATION_ID alone must NOT imply supervision: a process started from a
 // systemd agent shell (e.g. tat_agent) inherits INVOCATION_ID but is not the
 // unit's MainPID, so systemd will not restart it. Regression test for the
@@ -1480,7 +1474,6 @@ func TestIsRunningUnderSupervisor_InvocationID(t *testing.T) {
 		systemdCgroupPath = "/proc/self/cgroup"
 		systemctlShowFunc = systemctlShowMainPID
 	}()
-	t.Setenv("CLAWBENCH_NO_SUPERVISOR", "")
 	t.Setenv("INVOCATION_ID", "test-invocation-id")
 	t.Setenv("container", "")
 

--- a/internal/handler/upgrade.go
+++ b/internal/handler/upgrade.go
@@ -19,6 +19,7 @@ var (
 	upgradeCompareVersions     = version.CompareVersions
 	upgradeIsDevBuild          = version.IsDevBuild
 	upgradeCheckInstallDirWrit = service.CheckInstallDirWritable
+	upgradeIsDocker            = service.IsDocker
 )
 
 // ServeUpgradeCheck handles GET /api/upgrade/check
@@ -53,6 +54,10 @@ func ServeUpgradeCheck(w http.ResponseWriter, r *http.Request) {
 		"has_upgrade":      hasUpgrade,
 		"install_writable": installWritable,
 		"install_dir":      installDir,
+		// is_docker tells the UI to show an advisory (non-blocking) hint
+		// recommending an image-based upgrade. Self-replace still works in a
+		// container, but a later rebuild from the unchanged image reverts it.
+		"is_docker": upgradeIsDocker(),
 	})
 }
 

--- a/internal/handler/upgrade_test.go
+++ b/internal/handler/upgrade_test.go
@@ -22,9 +22,11 @@ func TestServeUpgradeCheck_Success(t *testing.T) {
 		upgradeCompareVersions = version.CompareVersions
 		upgradeIsDevBuild = version.IsDevBuild
 		upgradeCheckInstallDirWrit = service.CheckInstallDirWritable
+		upgradeIsDocker = service.IsDocker
 	}()
 
 	upgradeCheckInstallDirWrit = func() (string, error) { return "/usr/local/bin", nil }
+	upgradeIsDocker = func() bool { return false }
 
 	upgradeCheckForUpgrade = func() (string, string, error) {
 		return "1.0.0", "1.1.0", nil
@@ -50,6 +52,37 @@ func TestServeUpgradeCheck_Success(t *testing.T) {
 	assert.Equal(t, true, resp["has_upgrade"])
 	assert.Equal(t, true, resp["install_writable"])
 	assert.Equal(t, "/usr/local/bin", resp["install_dir"])
+	assert.Equal(t, false, resp["is_docker"])
+}
+
+// TestServeUpgradeCheck_DockerAdvisory guards that a container deployment is
+// reported to the UI (so it can show a non-blocking "pull the image" hint)
+// without affecting has_upgrade — the upgrade must remain available.
+func TestServeUpgradeCheck_DockerAdvisory(t *testing.T) {
+	defer func() {
+		upgradeCheckForUpgrade = service.CheckForUpgrade
+		upgradeCompareVersions = version.CompareVersions
+		upgradeIsDevBuild = version.IsDevBuild
+		upgradeCheckInstallDirWrit = service.CheckInstallDirWritable
+		upgradeIsDocker = service.IsDocker
+	}()
+
+	upgradeCheckForUpgrade = func() (string, string, error) { return "1.0.0", "1.1.0", nil }
+	upgradeCompareVersions = func(a, b string) int { return -1 }
+	upgradeIsDevBuild = func(v string) bool { return false }
+	upgradeCheckInstallDirWrit = func() (string, error) { return "/app", nil }
+	upgradeIsDocker = func() bool { return true }
+
+	req := newRequest(t, http.MethodGet, "/api/upgrade/check", nil)
+	withAuthCookie(req, model.SessionToken)
+	w := callHandler(ServeUpgradeCheck, req)
+
+	assert.Equal(t, http.StatusOK, w.Code)
+
+	var resp map[string]any
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &resp))
+	assert.Equal(t, true, resp["is_docker"])
+	assert.Equal(t, true, resp["has_upgrade"], "Docker must not block the upgrade")
 }
 
 func TestServeUpgradeCheck_InstallDirNotWritable(t *testing.T) {

--- a/internal/model/chat.go
+++ b/internal/model/chat.go
@@ -261,6 +261,12 @@ type ContentBlock struct {
 	DisplayName string         `json:"display_name,omitempty"` // subagent_type for Agent tools (tool_use) — redundant, replaces toolDisplayName() lookup
 	FilePath    string         `json:"file_path,omitempty"`    // detected file path (tool_use) — redundant, for FILE_MODIFYING_TOOLS detection
 	DurationMs  int            `json:"duration_ms,omitempty"`  // tool execution wall-clock duration in ms (tool_use)
+	// ParentToolCallID links sub-agent content to the Agent tool call that
+	// spawned it: set on thinking/text/tool_use blocks produced by a sub-agent,
+	// empty for top-level content. Extracted from the backend's ACP _meta
+	// parent-link key (see internal/ai/acp_parent_link.go). Used by the frontend
+	// to group a sub-agent's output under its parent Agent card.
+	ParentToolCallID string `json:"parent_tool_call_id,omitempty"`
 }
 
 // MarshalJSON implements custom serialization for ContentBlock.
@@ -288,19 +294,22 @@ func (b ContentBlock) MarshalJSON() ([]byte, error) {
 				DisplayName string         `json:"display_name,omitempty"`
 				FilePath    string         `json:"file_path,omitempty"`
 				DurationMs  int            `json:"duration_ms,omitempty"`
+				// ParentToolCallID must round-trip for sub-agent grouping on reload.
+				ParentToolCallID string `json:"parent_tool_call_id,omitempty"`
 			}
 			return json.Marshal(InteractiveBlock{
-				Type:        b.Type,
-				Name:        b.Name,
-				ID:          b.ID,
-				Input:       b.Input,
-				Output:      b.Output,
-				Status:      b.Status,
-				Done:        b.Done,
-				Summary:     b.Summary,
-				DisplayName: b.DisplayName,
-				FilePath:    b.FilePath,
-				DurationMs:  b.DurationMs,
+				Type:             b.Type,
+				Name:             b.Name,
+				ID:               b.ID,
+				Input:            b.Input,
+				Output:           b.Output,
+				Status:           b.Status,
+				Done:             b.Done,
+				Summary:          b.Summary,
+				DisplayName:      b.DisplayName,
+				FilePath:         b.FilePath,
+				DurationMs:       b.DurationMs,
+				ParentToolCallID: b.ParentToolCallID,
 			})
 		}
 		// Slim serialization: type+name+id+status+done+summary+display_name+file_path
@@ -314,17 +323,20 @@ func (b ContentBlock) MarshalJSON() ([]byte, error) {
 			DisplayName string `json:"display_name,omitempty"`
 			FilePath    string `json:"file_path,omitempty"`
 			DurationMs  int    `json:"duration_ms,omitempty"`
+			// ParentToolCallID must round-trip for sub-agent grouping on reload.
+			ParentToolCallID string `json:"parent_tool_call_id,omitempty"`
 		}
 		return json.Marshal(SlimBlock{
-			Type:        b.Type,
-			Name:        b.Name,
-			ID:          b.ID,
-			Status:      b.Status,
-			Done:        b.Done,
-			Summary:     b.Summary,
-			DisplayName: b.DisplayName,
-			FilePath:    b.FilePath,
-			DurationMs:  b.DurationMs,
+			Type:             b.Type,
+			Name:             b.Name,
+			ID:               b.ID,
+			Status:           b.Status,
+			Done:             b.Done,
+			Summary:          b.Summary,
+			DisplayName:      b.DisplayName,
+			FilePath:         b.FilePath,
+			DurationMs:       b.DurationMs,
+			ParentToolCallID: b.ParentToolCallID,
 		})
 	}
 	// Standard serialization using Alias to avoid infinite recursion

--- a/internal/model/chat_test.go
+++ b/internal/model/chat_test.go
@@ -2,6 +2,7 @@ package model
 
 import (
 	"encoding/json"
+	"strings"
 	"testing"
 )
 
@@ -450,3 +451,42 @@ func TestChatMessageQueueFieldsMarshal(t *testing.T) {
 }
 
 func strPtr(s string) *string { return &s }
+
+func TestContentBlockParentToolCallIDRoundTrip(t *testing.T) {
+	// Sub-agent parent link must survive serialization for every block kind so a
+	// reload can regroup a sub-agent's output under its parent Agent card.
+	cases := []struct {
+		name  string
+		block ContentBlock
+	}{
+		{"slim tool_use", ContentBlock{Type: "tool_use", Name: "Read", ID: "t1", Done: true, ParentToolCallID: "call_p"}},
+		{"interactive tool_use", ContentBlock{Type: "tool_use", Name: "AskUserQuestion", ID: "t2", Input: map[string]any{}, ParentToolCallID: "call_p"}},
+		{"thinking marker", ContentBlock{Type: "thinking", ThinkID: "th1", Done: true, ParentToolCallID: "call_p"}},
+		{"text", ContentBlock{Type: "text", Text: "hi", ParentToolCallID: "call_p"}},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			data, err := json.Marshal(c.block)
+			if err != nil {
+				t.Fatalf("marshal failed: %v", err)
+			}
+			var parsed map[string]any
+			if err := json.Unmarshal(data, &parsed); err != nil {
+				t.Fatalf("unmarshal failed: %v", err)
+			}
+			if parsed["parent_tool_call_id"] != "call_p" {
+				t.Errorf("expected parent_tool_call_id=call_p, got %v", parsed["parent_tool_call_id"])
+			}
+		})
+	}
+}
+
+func TestContentBlockParentToolCallIDOmittedWhenEmpty(t *testing.T) {
+	data, err := json.Marshal(ContentBlock{Type: "text", Text: "hi"})
+	if err != nil {
+		t.Fatalf("marshal failed: %v", err)
+	}
+	if strings.Contains(string(data), "parent_tool_call_id") {
+		t.Errorf("empty parent link should be omitted, got %s", data)
+	}
+}

--- a/internal/platform/container.go
+++ b/internal/platform/container.go
@@ -1,0 +1,74 @@
+package platform
+
+import "os"
+
+// dockerMarkers are filesystem markers created by Docker / Podman inside the
+// container's own filesystem.
+//
+//   - /.dockerenv          Docker (and most OCI runtimes built on runc)
+//   - /run/.containerenv   Podman
+var dockerMarkers = []string{
+	"/.dockerenv",
+	"/run/.containerenv",
+}
+
+// containerEnvVars are environment variables that identify a container of any
+// kind.
+//
+//   - container: set by systemd-nspawn / some runtimes when the process runs
+//     in a container (the de-facto "am I containerized" hint).
+//   - KUBERNETES_SERVICE_HOST: injected by Kubernetes into every pod. A pod is
+//     a container even when the runtime leaves no marker file, so this is the
+//     reliable signal for k8s.
+var containerEnvVars = []string{
+	"container",
+	"KUBERNETES_SERVICE_HOST",
+}
+
+// dockerEnvVars are the env signals that specifically indicate Docker/Podman
+// (not just any container). Kubernetes is excluded on purpose — see IsDockerLike.
+var dockerEnvVars = []string{
+	"container",
+}
+
+func anyEnvSet(keys []string) bool {
+	for _, key := range keys {
+		if os.Getenv(key) != "" {
+			return true
+		}
+	}
+	return false
+}
+
+func anyPathExists(paths []string) bool {
+	for _, p := range paths {
+		if _, err := os.Stat(p); err == nil {
+			return true
+		}
+	}
+	return false
+}
+
+// IsContainer reports whether the process is running inside a container of any
+// kind: Docker, Podman, Kubernetes, ...
+//
+// Use this — not IsDockerLike — to decide whether self-restart machinery can
+// work. In a container the runtime tears the namespace down when PID 1 exits,
+// killing every helper process, so a sentinel or `upgrade-replace` subprocess
+// can never complete its work; only the runtime's restart policy brings the
+// service back. That is true in a k8s pod just as much as in Docker, so the
+// check must be the broad one.
+func IsContainer() bool {
+	return anyPathExists(dockerMarkers) || anyEnvSet(containerEnvVars)
+}
+
+// IsDockerLike reports whether the process is running under Docker or Podman
+// specifically — i.e. where Docker-CLI advice (`docker pull`, `docker compose`)
+// is actionable.
+//
+// Deliberately narrower than IsContainer: a Kubernetes pod is a container but
+// the Docker CLI advice does not apply, so the UI must not show it there.
+// Use IsContainer for supervision/self-restart decisions.
+func IsDockerLike() bool {
+	return anyPathExists(dockerMarkers) || anyEnvSet(dockerEnvVars)
+}

--- a/internal/platform/container_test.go
+++ b/internal/platform/container_test.go
@@ -1,0 +1,117 @@
+package platform
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+// clearContainerEnv removes the env-var signals so a marker-file test is not
+// short-circuited by an inherited "container" / k8s var (CI images may set one).
+func clearContainerEnv(t *testing.T) {
+	t.Helper()
+	t.Setenv("container", "")
+	t.Setenv("KUBERNETES_SERVICE_HOST", "")
+}
+
+// stubMarkers points the marker-file probes at test-controlled paths and
+// returns a restore func.
+func stubMarkers(paths ...string) func() {
+	origDocker := dockerMarkers
+	dockerMarkers = paths
+	return func() { dockerMarkers = origDocker }
+}
+
+func TestIsContainer_DockerMarker(t *testing.T) {
+	clearContainerEnv(t)
+	marker := filepath.Join(t.TempDir(), "dockerenv")
+	assert.NoError(t, os.WriteFile(marker, nil, 0o644))
+	defer stubMarkers(marker)()
+
+	assert.True(t, IsContainer())
+}
+
+func TestIsContainer_PodmanMarker(t *testing.T) {
+	clearContainerEnv(t)
+	marker := filepath.Join(t.TempDir(), "containerenv")
+	assert.NoError(t, os.WriteFile(marker, nil, 0o644))
+	defer stubMarkers(marker)()
+
+	assert.True(t, IsContainer())
+}
+
+func TestIsContainer_ContainerEnvVar(t *testing.T) {
+	clearContainerEnv(t)
+	defer stubMarkers(filepath.Join(t.TempDir(), "absent"))()
+
+	t.Setenv("container", "docker")
+	assert.True(t, IsContainer())
+}
+
+// Kubernetes pods must be detected even when the runtime leaves no marker file:
+// the self-restart subprocess path is just as fatal in a pod as in Docker.
+func TestIsContainer_KubernetesServiceHost(t *testing.T) {
+	clearContainerEnv(t)
+	defer stubMarkers(filepath.Join(t.TempDir(), "absent"))()
+
+	t.Setenv("KUBERNETES_SERVICE_HOST", "10.96.0.1")
+	assert.True(t, IsContainer())
+}
+
+func TestIsContainer_NoSignals(t *testing.T) {
+	clearContainerEnv(t)
+	defer stubMarkers(filepath.Join(t.TempDir(), "absent"))()
+
+	assert.False(t, IsContainer())
+}
+
+// A marker that exists but is a directory must still count (the runtime may
+// mount it as a directory); the check is presence, not file-ness.
+func TestIsContainer_MarkerAsDirectory(t *testing.T) {
+	clearContainerEnv(t)
+	marker := filepath.Join(t.TempDir(), "containerenv")
+	assert.NoError(t, os.Mkdir(marker, 0o755))
+	defer stubMarkers(marker)()
+
+	assert.True(t, IsContainer())
+}
+
+// ---------- IsDockerLike ----------
+
+func TestIsDockerLike_DockerMarker(t *testing.T) {
+	clearContainerEnv(t)
+	marker := filepath.Join(t.TempDir(), "dockerenv")
+	assert.NoError(t, os.WriteFile(marker, nil, 0o644))
+	defer stubMarkers(marker)()
+
+	assert.True(t, IsDockerLike())
+}
+
+func TestIsDockerLike_ContainerEnvVar(t *testing.T) {
+	clearContainerEnv(t)
+	defer stubMarkers(filepath.Join(t.TempDir(), "absent"))()
+
+	t.Setenv("container", "docker")
+	assert.True(t, IsDockerLike())
+}
+
+// A k8s pod is a container (IsContainer) but NOT "docker-like": the Docker CLI
+// advice is not actionable there, so the UI must not show it.
+func TestIsDockerLike_KubernetesIsNotDockerLike(t *testing.T) {
+	clearContainerEnv(t)
+	defer stubMarkers(filepath.Join(t.TempDir(), "absent"))()
+
+	t.Setenv("KUBERNETES_SERVICE_HOST", "10.96.0.1")
+
+	assert.True(t, IsContainer(), "a pod is a container")
+	assert.False(t, IsDockerLike(), "but the Docker CLI advice does not apply")
+}
+
+func TestIsDockerLike_NoSignals(t *testing.T) {
+	clearContainerEnv(t)
+	defer stubMarkers(filepath.Join(t.TempDir(), "absent"))()
+
+	assert.False(t, IsDockerLike())
+}

--- a/internal/service/session_executor.go
+++ b/internal/service/session_executor.go
@@ -972,10 +972,13 @@ func (e *SessionExecutor) flushStreamingLocked(includeThinking bool) {
 			} else if b.Done && b.ThinkID != "" && e.thinkingPersisted(b.ThinkID) {
 				// Only blocks that actually reached chat_thinking get markers — an
 				// empty done block has no row to lazy-load and would 404.
+				// ParentToolCallID must ride along so a reload keeps a sub-agent's
+				// thinking grouped under its parent Agent card.
 				serializedBlocks = append(serializedBlocks, model.ContentBlock{
-					Type:    blockTypeThinking,
-					ThinkID: b.ThinkID,
-					Done:    true,
+					Type:             blockTypeThinking,
+					ThinkID:          b.ThinkID,
+					Done:             true,
+					ParentToolCallID: b.ParentToolCallID,
 				})
 			}
 			continue

--- a/internal/service/summary_cards.go
+++ b/internal/service/summary_cards.go
@@ -35,6 +35,15 @@ func isSummaryCardTool(name string) bool {
 func extractSummaryCards(blocks []model.ContentBlock) *model.SummaryCards {
 	cards := &model.SummaryCards{}
 	for _, b := range blocks {
+		// Sub-agent content (parent_tool_call_id set) is rendered nested under its
+		// Agent card, not at the top level. In the summary view the heavy blocks
+		// are stripped and only these cards survive — so a sub-agent's tool calls
+		// must NOT leak into the top-level summary cards (they would masquerade as
+		// the main agent's actions). Skip them here; the summary view is a compact
+		// top-level digest.
+		if b.ParentToolCallID != "" {
+			continue
+		}
 		switch b.Type {
 		case "tool_use":
 			if isSummaryCardTool(b.Name) {

--- a/internal/service/summary_cards_test.go
+++ b/internal/service/summary_cards_test.go
@@ -148,3 +148,33 @@ func TestExtractSummaryCardsWarnings(t *testing.T) {
 	}
 	// text/tool blocks must not be collected as warnings.
 }
+
+func TestExtractSummaryCards_ExcludesSubAgentBlocks(t *testing.T) {
+	blocks := []model.ContentBlock{
+		// Top-level agent actions — should appear.
+		{Type: "tool_use", Name: "Write", ID: "top-w", FilePath: "/src/top.go", Done: true},
+		{Type: "tool_use", Name: "AskUserQuestion", ID: "top-ask", Done: true, Input: map[string]any{}},
+		// Sub-agent actions (parent_tool_call_id set) — must NOT leak into the
+		// top-level summary cards.
+		{Type: "tool_use", Name: "Write", ID: "sub-w", FilePath: "/src/sub.go", Done: true, ParentToolCallID: "call_p"},
+		{Type: "tool_use", Name: "AskUserQuestion", ID: "sub-ask", Done: true, Input: map[string]any{}, ParentToolCallID: "call_p"},
+	}
+	cards := extractSummaryCards(blocks)
+
+	for _, f := range cards.CreatedFiles {
+		if f.Path == "/src/sub.go" {
+			t.Fatalf("sub-agent file change leaked into summary cards: %+v", f)
+		}
+	}
+	for _, tool := range cards.Tools {
+		if tool.ID == "sub-ask" {
+			t.Fatalf("sub-agent AskUserQuestion leaked into summary cards: %+v", tool)
+		}
+	}
+	if len(cards.CreatedFiles) != 1 || cards.CreatedFiles[0].Path != "/src/top.go" {
+		t.Fatalf("expected only the top-level file change, got %+v", cards.CreatedFiles)
+	}
+	if len(cards.Tools) != 1 || cards.Tools[0].ID != "top-ask" {
+		t.Fatalf("expected only the top-level ask card, got %+v", cards.Tools)
+	}
+}

--- a/internal/service/thinking_test.go
+++ b/internal/service/thinking_test.go
@@ -316,3 +316,30 @@ func TestPersistThinkingToDB_ParseErrorFallback(t *testing.T) {
 		t.Errorf("expected original content back on parse error, got %q", got)
 	}
 }
+
+func TestSlimThinkingInContent_PreservesParentToolCallID(t *testing.T) {
+	// A sub-agent thinking block must keep its parent link through slimming, so
+	// a reload can regroup it under the parent Agent card.
+	in := `{"blocks":[
+		{"type":"thinking","text":"child reasoning","done":true,"parent_tool_call_id":"call_p"}
+	]}`
+	slim, records, err := slimThinkingInContent(in)
+	if err != nil {
+		t.Fatalf("slimThinkingInContent: %v", err)
+	}
+	if len(records) != 1 {
+		t.Fatalf("records = %d, want 1", len(records))
+	}
+	var parsed struct {
+		Blocks []map[string]any `json:"blocks"`
+	}
+	if err := json.Unmarshal([]byte(slim), &parsed); err != nil {
+		t.Fatalf("unmarshal slim: %v", err)
+	}
+	if parsed.Blocks[0]["parent_tool_call_id"] != "call_p" {
+		t.Errorf("parent_tool_call_id lost in slim block: %v", parsed.Blocks[0])
+	}
+	if _, hasText := parsed.Blocks[0]["text"]; hasText {
+		t.Error("slim block should not have text")
+	}
+}

--- a/internal/service/upgrade.go
+++ b/internal/service/upgrade.go
@@ -58,6 +58,28 @@ func SetUpgradeIsSupervised(f func() bool) {
 	upgradeIsSupervised = f
 }
 
+// upgradeIsContainer reports whether the process runs inside a container.
+// Overridden in tests.
+var upgradeIsContainer = platform.IsContainer
+
+// resolveReplaceInPlace decides whether the upgrade should replace the binary
+// in place and rely on an external restart, rather than spawning the
+// self-restart `upgrade-replace` subprocess.
+//
+// A container always returns true. The subprocess path cannot work there: the
+// runtime destroys the namespace when PID 1 exits, killing the helper before it
+// can replace anything, so the service would silently come back on the old
+// binary. This holds regardless of the supervisor probe — k8s, runit and
+// supervisord are all unrecognized by it, which must not change the container's
+// behavior.
+//
+// Outside a container the probe is authoritative: a truly unsupervised
+// deployment (e.g. a plain nohup/setsid process) needs the subprocess path,
+// since nothing else would restart it.
+func resolveReplaceInPlace(isContainer, probeSupervised bool) bool {
+	return isContainer || probeSupervised
+}
+
 // upgradeCancel is the cancellation function for the current upgrade goroutine.
 var upgradeCancel context.CancelFunc
 
@@ -352,15 +374,16 @@ func performUpgrade(ctx context.Context) { //nolint:gocyclo // upgrade flow is i
 	}
 	slog.Info("upgrade: current binary", "path", currentBin)
 
-	isSupervised := upgradeIsSupervised != nil && upgradeIsSupervised()
-	isDockerEnv := isDocker()
-	slog.Info("upgrade: supervisor check", "isSupervised", isSupervised, "isDocker", isDockerEnv)
+	isContainerEnv := upgradeIsContainer()
+	probeSupervised := upgradeIsSupervised != nil && upgradeIsSupervised()
+	isSupervised := resolveReplaceInPlace(isContainerEnv, probeSupervised)
+	slog.Info("upgrade: supervisor check",
+		"isSupervised", isSupervised, "isContainer", isContainerEnv,
+		"probeSupervised", probeSupervised)
 
-	// Docker refuses self-replace — replacement is done by pulling a new image.
-	if isSupervised && isDockerEnv {
-		SetUpgradeError("Running in Docker — please pull new image: docker pull ghcr.io/xulongzhe/clawbench:latest")
-		broadcastUpgradeUpdate()
-		return
+	if isContainerEnv {
+		slog.Info("upgrade: container detected — using in-place replace + restart-policy restart",
+			"dockerLike", platform.IsDockerLike())
 	}
 
 	// 1c. Preflight: the install directory (and the backup path) must be
@@ -783,15 +806,14 @@ func CheckInstallDirWritable() (string, error) {
 	return dir, nil
 }
 
-// isDocker checks if running inside a Docker container.
-func isDocker() bool {
-	if os.Getenv("container") != "" {
-		return true
-	}
-	if _, err := os.Stat("/.dockerenv"); err == nil {
-		return true
-	}
-	return false
+// IsDocker reports whether the process runs under Docker or Podman — i.e.
+// where the `docker pull` / `docker compose` advice is actionable.
+//
+// Kept as a thin wrapper over platform.IsDockerLike for the upgrade API's
+// `is_docker` field. Use platform.IsContainer for supervision decisions: a k8s
+// pod is a container (so self-restart is impossible) but not Docker-like.
+func IsDocker() bool {
+	return platform.IsDockerLike()
 }
 
 // setStateAndBroadcast sets upgrade state and broadcasts it via WS.

--- a/internal/service/upgrade_supervised_test.go
+++ b/internal/service/upgrade_supervised_test.go
@@ -206,3 +206,45 @@ func TestPerformSupervisedUpgrade_NilShutdownFunc(t *testing.T) {
 	err := performSupervisedUpgrade(newPath, target)
 	require.NoError(t, err)
 }
+
+// --- path selection: container always wins ---
+
+// A container can never use the self-restart subprocess path: the runtime tears
+// the namespace down when PID 1 exits, killing the upgrade-replace child before
+// it finishes. Even when the supervisor probe says "not supervised" (k8s,
+// runit, supervisord), a container must still be treated as supervised.
+func TestResolveReplaceInPlace_ContainerForcesInPlaceEvenWhenProbeSaysNo(t *testing.T) {
+	assert.True(t, resolveReplaceInPlace(true, false),
+		"container + probe says not supervised => still in-place")
+}
+
+func TestResolveReplaceInPlace_ContainerAndProbeBothTrue(t *testing.T) {
+	assert.True(t, resolveReplaceInPlace(true, true))
+}
+
+// Outside a container the probe is authoritative: a genuinely unsupervised
+// deployment must use the self-restart subprocess path (nothing else restarts
+// it), while a supervised one replaces in place.
+func TestResolveReplaceInPlace_NonContainerFollowsProbe(t *testing.T) {
+	assert.False(t, resolveReplaceInPlace(false, false),
+		"not a container + not supervised => subprocess path")
+	assert.True(t, resolveReplaceInPlace(false, true),
+		"not a container + supervised (systemd) => in-place")
+}
+
+// The container override must survive a probe that reports false — this is the
+// exact combination an unrecognized runtime (k8s/runit/supervisord) produces.
+func TestResolveReplaceInPlace_ProbeOverrideCannotDefeatContainer(t *testing.T) {
+	origContainer := upgradeIsContainer
+	origProbe := upgradeIsSupervised
+	defer func() {
+		upgradeIsContainer = origContainer
+		upgradeIsSupervised = origProbe
+	}()
+
+	upgradeIsContainer = func() bool { return true }
+	upgradeIsSupervised = func() bool { return false } // unrecognized runtime
+
+	got := resolveReplaceInPlace(upgradeIsContainer(), upgradeIsSupervised())
+	assert.True(t, got, "container must force in-place even when the probe says false")
+}

--- a/internal/service/upgrade_test.go
+++ b/internal/service/upgrade_test.go
@@ -553,7 +553,7 @@ func TestIsDocker_WithContainerEnvVar(t *testing.T) {
 	defer os.Setenv("container", orig)
 
 	os.Setenv("container", "docker")
-	assert.True(t, isDocker())
+	assert.True(t, IsDocker())
 }
 
 func TestIsDocker_WithDockerenvFile(t *testing.T) {
@@ -566,7 +566,7 @@ func TestIsDocker_WithDockerenvFile(t *testing.T) {
 	// and the negative case.
 	_, _ = os.Stat("/.dockerenv")
 	// Just ensure it doesn't panic
-	_ = isDocker()
+	_ = IsDocker()
 }
 
 func TestIsDocker_NeitherIndicator(t *testing.T) {
@@ -576,7 +576,7 @@ func TestIsDocker_NeitherIndicator(t *testing.T) {
 
 	// If /.dockerenv exists, this will be true; that's OK.
 	// The test mainly ensures no panic and the env var path works.
-	result := isDocker()
+	result := IsDocker()
 	// On most CI, /.dockerenv may exist
 	if _, err := os.Stat("/.dockerenv"); os.IsNotExist(err) {
 		assert.False(t, result)
@@ -1126,7 +1126,7 @@ func TestIsDocker_EmptyContainerEnvVar(t *testing.T) {
 	os.Unsetenv("container")
 	// If /.dockerenv doesn't exist, result should be false
 	if _, err := os.Stat("/.dockerenv"); os.IsNotExist(err) {
-		assert.False(t, isDocker())
+		assert.False(t, IsDocker())
 	}
 }
 

--- a/internal/ws/stream_hub.go
+++ b/internal/ws/stream_hub.go
@@ -212,11 +212,19 @@ func StreamEventToPayload(event ai.StreamEvent) any {
 }
 
 // simpleTextPayload maps a bare-text event (content/thinking) to its keyed value.
+// Sub-agent content carries parent_tool_call_id so the frontend can group it
+// under the Agent card that spawned it.
 func simpleTextPayload(event ai.StreamEvent) any {
+	payload := map[string]string{}
 	if event.Type == "thinking" {
-		return map[string]string{"text": event.Content}
+		payload["text"] = event.Content
+	} else {
+		payload["content"] = event.Content
 	}
-	return map[string]string{"content": event.Content}
+	if event.ParentToolCallID != "" {
+		payload["parent_tool_call_id"] = event.ParentToolCallID
+	}
+	return payload
 }
 
 // streamStartPayload builds the stream_start message payload. Returns nil when
@@ -269,6 +277,9 @@ func toolUsePayload(event ai.StreamEvent) any {
 	if event.Tool.Status != "" {
 		payload["status"] = event.Tool.Status
 	}
+	if event.Tool.ParentToolCallID != "" {
+		payload["parent_tool_call_id"] = event.Tool.ParentToolCallID
+	}
 	attachToolMeta(payload, event.ToolMeta)
 	// Interactive tools: include input so frontend can render permission UI
 	nameLower := strings.ToLower(event.Tool.Name)
@@ -297,6 +308,9 @@ func toolResultPayload(event ai.StreamEvent) any {
 	}
 	if event.Tool.Status != "" {
 		payload["status"] = event.Tool.Status
+	}
+	if event.Tool.ParentToolCallID != "" {
+		payload["parent_tool_call_id"] = event.Tool.ParentToolCallID
 	}
 	attachToolMeta(payload, event.ToolMeta)
 	return payload

--- a/internal/ws/stream_hub_test.go
+++ b/internal/ws/stream_hub_test.go
@@ -933,3 +933,45 @@ func TestStreamHub_EmitACPStateEvents_DBUsageFallback(t *testing.T) {
 	require.NotNil(t, usage)
 	assert.Equal(t, 999, usage.Used)
 }
+
+func TestStreamEventToPayload_ContentParentLink(t *testing.T) {
+	payload := StreamEventToPayload(ai.StreamEvent{Type: "content", Content: "child", ParentToolCallID: "call_p"})
+	m, ok := payload.(map[string]string)
+	assert.True(t, ok)
+	assert.Equal(t, "child", m["content"])
+	assert.Equal(t, "call_p", m["parent_tool_call_id"])
+}
+
+func TestStreamEventToPayload_ThinkingParentLink(t *testing.T) {
+	payload := StreamEventToPayload(ai.StreamEvent{Type: "thinking", Content: "child thought", ParentToolCallID: "call_p"})
+	m, ok := payload.(map[string]string)
+	assert.True(t, ok)
+	assert.Equal(t, "child thought", m["text"])
+	assert.Equal(t, "call_p", m["parent_tool_call_id"])
+}
+
+func TestStreamEventToPayload_TopLevelContentNoParentKey(t *testing.T) {
+	payload := StreamEventToPayload(ai.StreamEvent{Type: "content", Content: "parent"})
+	m, ok := payload.(map[string]string)
+	assert.True(t, ok)
+	_, has := m["parent_tool_call_id"]
+	assert.False(t, has, "top-level content must not carry a parent key")
+}
+
+func TestStreamEventToPayload_ToolUseParentLink(t *testing.T) {
+	payload := StreamEventToPayload(ai.StreamEvent{Type: "tool_use", Tool: &ai.ToolCall{
+		Name: "Read", ID: "t1", ParentToolCallID: "call_p",
+	}})
+	m, ok := payload.(map[string]any)
+	assert.True(t, ok)
+	assert.Equal(t, "call_p", m["parent_tool_call_id"])
+}
+
+func TestStreamEventToPayload_ToolResultParentLink(t *testing.T) {
+	payload := StreamEventToPayload(ai.StreamEvent{Type: "tool_result", Tool: &ai.ToolCall{
+		Name: "Read", ID: "t1", ParentToolCallID: "call_p",
+	}})
+	m, ok := payload.(map[string]any)
+	assert.True(t, ok)
+	assert.Equal(t, "call_p", m["parent_tool_call_id"])
+}

--- a/web/src/components/UpgradePromptOverlay.vue
+++ b/web/src/components/UpgradePromptOverlay.vue
@@ -7,6 +7,10 @@
         </div>
         <p class="up-body">{{ t('upgrade.promptMessage', { version: latestVersion, currentVersion }) }}</p>
         <div class="up-version-badge">v{{ latestVersion }}</div>
+        <p v-if="isDocker" class="up-docker-hint">
+          {{ t('upgrade.dockerHintBody') }}
+          <span class="up-docker-restart">{{ t('upgrade.dockerHintRestart') }}</span>
+        </p>
         <a v-if="releaseNotesUrl" class="up-release-link" :href="releaseNotesUrl" target="_blank" rel="noopener noreferrer">
           {{ t('upgrade.releaseNotes', { version: latestVersion }) }}
         </a>
@@ -27,7 +31,7 @@ import { useUpgrade } from '@/composables/useUpgrade'
 import { registerBackHandler, PRIORITY_OVERLAY } from '@/composables/useBackHandler'
 
 const { t } = useI18n()
-const { skipVersion: doSkip, startUpgrade, releaseNotesUrl } = useUpgrade()
+const { skipVersion: doSkip, startUpgrade, releaseNotesUrl, isDocker } = useUpgrade()
 
 const visible = ref(false)
 const latestVersion = ref('')
@@ -134,6 +138,23 @@ watch(visible, (v) => {
   color: var(--accent-color);
   text-decoration: none;
   cursor: pointer;
+}
+
+.up-docker-hint {
+  margin: 0 16px 10px;
+  padding: 8px 10px;
+  border-radius: 8px;
+  background: color-mix(in srgb, var(--accent-color) 10%, transparent);
+  border: 1px solid color-mix(in srgb, var(--accent-color) 30%, transparent);
+  font-size: 12px;
+  color: var(--text-secondary);
+  line-height: 1.5;
+}
+
+.up-docker-restart {
+  display: block;
+  margin-top: 4px;
+  color: var(--text-warning, #d69e2e);
 }
 
 .up-release-link:hover {

--- a/web/src/components/chat/AttachDrawer.vue
+++ b/web/src/components/chat/AttachDrawer.vue
@@ -111,12 +111,15 @@
 
       <!-- Recently uploaded + pending uploads -->
       <template v-if="activeTab === 'uploads'">
-        <!-- Pending uploads: only show while uploading (failed items removed by useFileUpload) -->
+        <!-- Pending uploads: only the in-flight ones (failed items are removed by
+             useFileUpload). Loop over `uploadingFiles` rather than `pendingFiles`
+             with v-show, so finished-but-retained entries leave no hidden rows. The
+             loading/empty fallbacks below key off the same visible count, otherwise
+             a retained non-uploading entry hides every row while also suppressing the
+             empty state → the content area collapses. -->
         <button
-          v-for="(f, idx) in pendingFiles" :key="'pending-' + idx"
-          v-show="f.uploading"
-          class="ad-file-row" :class="{ 'ad-file-attached': f.path && isAttached(f.path) }"
-          @click="f.path && !f.uploading && toggleAttached(f.path)"
+          v-for="(f, idx) in uploadingFiles" :key="'pending-' + idx"
+          class="ad-file-row"
         >
           <div class="ad-icon-wrap ad-uploading-icon">
             <span class="ad-upload-pct">{{ f.progress }}%</span>
@@ -127,8 +130,8 @@
           </div>
         </button>
         <!-- Completed uploads from server -->
-        <LoadingIndicator v-if="loading && !recentUploads?.length && pendingFiles.length === 0" size="md" />
-        <div v-else-if="!recentUploads?.length && pendingFiles.length === 0" class="ad-empty">{{ t('chat.attach.emptyUploads') }}</div>
+        <LoadingIndicator v-if="loading && !recentUploads?.length && uploadingFiles.length === 0" size="md" />
+        <div v-else-if="!recentUploads?.length && uploadingFiles.length === 0" class="ad-empty">{{ t('chat.attach.emptyUploads') }}</div>
         <button
           v-for="item in recentUploads" :key="item.path"
           class="ad-file-row" :class="{ 'ad-file-attached': isAttached(item.path) }"

--- a/web/src/components/chat/ContentBlocks.vue
+++ b/web/src/components/chat/ContentBlocks.vue
@@ -117,9 +117,11 @@
     </template>
     <!-- Original content mode -->
     <template v-if="nested || !showingSummary || !summary">
-    <template v-for="(block, bi) in blocks" :key="stableBlockKey(absIdx(bi), block)">
+    <template v-for="(block, bi) in blocks" :key="stableBlockKey(bi, block)">
       <!-- Sub-agent child blocks are rendered nested under their parent Agent
-           block below; skip them in the flat stream. -->
+           block below; skip them in the flat stream. Children always arrive
+           AFTER their parent (the parent id is known when they are emitted), so
+           this branch never flips mid-stream for a live block. -->
       <template v-if="isChildBlock(block)"></template>
       <!-- Thinking block: streaming or expanded shows inline content, collapsed shows clickable chip -->
       <div v-else-if="block.type === 'thinking'"
@@ -163,7 +165,7 @@
         <!-- AskUserQuestion / PermissionApproval: unified interactive card
              (status strip + body in one box). -->
         <div v-if="shouldAutoExpand(block) && isUnifiedCardTool(block.name)" class="tool-detail chat-inline-card" :class="!block.done ? 'is-pending' : ''" :data-tool-name="block.name" :data-category="getToolIcon(block.name).category" :data-session-id="sessionId" :data-tool-call-id="block.id" @click="handleToolDetailClick" @input="handleToolDetailInput">
-          <div class="chat-card-strip" @click.stop="handleToolClick(block, key(bi), bi)">
+          <div class="chat-card-strip" @click.stop="handleToolClick(block, key(bi), absIdx(bi))">
             <component :is="getToolIcon(block.name).icon" :size="12" class="tool-icon" />
             <span class="tool-name">{{ unifiedCardTitle(block.name, block.input, block.display_name) }}</span>
             <span v-if="toolCallSummary(block)" class="tool-summary">{{ toolCallSummary(block) }}</span>
@@ -181,7 +183,7 @@
           </div>
         </div>
         <template v-else>
-          <div class="chat-tool-call" :class="{ done: block.done, 'chat-tool-call-group': hasSubagentGroup(block), 'chat-tool-call-group-open': hasSubagentGroup(block) && isSubagentGroupOpen(bi, block) }" :data-category="getToolIcon(block.name).category" @click.stop="handleToolClick(block, key(bi), bi)">
+          <div :ref="(el) => setSubagentPillRef(subagentGroupKey(bi, block), el)" class="chat-tool-call" :class="{ done: block.done, 'chat-tool-call-group': hasSubagentGroup(block), 'chat-tool-call-group-open': hasSubagentGroup(block) && isSubagentGroupOpen(bi, block) }" :data-category="getToolIcon(block.name).category" @click.stop="handleToolClick(block, key(bi), absIdx(bi))">
             <component :is="getToolIcon(block.name).icon" :size="12" class="tool-icon" />
             <span class="tool-name">{{ toolDisplayName(block.name, block.input, block.display_name) }}</span>
             <span v-if="toolCallSummary(block)" class="tool-summary">{{ toolCallSummary(block) }}</span>
@@ -199,7 +201,7 @@
                 :aria-expanded="isSubagentGroupOpen(bi, block)"
                 :aria-label="isSubagentGroupOpen(bi, block) ? t('chat.contentBlocks.subagentCollapse') : t('chat.contentBlocks.subagentExpand')"
                 :title="isSubagentGroupOpen(bi, block) ? t('chat.contentBlocks.subagentCollapse') : t('chat.contentBlocks.subagentExpand')"
-                @click.stop="$emit('toggle-tool', subagentGroupKey(bi, block))"
+                @click.stop="toggleSubagentGroup(bi, block)"
               >
                 <ChevronUp v-if="isSubagentGroupOpen(bi, block)" :size="12" />
                 <ChevronDown v-else :size="12" />
@@ -220,11 +222,14 @@
         <!-- Sub-agent group body: nested thinking/text/tool_use produced by the
              sub-agent this Agent call spawned, rendered by a recursive
              ContentBlocks instance so they get the exact same styles (thinking
-             callout/pill, tool pills) as top-level content. -->
+             callout/pill, tool pills) as top-level content. The recursive
+             subtree is mounted lazily on first open: a never-opened group (e.g.
+             a collapsed 4558-block sub-agent) pays no component/index cost. -->
         <div v-if="hasSubagentGroup(block)" class="subagent-group" :class="{ 'subagent-group-open': isSubagentGroupOpen(bi, block) }">
-          <div class="subagent-group-body-wrapper" :class="{ 'subagent-group-body-open': isSubagentGroupOpen(bi, block) }">
+          <div class="subagent-group-body-wrapper" :class="{ 'subagent-group-body-open': isSubagentGroupOpen(bi, block), 'subagent-group-body-nostransition': collapsingSubagentGroups[subagentGroupKey(bi, block)] }">
             <div class="subagent-group-body">
               <ContentBlocks
+                v-if="isSubagentGroupMounted(bi, block)"
                 :blocks="childBlocksOf(block.id)"
                 :root-blocks="rootBlocksResolved"
                 :nested="true"
@@ -255,6 +260,18 @@
                 @resume-session="$emit('resume-session', $event)"
                 @reset-session="$emit('reset-session', $event)"
               />
+              <!-- Footer: a bottom affordance to collapse the group (the pill
+                   chevron also toggles, but after scrolling a long sub-agent
+                   trace the bottom is the natural place to close it). -->
+              <button
+                v-if="isSubagentGroupOpen(bi, block)"
+                type="button"
+                class="subagent-group-footer"
+                @click.stop="toggleSubagentGroup(bi, block)"
+              >
+                <ChevronUp :size="12" />
+                <span>{{ t('chat.contentBlocks.subagentCollapse') }}</span>
+              </button>
             </div>
           </div>
         </div>
@@ -599,12 +616,20 @@ const elapsedLabel = computed(() => {
 // indices 0..n-1, but every per-block cache key and the detail drawer's live
 // lookup are keyed by the ABSOLUTE index in the root blocks array. Resolve by
 // object identity so nested instances stay correctly keyed at any depth.
+// A single identity Map per root array keeps lookups O(1) — absIdx is called
+// several times per block per render, and a sub-agent can have thousands of
+// child blocks (a naive indexOf would be O(n) each time).
 const rootBlocksResolved = computed(() => props.rootBlocks || props.blocks)
+const rootIndexByIdentity = computed(() => {
+  const map = new Map<any, number>()
+  const arr = rootBlocksResolved.value
+  for (let i = 0; i < arr.length; i++) map.set(arr[i], i)
+  return map
+})
 function absIdx(bi: number): number {
   if (!props.nested || !props.rootBlocks) return bi
-  const block = props.blocks[bi]
-  const idx = rootBlocksResolved.value.indexOf(block)
-  return idx >= 0 ? idx : bi
+  const idx = rootIndexByIdentity.value.get(props.blocks[bi])
+  return idx !== undefined ? idx : bi
 }
 
 // Key helper: use msgId if available, otherwise msgIndex
@@ -703,12 +728,78 @@ function isChildBlock(block: any): boolean {
 
 /** Expand key for a sub-agent group: reuses the Agent block's stable key. */
 function subagentGroupKey(bi: number, block: any): string {
-  return `subagent-${stableBlockKey(absIdx(bi), block)}`
+  return `subagent-${stableBlockKey(bi, block)}`
 }
 
 /** Whether the sub-agent group under this Agent block is expanded. */
 function isSubagentGroupOpen(bi: number, block: any): boolean {
   return !!props.expandedTools[subagentGroupKey(bi, block)]
+}
+
+// Pill elements by group key, so collapsing can anchor the pill to the top of
+// the scroll viewport (see toggleSubagentGroup).
+const subagentPillEls = new Map<string, HTMLElement>()
+function setSubagentPillRef(key: string, el: any) {
+  if (el) subagentPillEls.set(key, el as HTMLElement)
+  else subagentPillEls.delete(key)
+}
+
+/**
+ * Toggle a sub-agent group. Collapsing shrinks the group by potentially
+ * thousands of pixels, which would violently shift everything below the
+ * viewport. Before collapsing we anchor the Agent pill to the top of its
+ * scroll container and restore that offset after the DOM updates, so the
+ * pill (and the following content) stay put instead of jumping.
+ */
+function toggleSubagentGroup(bi: number, block: any) {
+  const key = subagentGroupKey(bi, block)
+  const wasOpen = isSubagentGroupOpen(bi, block)
+  if (!wasOpen) {
+    // Expanding: no anchoring needed (content grows below the pill).
+    emit('toggle-tool', key)
+    return
+  }
+  const pill = subagentPillEls.get(key)
+  const scroller = pill?.closest('.chat-messages') as HTMLElement | null
+  if (!pill || !scroller) {
+    emit('toggle-tool', key)
+    return
+  }
+  // Distance from the pill's top to the scroller's visible top, plus the
+  // current scrollTop. After collapse we restore scrollTop so the pill keeps
+  // the same on-screen position (clamped to the pill's new max scroll).
+  const pillTopInContent = scroller.scrollTop + (pill.getBoundingClientRect().top - scroller.getBoundingClientRect().top)
+  // Disable the grid transition for this collapse so the height change is
+  // applied synchronously — nextTick then measures the final layout and the
+  // anchor restore is exact. Expansion animates normally.
+  collapsingSubagentGroups[key] = true
+  emit('toggle-tool', key)
+  nextTick(() => {
+    const maxScroll = scroller.scrollHeight - scroller.clientHeight
+    const target = Math.max(0, Math.min(pillTopInContent, maxScroll))
+    if (Math.abs(target - scroller.scrollTop) > 1) {
+      scroller.scrollTop = target
+    }
+    // Re-enable the transition on the next frame so a later expand animates.
+    requestAnimationFrame(() => { delete collapsingSubagentGroups[key] })
+  })
+}
+
+// Groups whose recursive body has been mounted at least once. Once mounted it
+// stays mounted so the collapse animation works on subsequent toggles; an
+// unopened group never instantiates its (possibly huge) child subtree.
+const mountedSubagentGroups = reactive<Record<string, boolean>>({})
+
+// Groups mid-collapse. Collapse is instant (transition disabled) so the
+// viewport anchor can be restored at nextTick against the final height; only
+// expansion animates.
+const collapsingSubagentGroups = reactive<Record<string, boolean>>({})
+
+/** Whether to mount the recursive body for this group (first open or later). */
+function isSubagentGroupMounted(bi: number, block: any): boolean {
+  const k = subagentGroupKey(bi, block)
+  if (isSubagentGroupOpen(bi, block)) mountedSubagentGroups[k] = true
+  return !!mountedSubagentGroups[k]
 }
 
 /** Whether the parent Agent tool is still running (drives the group spinner). */
@@ -813,14 +904,16 @@ function handleSummaryToolClick(tool: any, ti: number) {
  *  thinking: block.think_id (stable backend-assigned ID, survives re-opens),
  *            falling back to block._key (key assigned at creation/parsing)
  *  text: text-${bi} (text blocks merge so index is stable)
- *  other: type-bi (fallback) */
+ *  other: type-bi (fallback)
+ *  The index fallback uses the ABSOLUTE root index (absIdx) so a nested
+ *  instance's keys never collide with the parent's. */
 function stableBlockKey(bi: number, block: any) {
   if (block.type === 'tool_use' && block.id) return block.id
   if (block.type === 'thinking') {
     if (block.think_id) return block.think_id
     if (block._key) return block._key
   }
-  return `${block.type || 'other'}-${bi}`
+  return `${block.type || 'other'}-${absIdx(bi)}`
 }
 
 function handleThinkingClick(block: any, bi: number) {
@@ -1055,7 +1148,7 @@ function getBlockHtml(bi: number, block: any) {
     return ''
   }
   // Streaming: deferred rendering with throttling
-  const key = stableBlockKey(ai, block)
+  const key = stableBlockKey(bi, block)
   if (blockHtmlCache.value[key] !== undefined) {
     if (!_throttleTimer) {
       const newCache = { ...blockHtmlCache.value }
@@ -1096,7 +1189,7 @@ function getThinkingTextHtml(text: string, bi: number, block: any) {
   }
   // Streaming: skip KaTeX (formulas may be incomplete)
   const streamingOpts = { skipKatex: true } as const
-  const cacheKey = `t-${stableBlockKey(absIdx(bi), block)}`
+  const cacheKey = `t-${stableBlockKey(bi, block)}`
   // Streaming: deferred rendering with throttling (same pattern as text blocks)
   if (blockHtmlCache.value[cacheKey] !== undefined) {
     if (!_throttleTimer) {
@@ -1780,6 +1873,12 @@ onUnmounted(() => {
   opacity: 1;
 }
 
+/* Collapse is applied without a transition so the viewport anchor restore
+   (toggleSubagentGroup) can measure the final height synchronously. */
+.subagent-group-body-wrapper.subagent-group-body-nostransition {
+  transition: none;
+}
+
 .subagent-group-body {
   overflow: hidden;
   min-height: 0;
@@ -1787,6 +1886,28 @@ onUnmounted(() => {
 
 .subagent-group-body-open .subagent-group-body {
   padding: 6px 10px;
+}
+
+/* Bottom "collapse" affordance shown only while the group is open. */
+.subagent-group-footer {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 4px;
+  width: 100%;
+  margin-top: 6px;
+  padding: 4px 0;
+  font-size: 11px;
+  color: var(--text-muted);
+  background: none;
+  border: none;
+  border-top: 1px solid color-mix(in srgb, var(--subagent-accent) 20%, var(--border-color));
+  cursor: pointer;
+  transition: color 0.15s;
+}
+
+.subagent-group-footer:hover {
+  color: var(--subagent-accent);
 }
 
 /* Inline tool detail — only used by AskUserQuestion (other tools use ToolDetailDrawer) */

--- a/web/src/components/chat/ContentBlocks.vue
+++ b/web/src/components/chat/ContentBlocks.vue
@@ -1,5 +1,5 @@
 <template>
-  <div class="content-blocks">
+  <div class="content-blocks" :class="{ 'content-blocks-nested': nested }">
     <!-- Summary mode: render summary as a single text block.
          Using v-show for summary to avoid Vue Fragment patching issues when
          switching between v-if/v-else branches with nested template v-for.
@@ -7,11 +7,11 @@
          branch to render as an empty comment node because Vue 3's patch
          algorithm fails to correctly transition between different Fragment
          structures (summary div vs blocks template v-for). -->
-    <div v-show="showingSummary && summary" v-html="renderTextBlock(summary || '', msgId, 0, false)"></div>
+    <div v-if="!nested" v-show="showingSummary && summary" v-html="renderTextBlock(summary || '', msgId, 0, false)"></div>
     <!-- Summary mode: render structured cards (tools / scheduled tasks / ask-questions)
          directly from summaryCards — NOT by traversing blocks (which may be empty in
          summary-first loading). -->
-    <template v-if="showingSummary && summary">
+    <template v-if="!nested && showingSummary && summary">
       <!-- Warning/error banners from summaryCards.warnings — the summary view
            renders with stripped content blocks ({"blocks":[]}), so warning/error
            banners are carried here to stay visible (mirrors file-changes cards). -->
@@ -116,10 +116,13 @@
       </template>
     </template>
     <!-- Original content mode -->
-    <template v-if="!showingSummary || !summary">
-    <template v-for="(block, bi) in blocks" :key="stableBlockKey(bi, block)">
+    <template v-if="nested || !showingSummary || !summary">
+    <template v-for="(block, bi) in blocks" :key="stableBlockKey(absIdx(bi), block)">
+      <!-- Sub-agent child blocks are rendered nested under their parent Agent
+           block below; skip them in the flat stream. -->
+      <template v-if="isChildBlock(block)"></template>
       <!-- Thinking block: streaming or expanded shows inline content, collapsed shows clickable chip -->
-      <div v-if="block.type === 'thinking'"
+      <div v-else-if="block.type === 'thinking'"
         :ref="(el) => setThinkingRef(stableBlockKey(bi, block), el)"
         class="chat-thinking"
         :class="{
@@ -178,20 +181,83 @@
           </div>
         </div>
         <template v-else>
-          <div class="chat-tool-call" :class="{ done: block.done }" :data-category="getToolIcon(block.name).category" @click.stop="handleToolClick(block, key(bi), bi)">
+          <div class="chat-tool-call" :class="{ done: block.done, 'chat-tool-call-group': hasSubagentGroup(block), 'chat-tool-call-group-open': hasSubagentGroup(block) && isSubagentGroupOpen(bi, block) }" :data-category="getToolIcon(block.name).category" @click.stop="handleToolClick(block, key(bi), bi)">
             <component :is="getToolIcon(block.name).icon" :size="12" class="tool-icon" />
             <span class="tool-name">{{ toolDisplayName(block.name, block.input, block.display_name) }}</span>
             <span v-if="toolCallSummary(block)" class="tool-summary">{{ toolCallSummary(block) }}</span>
-            <!-- Loading: spinner -->
-            <LoadingIndicator v-if="!block.done" class="tool-spinner" size="sm" inline />
-            <!-- Done with error: red X -->
-            <XCircle v-else-if="block.status === 'error'" :size="14" color="#ef4444" class="tool-error-icon" />
-            <!-- Done (success or unknown): green check -->
-            <CheckCircle2 v-else :size="14" color="#22c55e" class="tool-check" />
+            <!-- Sub-agent: step count + expand/collapse toggle live IN the pill,
+                 so the Agent call and its sub-agent work are one row instead of
+                 two stacked bars showing the same name. -->
+            <template v-if="hasSubagentGroup(block)">
+              <span v-if="subagentStepCount(block.id) > 0" class="subagent-group-count">{{ t('chat.contentBlocks.subagentSteps', { count: subagentStepCount(block.id) }) }}</span>
+              <LoadingIndicator v-if="isSubagentStreaming(block)" class="tool-spinner" size="sm" inline />
+              <XCircle v-else-if="block.status === 'error'" :size="14" color="#ef4444" class="tool-error-icon" />
+              <CheckCircle2 v-else :size="14" color="#22c55e" class="tool-check" />
+              <button
+                type="button"
+                class="subagent-group-toggle"
+                :aria-expanded="isSubagentGroupOpen(bi, block)"
+                :aria-label="isSubagentGroupOpen(bi, block) ? t('chat.contentBlocks.subagentCollapse') : t('chat.contentBlocks.subagentExpand')"
+                :title="isSubagentGroupOpen(bi, block) ? t('chat.contentBlocks.subagentCollapse') : t('chat.contentBlocks.subagentExpand')"
+                @click.stop="$emit('toggle-tool', subagentGroupKey(bi, block))"
+              >
+                <ChevronUp v-if="isSubagentGroupOpen(bi, block)" :size="12" />
+                <ChevronDown v-else :size="12" />
+              </button>
+            </template>
+            <template v-else>
+              <!-- Loading: spinner -->
+              <LoadingIndicator v-if="!block.done" class="tool-spinner" size="sm" inline />
+              <!-- Done with error: red X -->
+              <XCircle v-else-if="block.status === 'error'" :size="14" color="#ef4444" class="tool-error-icon" />
+              <!-- Done (success or unknown): green check -->
+              <CheckCircle2 v-else :size="14" color="#22c55e" class="tool-check" />
+            </template>
           </div>
           <!-- All auto-expand tools render as unified cards above, so this
                branch only sees click-to-open pills (opens the detail drawer). -->
         </template>
+        <!-- Sub-agent group body: nested thinking/text/tool_use produced by the
+             sub-agent this Agent call spawned, rendered by a recursive
+             ContentBlocks instance so they get the exact same styles (thinking
+             callout/pill, tool pills) as top-level content. -->
+        <div v-if="hasSubagentGroup(block)" class="subagent-group" :class="{ 'subagent-group-open': isSubagentGroupOpen(bi, block) }">
+          <div class="subagent-group-body-wrapper" :class="{ 'subagent-group-body-open': isSubagentGroupOpen(bi, block) }">
+            <div class="subagent-group-body">
+              <ContentBlocks
+                :blocks="childBlocksOf(block.id)"
+                :root-blocks="rootBlocksResolved"
+                :nested="true"
+                :msg-id="props.msgId"
+                :msg-index="props.msgIndex"
+                :session-id="props.sessionId"
+                :expanded-tools="props.expandedTools"
+                :block-tasks="props.blockTasks"
+                :block-ask-questions="props.blockAskQuestions"
+                :streaming="props.streaming"
+                :started-at="props.startedAt"
+                :cancelled="props.cancelled"
+                :render-text-block="props.renderTextBlock"
+                :format-tool-input="props.formatToolInput"
+                :tool-call-summary="props.toolCallSummary"
+                :humanize-cron="props.humanizeCron"
+                :repeat-label="props.repeatLabel"
+                :truncate="props.truncate"
+                :get-agent-backend="props.getAgentBackend"
+                :get-agent-name="props.getAgentName"
+                :static-block-cache="props.staticBlockCache"
+                :active="props.active"
+                @toggle-tool="$emit('toggle-tool', $event)"
+                @show-tool-detail="forwardSubagentToolDetail"
+                @task-card-click="$emit('task-card-click', $event)"
+                @send-message="$emit('send-message', $event)"
+                @render-flush="$emit('render-flush')"
+                @resume-session="$emit('resume-session', $event)"
+                @reset-session="$emit('reset-session', $event)"
+              />
+            </div>
+          </div>
+        </div>
       </template>
       <!-- Error block -->
       <div v-else-if="block.type === 'error'" class="chat-error-card">
@@ -285,7 +351,7 @@
     </template>
     </template>
     <!-- Loading dots while AI is still streaming (not when cancelled, and not when showing summary) -->
-    <div v-if="streaming && !cancelled && !(showingSummary && summary)" class="streaming-status">
+    <div v-if="!nested && streaming && !cancelled && !(showingSummary && summary)" class="streaming-status">
       <div class="placeholder-dots"><span></span><span></span><span></span></div>
       <span class="streaming-elapsed" role="timer">{{ elapsedLabel }}</span>
     </div>
@@ -481,6 +547,12 @@ const props = defineProps({
   // Performance: static block cache from useChatRender (Problem 6)
   staticBlockCache: { type: Object as () => any, default: null },
   active: { type: Boolean, default: true },
+  // Recursive rendering: a nested instance renders one sub-agent group's child
+  // blocks. `nested` suppresses the footer/summary chrome; `rootBlocks` is the
+  // top-level blocks array so absolute indices (for caches + the detail drawer)
+  // resolve correctly at any depth.
+  nested: { type: Boolean, default: false },
+  rootBlocks: { type: Array as () => any[], default: null },
 })
 
 const emit = defineEmits(['toggle-tool', 'show-tool-detail', 'task-card-click', 'send-message', 'render-flush', 'resume-session', 'reset-session'])
@@ -522,14 +594,27 @@ const elapsedLabel = computed(() => {
   return `${minutes}m ${seconds}s`
 })
 
+// ── Absolute index resolution (recursive rendering) ──
+// A nested instance (sub-agent group) renders its own child blocks with local
+// indices 0..n-1, but every per-block cache key and the detail drawer's live
+// lookup are keyed by the ABSOLUTE index in the root blocks array. Resolve by
+// object identity so nested instances stay correctly keyed at any depth.
+const rootBlocksResolved = computed(() => props.rootBlocks || props.blocks)
+function absIdx(bi: number): number {
+  if (!props.nested || !props.rootBlocks) return bi
+  const block = props.blocks[bi]
+  const idx = rootBlocksResolved.value.indexOf(block)
+  return idx >= 0 ? idx : bi
+}
+
 // Key helper: use msgId if available, otherwise msgIndex
 function key(bi: number) {
-  return blockKey(props.msgId, bi)
+  return blockKey(props.msgId, absIdx(bi))
 }
 
 // Key for blockTasks/blockAskQuestions lookup — prefix format used in useChatRender.ts
 function blockTaskKey(bi: number) {
-  return blockTaskKeyUtil(props.msgId, bi)
+  return blockTaskKeyUtil(props.msgId, absIdx(bi))
 }
 
 // Quick check if block text contains <ask-question> tag — used in v-else-if condition
@@ -563,6 +648,89 @@ const summaryTools = computed(() => (props.summaryCards?.tools || []).filter((t:
 const summaryTaskIDs = computed(() => props.summaryCards?.taskIDs || [])
 const summaryAskQuestions = computed(() => props.summaryCards?.askQuestions || [])
 const summaryWarnings = computed(() => props.summaryCards?.warnings || [])
+
+// ── Sub-agent grouping (recursive) ──
+// Blocks carrying a `parent_tool_call_id` were produced by a sub-agent spawned
+// by that Agent tool call; they render nested under the Agent block instead of
+// in the flat stream. Grouping is computed from the ROOT blocks array so it is
+// identical at every recursion depth (a depth-2 sub-agent's children group under
+// its own id).
+//
+// Orphans — a child whose parent id matches no block in the message (e.g. the
+// Agent block was rejected/removed) — would otherwise be skipped by the flat
+// loop AND never rendered by any group, silently losing content. They are
+// rendered flat as a fallback instead.
+const childBlocksByParent = computed(() => {
+  const map: Record<string, any[]> = {}
+  for (const b of rootBlocksResolved.value) {
+    const pid = b?.parent_tool_call_id
+    if (pid) {
+      if (!map[pid]) map[pid] = []
+      map[pid].push(b)
+    }
+  }
+  return map
+})
+
+/** Child blocks of the Agent tool call with the given id (empty when none). */
+function childBlocksOf(agentToolId: string | undefined): any[] {
+  if (!agentToolId) return []
+  return childBlocksByParent.value[agentToolId] || []
+}
+
+/** Ids of blocks present in the CURRENT blocks array (not the root). A block is
+ *  skipped in this iteration iff its parent is rendered in this same array —
+ *  i.e. the parent hosts a group right here. In a nested instance the array is
+ *  already a group's children, so they are not skipped (and a depth-2 child
+ *  whose parent is a sibling in this array is skipped, rendering under that
+ *  parent's own recursive group). */
+const currentBlockIds = computed(() => {
+  const ids = new Set<string>()
+  for (const b of props.blocks) {
+    if (b?.id) ids.add(b.id)
+  }
+  return ids
+})
+
+/** True when this block is rendered under a sibling parent's group (so it is
+ *  skipped in this flat loop). Orphans — whose parent id matches no block — and
+ *  blocks whose parent is not in this array render flat as a fallback. */
+function isChildBlock(block: any): boolean {
+  const pid = block?.parent_tool_call_id
+  if (!pid) return false
+  return currentBlockIds.value.has(pid)
+}
+
+/** Expand key for a sub-agent group: reuses the Agent block's stable key. */
+function subagentGroupKey(bi: number, block: any): string {
+  return `subagent-${stableBlockKey(absIdx(bi), block)}`
+}
+
+/** Whether the sub-agent group under this Agent block is expanded. */
+function isSubagentGroupOpen(bi: number, block: any): boolean {
+  return !!props.expandedTools[subagentGroupKey(bi, block)]
+}
+
+/** Whether the parent Agent tool is still running (drives the group spinner). */
+function isSubagentStreaming(block: any): boolean {
+  return !block?.done
+}
+
+/** Step count for a group: number of child tool calls (the meaningful unit of
+ *  sub-agent progress). */
+function subagentStepCount(agentToolId: string | undefined): number {
+  return childBlocksOf(agentToolId).filter((b) => b.type === 'tool_use').length
+}
+
+/** Whether the Agent block has a sub-agent group to render. */
+function hasSubagentGroup(block: any): boolean {
+  return !!block?.id && childBlocksOf(block.id).length > 0
+}
+
+/** Forward a child block's tool-detail event with its real root index. */
+function forwardSubagentToolDetail(payload: any) {
+  emit('show-tool-detail', payload)
+}
 
 
 
@@ -864,10 +1032,11 @@ function flushBlockHtml() {
 }
 
 function getBlockHtml(bi: number, block: any) {
+  const ai = absIdx(bi)
   if (!props.streaming) {
     // Non-streaming: full pipeline with cache
     if (props.staticBlockCache) {
-      const cached = props.staticBlockCache.get(props.msgId, bi, block.text)
+      const cached = props.staticBlockCache.get(props.msgId, ai, block.text)
       if (cached !== undefined) {
         return cached
       }
@@ -875,22 +1044,22 @@ function getBlockHtml(bi: number, block: any) {
       // Deferred rendering (skipEnhancements=true → scheduleUpgrade) causes
       // scrollHeight to change after initial paint, creating a visible "snap"
       // when scrollToBottom corrects for the height difference.
-      const fullHtml = props.renderTextBlock(block.text, props.msgId, bi, false, false)
-      props.staticBlockCache.set(props.msgId, bi, block.text, fullHtml, false)
+      const fullHtml = props.renderTextBlock(block.text, props.msgId, ai, false, false)
+      props.staticBlockCache.set(props.msgId, ai, block.text, fullHtml, false)
       return fullHtml
     }
-    return props.renderTextBlock(block.text, props.msgId, bi, false)
+    return props.renderTextBlock(block.text, props.msgId, ai, false)
   }
   // Streaming + panel not visible: skip expensive markdown parsing
   if (!props.active) {
     return ''
   }
   // Streaming: deferred rendering with throttling
-  const key = stableBlockKey(bi, block)
+  const key = stableBlockKey(ai, block)
   if (blockHtmlCache.value[key] !== undefined) {
     if (!_throttleTimer) {
       const newCache = { ...blockHtmlCache.value }
-      newCache[key] = props.renderTextBlock(block.text, props.msgId, bi, true)
+      newCache[key] = props.renderTextBlock(block.text, props.msgId, ai, true)
       blockHtmlCache.value = newCache
       _throttleTimer = setTimeout(flushBlockHtml, THROTTLE_MS)
     } else {
@@ -898,7 +1067,7 @@ function getBlockHtml(bi: number, block: any) {
     }
     return blockHtmlCache.value[key]
   }
-  const html = props.renderTextBlock(block.text, props.msgId, bi, true)
+  const html = props.renderTextBlock(block.text, props.msgId, ai, true)
   blockHtmlCache.value = { ...blockHtmlCache.value, [key]: html }
   return html
 }
@@ -927,7 +1096,7 @@ function getThinkingTextHtml(text: string, bi: number, block: any) {
   }
   // Streaming: skip KaTeX (formulas may be incomplete)
   const streamingOpts = { skipKatex: true } as const
-  const cacheKey = `t-${stableBlockKey(bi, block)}`
+  const cacheKey = `t-${stableBlockKey(absIdx(bi), block)}`
   // Streaming: deferred rendering with throttling (same pattern as text blocks)
   if (blockHtmlCache.value[cacheKey] !== undefined) {
     if (!_throttleTimer) {
@@ -1544,6 +1713,80 @@ onUnmounted(() => {
 .chat-tool-call .tool-error-icon {
   flex-shrink: 0;
   margin-left: auto;
+}
+
+/* ── Sub-agent group ──
+   Collapsed: the Agent pill is IDENTICAL to every other tool pill (no special
+   shape). Expanded: the pill becomes the rounded-rectangle top half and the
+   body below joins it as a matching rounded-rectangle bottom half (2px pink
+   accent border, small radius). The body holds a recursive ContentBlocks
+   instance, so child thinking/tool blocks keep their normal callout/pill
+   styling. */
+.subagent-group {
+  --subagent-accent: #ec4899;
+  margin: 0 0 4px;
+}
+
+/* Only when expanded does the pill's shape change: it becomes the rounded-
+   rectangle top half of the group (small radius, not a pill). */
+.chat-tool-call-group-open {
+  border-radius: 6px 6px 0 0;
+}
+
+.subagent-group-open > .subagent-group-body-wrapper {
+  border-left: 2px solid color-mix(in srgb, var(--subagent-accent) 35%, transparent);
+  border-right: 2px solid color-mix(in srgb, var(--subagent-accent) 35%, transparent);
+  border-bottom: 2px solid color-mix(in srgb, var(--subagent-accent) 35%, transparent);
+  border-bottom-left-radius: 6px;
+  border-bottom-right-radius: 6px;
+  background: color-mix(in srgb, var(--subagent-accent) 4%, transparent);
+}
+
+.subagent-group-count {
+  font-size: 10px;
+  color: var(--text-muted);
+  flex-shrink: 0;
+}
+
+/* In-pill expand/collapse chevron button. */
+.subagent-group-toggle {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  flex-shrink: 0;
+  padding: 0;
+  margin-left: 2px;
+  border: none;
+  background: none;
+  cursor: pointer;
+  color: var(--text-tertiary, #999);
+  transition: color 0.15s;
+}
+
+.subagent-group-toggle:hover {
+  color: var(--tool-accent, var(--subagent-accent));
+}
+
+/* Body: grid 0fr↔1fr transition (same technique as thinking). */
+.subagent-group-body-wrapper {
+  display: grid;
+  grid-template-rows: 0fr;
+  opacity: 0;
+  transition: grid-template-rows 200ms ease, opacity 200ms ease;
+}
+
+.subagent-group-body-wrapper.subagent-group-body-open {
+  grid-template-rows: 1fr;
+  opacity: 1;
+}
+
+.subagent-group-body {
+  overflow: hidden;
+  min-height: 0;
+}
+
+.subagent-group-body-open .subagent-group-body {
+  padding: 6px 10px;
 }
 
 /* Inline tool detail — only used by AskUserQuestion (other tools use ToolDetailDrawer) */

--- a/web/src/components/chat/__tests__/AttachDrawer.test.ts
+++ b/web/src/components/chat/__tests__/AttachDrawer.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it, vi, beforeEach } from 'vitest'
+import { describe, expect, it, vi, beforeEach, afterEach } from 'vitest'
 import { mount } from '@vue/test-utils'
 import { createI18n } from 'vue-i18n'
 import { ref, nextTick, h, defineComponent } from 'vue'
@@ -432,6 +432,69 @@ describe('AttachDrawer', () => {
     await fileRow.find('.ad-file-open').trigger('click')
     expect(wrapper.emitted('file-open')).toBeTruthy()
     expect(wrapper.emitted('file-open')![0]).toEqual(['src/main.ts'])
+  })
+
+  describe('uploads tab content', () => {
+    beforeEach(() => {
+      sharedPendingFiles.value = []
+      sharedAttachedFiles.value = []
+      sharedRecentUploads.value = []
+    })
+    afterEach(() => {
+      sharedPendingFiles.value = []
+      sharedAttachedFiles.value = []
+      sharedRecentUploads.value = []
+    })
+
+    async function openUploadsTab(wrapper: ReturnType<typeof mountDrawer>) {
+      await wrapper.findAll('.ad-tab')[3].trigger('click')
+      await nextTick()
+      await nextTick()
+    }
+
+    it('renders only in-flight pending uploads as rows', async () => {
+      sharedPendingFiles.value = [
+        { path: '', previewUrl: null, isImage: false, uploading: true, progress: 40, size: 100 },
+        { path: '/tmp/done.txt', previewUrl: null, isImage: false, uploading: false, progress: 100, size: 100 },
+      ]
+      const wrapper = mountDrawer()
+      await openUploadsTab(wrapper)
+      const rows = wrapper.find('.ad-content').findAll('.ad-file-row')
+      expect(rows.length).toBe(1)
+      expect(wrapper.find('.ad-content').text()).toContain('40%')
+    })
+
+    it('shows the empty state when a finished entry is retained and recent uploads is empty', async () => {
+      // Regression: a non-uploading entry kept in pendingFiles (e.g. an
+      // auto-attached paste/drag upload) used to hide every row via v-show while
+      // also suppressing the empty state, collapsing the content area to nothing.
+      sharedPendingFiles.value = [
+        { path: '/tmp/kept.txt', previewUrl: null, isImage: false, uploading: false, progress: 100, size: 100 },
+      ]
+      sharedAttachedFiles.value = [{ path: '/tmp/kept.txt' }]
+      sharedRecentUploads.value = []
+      const wrapper = mountDrawer()
+      await openUploadsTab(wrapper)
+      const content = wrapper.find('.ad-content')
+      expect(content.findAll('.ad-file-row').length).toBe(0)
+      expect(content.find('.ad-empty').exists()).toBe(true)
+      expect(content.text()).toContain('No uploaded files')
+    })
+
+    it('renders recent uploads rows even when a finished entry is retained', async () => {
+      sharedPendingFiles.value = [
+        { path: '/tmp/kept.txt', previewUrl: null, isImage: false, uploading: false, progress: 100, size: 100 },
+      ]
+      sharedAttachedFiles.value = [{ path: '/tmp/kept.txt' }]
+      sharedRecentUploads.value = [
+        { name: 'kept.txt', path: '/tmp/kept.txt', size: 100, modTime: new Date().toISOString() },
+      ]
+      const wrapper = mountDrawer()
+      await openUploadsTab(wrapper)
+      const content = wrapper.find('.ad-content')
+      expect(content.findAll('.ad-file-row').length).toBe(1)
+      expect(content.find('.ad-empty').exists()).toBe(false)
+    })
   })
 
   it('upload watcher cleans up finished uploads and refreshes', async () => {

--- a/web/src/components/chat/__tests__/ContentBlocks.test.ts
+++ b/web/src/components/chat/__tests__/ContentBlocks.test.ts
@@ -112,7 +112,6 @@ const i18n = createI18n({
         retry: 'Retry',
         continue: 'Continue',
         resetSession: 'Reset session',
-        subagentGroup: 'Sub-agent',
         subagentSteps: '{count} steps',
         subagentExpand: 'Expand sub-agent output',
         subagentCollapse: 'Collapse sub-agent output',
@@ -145,7 +144,6 @@ function mountBlocks(props: Record<string, unknown> = {}) {
         // icon" test verifies the real component renders. Stub every other
         // lucide icon explicitly instead of the package-level stub.
         Brain: LucideStub,
-        Bot: LucideStub,
         ChevronRight: LucideStub,
         ChevronDown: LucideStub,
         ChevronUp: LucideStub,
@@ -1390,6 +1388,7 @@ describe('ContentBlocks — sub-agent grouping', () => {
         { type: 'tool_use', name: 'Read', id: 't1', done: true, input: {}, parent_tool_call_id: 'call_p' },
         { type: 'text', text: 'child answer', parent_tool_call_id: 'call_p' },
       ],
+      expandedTools: { 'subagent-call_p': true },
     })
     // The expand/collapse toggle lives INSIDE the Agent pill — no separate
     // group header bar duplicating the agent name.
@@ -1408,6 +1407,49 @@ describe('ContentBlocks — sub-agent grouping', () => {
     expect(directPills.length).toBe(1)
   })
 
+  it('does not mount the recursive body until the group is first opened', () => {
+    const collapsed = mountBlocks({
+      blocks: [
+        { type: 'tool_use', name: 'Agent', id: 'call_p', done: true, input: {} },
+        { type: 'tool_use', name: 'Read', id: 't1', done: true, input: {}, parent_tool_call_id: 'call_p' },
+      ],
+    })
+    // Collapsed: the child subtree is not instantiated at all.
+    expect(collapsed.find('.subagent-group-body .content-blocks-nested').exists()).toBe(false)
+
+    const open = mountBlocks({
+      blocks: [
+        { type: 'tool_use', name: 'Agent', id: 'call_p', done: true, input: {} },
+        { type: 'tool_use', name: 'Read', id: 't1', done: true, input: {}, parent_tool_call_id: 'call_p' },
+      ],
+      expandedTools: { 'subagent-call_p': true },
+    })
+    expect(open.find('.subagent-group-body .content-blocks-nested').exists()).toBe(true)
+  })
+
+  it('child tool detail is emitted with its real ROOT block index', async () => {
+    // Regression: nested instances must translate the local index back to the
+    // root array index — the drawer resolves the live block by root index.
+    const wrapper = mountBlocks({
+      blocks: [
+        { type: 'tool_use', name: 'Agent', id: 'call_p', done: true, input: {} },
+        { type: 'thinking', text: 'child reasoning', parent_tool_call_id: 'call_p' },
+        { type: 'tool_use', name: 'Read', id: 't1', done: true, input: {}, parent_tool_call_id: 'call_p' },
+      ],
+      expandedTools: { 'subagent-call_p': true },
+    })
+    const group = wrapper.find('.subagent-group')
+    const childPill = group.findAll('.chat-tool-call').find((p) => p.text().includes('Read'))!
+    expect(childPill).toBeTruthy()
+    await childPill.trigger('click')
+    const events = wrapper.emitted('show-tool-detail')
+    expect(events).toBeTruthy()
+    const detail = events!.find((e) => (e[0] as any).name === 'Read')?.[0] as any
+    expect(detail).toBeTruthy()
+    // The Read block is at root index 2 (Agent=0, thinking=1, Read=2).
+    expect(detail.blockIdx).toBe(2)
+  })
+
   it('toggling the in-pill chevron emits toggle-tool with the group key', async () => {
     const wrapper = mountBlocks({
       blocks: [
@@ -1417,6 +1459,31 @@ describe('ContentBlocks — sub-agent grouping', () => {
     })
     await wrapper.find('.subagent-group-toggle').trigger('click')
     const events = wrapper.emitted('toggle-tool')
+    expect(events).toBeTruthy()
+    expect(events![0][0]).toBe('subagent-call_p')
+  })
+
+  it('renders a bottom footer collapse button only while open, and it toggles', async () => {
+    const collapsed = mountBlocks({
+      blocks: [
+        { type: 'tool_use', name: 'Agent', id: 'call_p', done: true, input: {} },
+        { type: 'tool_use', name: 'Read', id: 't1', done: true, input: {}, parent_tool_call_id: 'call_p' },
+      ],
+    })
+    // Body is not mounted while collapsed → no footer.
+    expect(collapsed.find('.subagent-group-footer').exists()).toBe(false)
+
+    const open = mountBlocks({
+      blocks: [
+        { type: 'tool_use', name: 'Agent', id: 'call_p', done: true, input: {} },
+        { type: 'tool_use', name: 'Read', id: 't1', done: true, input: {}, parent_tool_call_id: 'call_p' },
+      ],
+      expandedTools: { 'subagent-call_p': true },
+    })
+    const footer = open.find('.subagent-group-footer')
+    expect(footer.exists()).toBe(true)
+    await footer.trigger('click')
+    const events = open.emitted('toggle-tool')
     expect(events).toBeTruthy()
     expect(events![0][0]).toBe('subagent-call_p')
   })
@@ -1474,6 +1541,8 @@ describe('ContentBlocks — sub-agent grouping', () => {
         { type: 'tool_use', name: 'Agent', id: 'call_c', done: true, input: {}, parent_tool_call_id: 'call_p' },
         { type: 'text', text: 'grandchild content', parent_tool_call_id: 'call_c' },
       ],
+      // Open both levels so the recursive subtrees mount.
+      expandedTools: { 'subagent-call_p': true, 'subagent-call_c': true },
     })
     // Both Agent blocks render a group; the grandchild nests under call_c.
     expect(wrapper.findAll('.subagent-group').length).toBe(2)

--- a/web/src/components/chat/__tests__/ContentBlocks.test.ts
+++ b/web/src/components/chat/__tests__/ContentBlocks.test.ts
@@ -112,6 +112,10 @@ const i18n = createI18n({
         retry: 'Retry',
         continue: 'Continue',
         resetSession: 'Reset session',
+        subagentGroup: 'Sub-agent',
+        subagentSteps: '{count} steps',
+        subagentExpand: 'Expand sub-agent output',
+        subagentCollapse: 'Collapse sub-agent output',
       },
     },
     tool: {
@@ -141,6 +145,7 @@ function mountBlocks(props: Record<string, unknown> = {}) {
         // icon" test verifies the real component renders. Stub every other
         // lucide icon explicitly instead of the package-level stub.
         Brain: LucideStub,
+        Bot: LucideStub,
         ChevronRight: LucideStub,
         ChevronDown: LucideStub,
         ChevronUp: LucideStub,
@@ -1373,5 +1378,119 @@ describe('AskUserQuestion card interactive dispatch', () => {
 
     expect(handleToolAction).toHaveBeenCalled()
     expect(handleToolAction.mock.calls[0][0]).toBe('AskUserQuestion')
+  })
+})
+
+describe('ContentBlocks — sub-agent grouping', () => {
+  it('merges the group into the Agent pill (one row, not two stacked bars)', () => {
+    const wrapper = mountBlocks({
+      blocks: [
+        { type: 'tool_use', name: 'Agent', id: 'call_p', done: true, input: {} },
+        { type: 'thinking', text: 'child reasoning', parent_tool_call_id: 'call_p' },
+        { type: 'tool_use', name: 'Read', id: 't1', done: true, input: {}, parent_tool_call_id: 'call_p' },
+        { type: 'text', text: 'child answer', parent_tool_call_id: 'call_p' },
+      ],
+    })
+    // The expand/collapse toggle lives INSIDE the Agent pill — no separate
+    // group header bar duplicating the agent name.
+    const pill = wrapper.find('.chat-tool-call-group')
+    expect(pill.exists()).toBe(true)
+    expect(pill.find('.subagent-group-toggle').exists()).toBe(true)
+    expect(wrapper.find('.subagent-group-header').exists()).toBe(false)
+    // The child Read pill must live INSIDE the group body, not at the top level.
+    const group = wrapper.find('.subagent-group')
+    expect(group.find('.chat-tool-call').exists()).toBe(true)
+    // The root content-blocks container has exactly one direct tool pill: Agent.
+    const root = wrapper.find('.content-blocks')
+    const directPills = root.element.children && Array.from(root.element.children).filter(
+      (el) => (el as HTMLElement).classList.contains('chat-tool-call'),
+    )
+    expect(directPills.length).toBe(1)
+  })
+
+  it('toggling the in-pill chevron emits toggle-tool with the group key', async () => {
+    const wrapper = mountBlocks({
+      blocks: [
+        { type: 'tool_use', name: 'Agent', id: 'call_p', done: true, input: {} },
+        { type: 'tool_use', name: 'Read', id: 't1', done: true, input: {}, parent_tool_call_id: 'call_p' },
+      ],
+    })
+    await wrapper.find('.subagent-group-toggle').trigger('click')
+    const events = wrapper.emitted('toggle-tool')
+    expect(events).toBeTruthy()
+    expect(events![0][0]).toBe('subagent-call_p')
+  })
+
+  it('renders step count from child tool calls', () => {
+    const wrapper = mountBlocks({
+      blocks: [
+        { type: 'tool_use', name: 'Agent', id: 'call_p', done: true, input: {} },
+        { type: 'tool_use', name: 'Read', id: 't1', done: true, input: {}, parent_tool_call_id: 'call_p' },
+        { type: 'tool_use', name: 'Grep', id: 't2', done: true, input: {}, parent_tool_call_id: 'call_p' },
+      ],
+    })
+    expect(wrapper.html()).toContain('2 steps')
+  })
+
+  it('expands child content when the group is open', () => {
+    const wrapper = mountBlocks({
+      blocks: [
+        { type: 'tool_use', name: 'Agent', id: 'call_p', done: true, input: {} },
+        { type: 'text', text: 'nested answer', parent_tool_call_id: 'call_p' },
+      ],
+      expandedTools: { 'subagent-call_p': true },
+    })
+    expect(wrapper.find('.subagent-group-body-open').exists()).toBe(true)
+    expect(wrapper.html()).toContain('nested answer')
+  })
+
+  it('does not group blocks without a parent link', () => {
+    const wrapper = mountBlocks({
+      blocks: [
+        { type: 'tool_use', name: 'Agent', id: 'call_p', done: true, input: {} },
+        { type: 'text', text: 'top level' },
+      ],
+    })
+    expect(wrapper.find('.subagent-group').exists()).toBe(false)
+    expect(wrapper.html()).toContain('top level')
+  })
+
+  it('renders orphan child blocks flat (parent absent) instead of dropping them', () => {
+    const wrapper = mountBlocks({
+      blocks: [
+        { type: 'text', text: 'orphan child content', parent_tool_call_id: 'call_missing' },
+      ],
+    })
+    expect(wrapper.find('.subagent-group').exists()).toBe(false)
+    expect(wrapper.html()).toContain('orphan child content')
+  })
+
+  it('recursively groups a depth-2 sub-agent under its own Agent block', () => {
+    const wrapper = mountBlocks({
+      blocks: [
+        { type: 'tool_use', name: 'Agent', id: 'call_p', done: true, input: {} },
+        // depth-2: call_c is itself a child, but it is a known block id, so its
+        // own children group under it recursively.
+        { type: 'tool_use', name: 'Agent', id: 'call_c', done: true, input: {}, parent_tool_call_id: 'call_p' },
+        { type: 'text', text: 'grandchild content', parent_tool_call_id: 'call_c' },
+      ],
+    })
+    // Both Agent blocks render a group; the grandchild nests under call_c.
+    expect(wrapper.findAll('.subagent-group').length).toBe(2)
+    expect(wrapper.html()).toContain('grandchild content')
+  })
+
+  it('reuses the same tool pill markup for child tools (no bespoke styling)', () => {
+    const wrapper = mountBlocks({
+      blocks: [
+        { type: 'tool_use', name: 'Agent', id: 'call_p', done: true, input: {} },
+        { type: 'tool_use', name: 'Read', id: 't1', done: true, input: {}, parent_tool_call_id: 'call_p' },
+      ],
+      expandedTools: { 'subagent-call_p': true },
+    })
+    // The child tool renders through the recursive ContentBlocks instance, so it
+    // gets the exact same .chat-tool-call pill as a top-level tool.
+    const group = wrapper.find('.subagent-group')
+    expect(group.find('.chat-tool-call').exists()).toBe(true)
   })
 })

--- a/web/src/components/settings/UpgradeDialog.vue
+++ b/web/src/components/settings/UpgradeDialog.vue
@@ -53,6 +53,16 @@
           <p class="ug-warn-hint">{{ t('upgrade.installDirNotWritableHint') }}</p>
         </div>
 
+        <!-- Docker advisory: a container CAN self-upgrade, but a later rebuild
+             from the unchanged image reverts it — recommend the image path
+             without blocking the in-place upgrade. -->
+        <div v-if="showDockerHint" class="ug-hint">
+          <p class="ug-hint-title">{{ t('upgrade.dockerHintTitle') }}</p>
+          <p class="ug-hint-body">{{ t('upgrade.dockerHintBody') }}</p>
+          <code class="ug-hint-cmd">docker pull ghcr.io/clawbench-dev/clawbench:latest &amp;&amp; docker compose up -d</code>
+          <p class="ug-hint-warn">{{ t('upgrade.dockerHintRestart') }}</p>
+        </div>
+
         <!-- Progress area -->
         <div v-if="isInProgress || isRestarting" class="ug-progress-area">
           <template v-if="state.phase === 'downloading'">
@@ -116,7 +126,7 @@ defineExpose({ show })
 const { t } = useI18n()
 const {
   state, checking, hasUpgrade, isInProgress, isRestarting, isCompleted, isFailed,
-  installWritable, installDir, checkUpgrade, startUpgrade, releaseNotesUrl,
+  installWritable, installDir, isDocker, checkUpgrade, startUpgrade, releaseNotesUrl,
 } = useUpgrade()
 
 /**
@@ -129,6 +139,19 @@ const showWritableWarning = computed(() =>
   hasUpgrade.value &&
   !checking.value &&
   !installWritable.value &&
+  !isInProgress.value &&
+  !isCompleted.value &&
+  !isFailed.value,
+)
+
+/**
+ * Docker advisory — same visibility window as the writability warning: only
+ * while the user is deciding. Informational, never blocking.
+ */
+const showDockerHint = computed(() =>
+  hasUpgrade.value &&
+  !checking.value &&
+  isDocker.value &&
   !isInProgress.value &&
   !isCompleted.value &&
   !isFailed.value,
@@ -357,6 +380,49 @@ watch(visible, (v) => {
   margin: 0;
   font-size: 12px;
   color: var(--text-muted);
+}
+
+/* Docker advisory (informational, non-fatal) */
+.ug-hint {
+  margin: 0 16px 12px;
+  padding: 10px 12px;
+  border-radius: 8px;
+  background: color-mix(in srgb, var(--accent-color) 10%, transparent);
+  border: 1px solid color-mix(in srgb, var(--accent-color) 30%, transparent);
+  text-align: left;
+}
+
+.ug-hint-title {
+  margin: 0 0 6px;
+  font-size: 13px;
+  font-weight: 600;
+  color: var(--accent-color);
+}
+
+.ug-hint-body {
+  margin: 0 0 8px;
+  font-size: 12px;
+  color: var(--text-secondary);
+  word-break: break-word;
+}
+
+.ug-hint-cmd {
+  display: block;
+  padding: 6px 8px;
+  border-radius: 6px;
+  background: var(--bg-tertiary);
+  color: var(--text-primary);
+  font-size: 11px;
+  font-family: var(--font-mono, monospace);
+  word-break: break-all;
+  user-select: all;
+}
+
+.ug-hint-warn {
+  margin: 8px 0 0;
+  font-size: 11px;
+  color: var(--text-warning, #d69e2e);
+  line-height: 1.5;
 }
 
 .ug-error-title {

--- a/web/src/components/settings/__tests__/UpgradeDialog.test.ts
+++ b/web/src/components/settings/__tests__/UpgradeDialog.test.ts
@@ -29,6 +29,9 @@ const i18n = createI18n({
         installDirNotWritableTitle: '无法自动升级：安装目录不可写',
         installDirNotWritableBody: '当前用户对 {dir} 没有写权限。',
         installDirNotWritableHint: '请用 sudo 手动更新，或安装到用户可写目录。',
+        dockerHintTitle: '当前运行在 Docker 中',
+        dockerHintBody: '就地升级仍然可用，但用未更新的镜像重建容器会回退到旧版本。',
+        dockerHintRestart: '容器必须使用 --restart always 或 --restart unless-stopped，否则就地升级后服务不会自动恢复。请勿使用 --restart on-failure：服务以退出码 0 结束，该策略不会触发重启。',
       },
     },
   },
@@ -55,6 +58,7 @@ const mockIsFailed = ref(false)
 const mockReleaseNotesUrl = ref('https://example.com/releases')
 const mockInstallWritable = ref(true)
 const mockInstallDir = ref('')
+const mockIsDocker = ref(false)
 
 const mockCheckUpgrade = vi.fn()
 const mockStartUpgrade = vi.fn()
@@ -78,6 +82,7 @@ vi.mock('@/composables/useUpgrade', async (importOriginal) => {
       releaseNotesUrl: mockReleaseNotesUrl,
       installWritable: mockInstallWritable,
       installDir: mockInstallDir,
+      isDocker: mockIsDocker,
     }),
   }
 })
@@ -139,6 +144,7 @@ beforeEach(() => {
   mockReleaseNotesUrl.value = 'https://example.com/releases'
   mockInstallWritable.value = true
   mockInstallDir.value = ''
+  mockIsDocker.value = false
 })
 
 describe('UpgradeDialog', () => {
@@ -437,6 +443,76 @@ describe('UpgradeDialog', () => {
       ;(wrapper!.vm as any).show()
       await nextTick()
       expect($('.ug-warn')).toBeFalsy()
+    })
+  })
+
+  describe('docker advisory hint', () => {
+    it('shows the advisory when running in Docker', async () => {
+      mockIsDocker.value = true
+      const wrapper = mountDialog()
+      ;(wrapper!.vm as any).show()
+      await nextTick()
+      expect($('.ug-hint')).toBeTruthy()
+      expect(document.body.textContent).toContain('当前运行在 Docker 中')
+      expect($('.ug-hint-cmd')!.textContent).toContain('docker pull')
+    })
+
+    it('warns about the restart policy requirement', async () => {
+      mockIsDocker.value = true
+      const wrapper = mountDialog()
+      ;(wrapper!.vm as any).show()
+      await nextTick()
+      expect($('.ug-hint-warn')).toBeTruthy()
+      expect(document.body.textContent).toContain('重启')
+    })
+
+    it('names the working policies and warns that on-failure does not restart', async () => {
+      // The server exits with code 0 after a graceful shutdown, so only
+      // `always` / `unless-stopped` bring it back; `on-failure` never fires.
+      // The hint must say so explicitly or users pick the "safer" on-failure.
+      mockIsDocker.value = true
+      const wrapper = mountDialog()
+      ;(wrapper!.vm as any).show()
+      await nextTick()
+      const text = $('.ug-hint-warn')!.textContent ?? ''
+      expect(text).toContain('--restart always')
+      expect(text).toContain('--restart unless-stopped')
+      expect(text).toContain('on-failure')
+    })
+
+    it('does not show the advisory outside Docker', async () => {
+      mockIsDocker.value = false
+      const wrapper = mountDialog()
+      ;(wrapper!.vm as any).show()
+      await nextTick()
+      expect($('.ug-hint')).toBeFalsy()
+    })
+
+    it('does not block the upgrade — start button stays enabled', async () => {
+      mockIsDocker.value = true
+      mockHasUpgrade.value = true
+      const wrapper = mountDialog()
+      ;(wrapper!.vm as any).show()
+      await nextTick()
+      expect($('.ug-start')).toBeTruthy()
+    })
+
+    it('hides the advisory while an upgrade is in progress', async () => {
+      mockIsDocker.value = true
+      mockIsInProgress.value = true
+      const wrapper = mountDialog()
+      ;(wrapper!.vm as any).show()
+      await nextTick()
+      expect($('.ug-hint')).toBeFalsy()
+    })
+
+    it('hides the advisory when no upgrade is available', async () => {
+      mockIsDocker.value = true
+      mockHasUpgrade.value = false
+      const wrapper = mountDialog()
+      ;(wrapper!.vm as any).show()
+      await nextTick()
+      expect($('.ug-hint')).toBeFalsy()
     })
   })
 

--- a/web/src/composables/__tests__/useUpgrade.test.ts
+++ b/web/src/composables/__tests__/useUpgrade.test.ts
@@ -107,6 +107,7 @@ describe('useUpgrade', () => {
     upgrade.state.error_code = ''
     upgrade.installWritable.value = true
     upgrade.installDir.value = ''
+    upgrade.isDocker.value = false
   })
 
   // ── checkUpgrade ──
@@ -194,6 +195,33 @@ describe('useUpgrade', () => {
       await upgrade.checkUpgrade()
 
       expect(upgrade.installWritable.value).toBe(true)
+    })
+
+    it('records is_docker from the response', async () => {
+      mockApiGet.mockResolvedValue({
+        current_version: 'v1.0.0',
+        latest_version: 'v1.1.0',
+        has_upgrade: true,
+        is_docker: true,
+      })
+
+      const upgrade = useUpgrade()
+      await upgrade.checkUpgrade()
+
+      expect(upgrade.isDocker.value).toBe(true)
+    })
+
+    it('defaults is_docker to false when absent (older server)', async () => {
+      mockApiGet.mockResolvedValue({
+        current_version: 'v1.0.0',
+        latest_version: 'v1.1.0',
+        has_upgrade: true,
+      })
+
+      const upgrade = useUpgrade()
+      await upgrade.checkUpgrade()
+
+      expect(upgrade.isDocker.value).toBe(false)
     })
   })
 

--- a/web/src/composables/useChatStream.ts
+++ b/web/src/composables/useChatStream.ts
@@ -341,7 +341,7 @@ export function useChatStream(options: UseChatStreamOptions) {
         if (sessionChanged()) return
         if (!findStreamingMsg(messages.value)) return
         const contentData = payload as unknown as ContentEventData
-        dispatch({ type: 'ws_content', text: contentData.content ?? '' })
+        dispatch({ type: 'ws_content', text: contentData.content ?? '', parentToolCallId: contentData.parent_tool_call_id })
         debouncedRender()
         break
       }
@@ -350,7 +350,7 @@ export function useChatStream(options: UseChatStreamOptions) {
         if (sessionChanged()) return
         if (!findStreamingMsg(messages.value)) return
         const thinkingData = payload as unknown as ThinkingEventData
-        dispatch({ type: 'ws_thinking', text: thinkingData.text ?? '', key: `thinking-${thinkingBlockCounter++}` })
+        dispatch({ type: 'ws_thinking', text: thinkingData.text ?? '', key: `thinking-${thinkingBlockCounter++}`, parentToolCallId: thinkingData.parent_tool_call_id })
         // debouncedRender schedules the scroll pin in the same rAF — no
         // separate onScrollBottom here (duplicate pin in the same frame).
         debouncedRender()

--- a/web/src/composables/useUpgrade.ts
+++ b/web/src/composables/useUpgrade.ts
@@ -55,6 +55,13 @@ const showProgressDialog = ref(false)
 const installWritable = ref(true)
 const installDir = ref('')
 
+// Whether the server runs in a container, reported by /api/upgrade/check.
+// Docker can self-upgrade (the writable layer accepts the new binary and the
+// container restart policy brings it up), but a later rebuild from the
+// unchanged image reverts it — so the UI shows an advisory hint recommending
+// `docker pull`. Kept outside `state` for the same reason as installWritable.
+const isDocker = ref(false)
+
 let wsUnsubscribe: (() => void) | null = null
 let reconnectPollTimer: ReturnType<typeof setInterval> | null = null
 let pollStartTime: number | null = null
@@ -213,6 +220,7 @@ export function useUpgrade() {
         has_upgrade: boolean
         install_writable?: boolean
         install_dir?: string
+        is_docker?: boolean
       }>('/api/upgrade/check')
       state.current_version = data.current_version
       state.latest_version = data.latest_version
@@ -220,6 +228,8 @@ export function useUpgrade() {
       // Absent on older servers — default to writable so the UI is unchanged.
       installWritable.value = data.install_writable !== false
       installDir.value = data.install_dir ?? ''
+      // Absent on older servers — default to false (no advisory).
+      isDocker.value = data.is_docker === true
     } catch (e) {
       appLog.w(TAG, 'Check failed', e)
       hasUpgrade.value = false
@@ -318,6 +328,7 @@ export function useUpgrade() {
     showProgressDialog,
     installWritable,
     installDir,
+    isDocker,
     isInProgress,
     isRestarting,
     isCompleted,

--- a/web/src/i18n/locales/en.ts
+++ b/web/src/i18n/locales/en.ts
@@ -2449,6 +2449,9 @@ export default {
     installDirNotWritableTitle: 'Cannot upgrade automatically: install directory not writable',
     installDirNotWritableBody: 'The current user cannot write to {dir}, so the upgrade cannot create a backup or replace the binary there.',
     installDirNotWritableHint: 'Update manually with sudo, or install ClawBench to a user-writable directory (e.g. ~/.local/bin) and try again.',
+    dockerHintTitle: 'Running in Docker',
+    dockerHintBody: 'The in-place upgrade still works, but rebuilding the container from the unchanged image will revert it. Prefer updating the image instead:',
+    dockerHintRestart: 'The container must use --restart always or --restart unless-stopped, otherwise the service will not come back after an in-place upgrade. Do not use --restart on-failure: the server exits with code 0, so it would never restart.',
   },
   share: {
     loading: 'Loading...',

--- a/web/src/i18n/locales/en.ts
+++ b/web/src/i18n/locales/en.ts
@@ -700,6 +700,10 @@ export default {
       resetSessionFailed: 'Failed to reset session',
       detailsUnavailable: 'Details unavailable',
       detailsLoadFailed: 'Failed to load details',
+      subagentGroup: 'Sub-agent',
+      subagentSteps: '{count} steps',
+      subagentExpand: 'Expand sub-agent output',
+      subagentCollapse: 'Collapse sub-agent output',
       warningReasons: {
         user_cancel: 'User cancelled',
         disconnect: 'Connection lost, AI response interrupted',

--- a/web/src/i18n/locales/zh.ts
+++ b/web/src/i18n/locales/zh.ts
@@ -700,6 +700,10 @@ export default {
       resetSessionFailed: '重置会话失败',
       detailsUnavailable: '详情暂不可用',
       detailsLoadFailed: '加载失败',
+      subagentGroup: '子智能体',
+      subagentSteps: '{count} 步',
+      subagentExpand: '展开子智能体输出',
+      subagentCollapse: '收起子智能体输出',
       warningReasons: {
         user_cancel: '用户已中断',
         disconnect: '连接已断开，AI 响应中断',

--- a/web/src/i18n/locales/zh.ts
+++ b/web/src/i18n/locales/zh.ts
@@ -2449,6 +2449,9 @@ export default {
     installDirNotWritableTitle: '无法自动升级：安装目录不可写',
     installDirNotWritableBody: '当前用户对 {dir} 没有写权限，升级无法在该目录创建备份并替换二进制。',
     installDirNotWritableHint: '请用 sudo 手动更新，或将 ClawBench 安装到用户可写目录（如 ~/.local/bin）后重试。',
+    dockerHintTitle: '当前运行在 Docker 中',
+    dockerHintBody: '就地升级仍然可用，但用未更新的镜像重建容器会回退到旧版本。建议改用镜像更新：',
+    dockerHintRestart: '容器必须使用 --restart always 或 --restart unless-stopped，否则就地升级后服务不会自动恢复。请勿使用 --restart on-failure：服务以退出码 0 结束，该策略不会触发重启。',
   },
   share: {
     loading: '加载中...',

--- a/web/src/utils/__tests__/chatStreamUtils.test.ts
+++ b/web/src/utils/__tests__/chatStreamUtils.test.ts
@@ -2954,3 +2954,86 @@ describe('in-flight direct-send guard in rebuildFromDb', () => {
     expect(merged.filter((m: any) => m.role === 'user' && m.content === 'msg2')).toHaveLength(0)
   })
 })
+
+describe('sub-agent parent grouping (reducer)', () => {
+  const streamingMsg = (): any => ({
+    id: 1,
+    role: 'assistant',
+    content: '',
+    blocks: [],
+    streaming: true,
+    createdAt: '2026-01-01T00:00:00Z',
+  })
+
+  it('ws_content with parentToolCallId tags the block', () => {
+    let s = [streamingMsg()]
+    s = chatMessageReducer(s, { type: 'ws_content', text: 'child', parentToolCallId: 'call_p' })
+    expect(s[0].blocks![0]).toMatchObject({ type: 'text', text: 'child', parent_tool_call_id: 'call_p' })
+  })
+
+  it('ws_content top-level has no parent field', () => {
+    let s = [streamingMsg()]
+    s = chatMessageReducer(s, { type: 'ws_content', text: 'parent' })
+    expect(s[0].blocks![0].parent_tool_call_id).toBeUndefined()
+  })
+
+  it('parent and child text do not merge into one block', () => {
+    let s = [streamingMsg()]
+    s = chatMessageReducer(s, { type: 'ws_content', text: 'parent ' })
+    s = chatMessageReducer(s, { type: 'ws_content', text: 'child', parentToolCallId: 'call_p' })
+    s = chatMessageReducer(s, { type: 'ws_content', text: ' parent2' })
+    // parent text resumes must NOT merge into the child block: 3 text blocks
+    const texts = s[0].blocks!.filter((b: any) => b.type === 'text')
+    expect(texts.length).toBe(3)
+    expect(texts[0]).toMatchObject({ text: 'parent ' })
+    expect(texts[1]).toMatchObject({ text: 'child', parent_tool_call_id: 'call_p' })
+    expect(texts[2]).toMatchObject({ text: ' parent2' })
+  })
+
+  it('ws_thinking with parentToolCallId tags the block', () => {
+    let s = [streamingMsg()]
+    s = chatMessageReducer(s, { type: 'ws_thinking', text: 'reason', key: 'k1', parentToolCallId: 'call_p' })
+    expect(s[0].blocks![0]).toMatchObject({ type: 'thinking', text: 'reason', parent_tool_call_id: 'call_p' })
+  })
+
+  it('child thinking does not merge into parent thinking', () => {
+    let s = [streamingMsg()]
+    s = chatMessageReducer(s, { type: 'ws_thinking', text: 'pt' })
+    s = chatMessageReducer(s, { type: 'ws_thinking', text: 'ct', parentToolCallId: 'call_p' })
+    const thinks = s[0].blocks!.filter((b: any) => b.type === 'thinking')
+    expect(thinks.length).toBe(2)
+    expect(thinks[0].text).toBe('pt')
+    expect(thinks[1]).toMatchObject({ text: 'ct', parent_tool_call_id: 'call_p' })
+  })
+
+  it('ws_tool_use records parent_tool_call_id', () => {
+    let s = [streamingMsg()]
+    s = chatMessageReducer(s, { type: 'ws_tool_use', data: { id: 't1', name: 'Read', parent_tool_call_id: 'call_p' } as any })
+    expect(s[0].blocks![0]).toMatchObject({ type: 'tool_use', id: 't1', parent_tool_call_id: 'call_p' })
+  })
+})
+
+describe('sub-agent thinking_done', () => {
+  const streamingMsg = (): any => ({
+    id: 1, role: 'assistant', content: '', blocks: [], streaming: true, createdAt: '2026-01-01T00:00:00Z',
+  })
+
+  it('marks a sub-agent thinking block done (parent boundary must not block it)', () => {
+    let s = [streamingMsg()]
+    s = chatMessageReducer(s, { type: 'ws_thinking', text: 'child thought', parentToolCallId: 'call_p' })
+    s = chatMessageReducer(s, { type: 'ws_thinking_done' })
+    const think = s[0].blocks!.find((b: any) => b.type === 'thinking')!
+    expect(think.done).toBe(true)
+    expect(think.parent_tool_call_id).toBe('call_p')
+  })
+
+  it('marks the last thinking block done when child follows parent', () => {
+    let s = [streamingMsg()]
+    s = chatMessageReducer(s, { type: 'ws_thinking', text: 'parent thought' })
+    s = chatMessageReducer(s, { type: 'ws_thinking', text: 'child thought', parentToolCallId: 'call_p' })
+    s = chatMessageReducer(s, { type: 'ws_thinking_done' })
+    const thinks = s[0].blocks!.filter((b: any) => b.type === 'thinking')
+    expect(thinks[1].done).toBe(true)
+    expect(thinks[0].done).toBeUndefined()
+  })
+})

--- a/web/src/utils/chatStreamUtils.ts
+++ b/web/src/utils/chatStreamUtils.ts
@@ -27,6 +27,12 @@ export interface ContentBlock {
   duration_ms?: number
   _key?: string
   reason?: string
+  /**
+   * Parent Agent tool-call id when this block was produced by a sub-agent
+   * spawned by that Agent call; empty/undefined for top-level content. Used to
+   * group a sub-agent's thinking/text/tool_use under its parent Agent card.
+   */
+  parent_tool_call_id?: string
   [key: string]: unknown
 }
 
@@ -77,6 +83,8 @@ export interface ChatMessage {
 /** SSE event data for content events */
 export interface ContentEventData {
   content?: string
+  /** Parent Agent tool-call id when this content belongs to a sub-agent. */
+  parent_tool_call_id?: string
 }
 
 /** Extract the textual content of a message: blocks' text concat, else content. */
@@ -118,6 +126,8 @@ function isJsonContent(c: string): boolean {
 /** SSE event data for thinking events */
 export interface ThinkingEventData {
   text?: string
+  /** Parent Agent tool-call id when this thinking belongs to a sub-agent. */
+  parent_tool_call_id?: string
 }
 
 /** SSE event data for tool_use/tool_result events */
@@ -131,6 +141,8 @@ export interface ToolUseEventData {
   display_name?: string
   file_path?: string
   duration_ms?: number
+  /** Parent Agent tool-call id when this tool call belongs to a sub-agent. */
+  parent_tool_call_id?: string
 }
 
 /** SSE event data for mode/config/thinking_effort events */
@@ -800,8 +812,8 @@ export type ChatMessageAction =
   | { type: 'ws_error'; text: string; reason?: string; errorCode?: number; httpStatus?: number; errorSource?: string }
   | { type: 'stream_finalize' }
   // ── WS block-level (in-place blocks mutation, same array reference) ──
-  | { type: 'ws_content'; text: string }
-  | { type: 'ws_thinking'; text: string; key?: string }
+  | { type: 'ws_content'; text: string; parentToolCallId?: string }
+  | { type: 'ws_thinking'; text: string; key?: string; parentToolCallId?: string }
   | { type: 'ws_thinking_done' }
   | { type: 'ws_content_reset' }
   | { type: 'ws_tool_use'; data: ToolUseEventData }
@@ -811,8 +823,12 @@ export type ChatMessageAction =
   // ── DB rebuild (loadHistory) ──
   | { type: 'db_load'; dbMessages: ChatMessage[] }
 
-function findBlockByTypeBackward(blocks: ContentBlock[], type: string): ContentBlock | undefined {
+function findBlockByTypeBackward(blocks: ContentBlock[], type: string, parent?: string): ContentBlock | undefined {
+  const wantParent = parent || ''
   for (let i = blocks.length - 1; i >= 0; i--) {
+    // Sub-agent boundary: a block belonging to a different parent (or top-level)
+    // must not absorb this event's deltas.
+    if ((blocks[i].parent_tool_call_id || '') !== wantParent) return undefined
     if (blocks[i].type === type) return blocks[i]
     if (blocks[i].type === 'tool_use') return undefined
   }
@@ -1363,18 +1379,20 @@ export function chatMessageReducer(state: ChatMessage[], action: ChatMessageActi
       const sm = state.find((m) => m.role === 'assistant' && m.streaming)
       if (!sm) return state
       const blocks = sm.blocks!
-      const existingText = findBlockByTypeBackward(blocks, 'text')
+      const parent = action.parentToolCallId
+      const existingText = findBlockByTypeBackward(blocks, 'text', parent)
       if (existingText) existingText.text += action.text
-      else blocks.push({ type: 'text', text: action.text })
+      else blocks.push({ type: 'text', text: action.text, ...(parent ? { parent_tool_call_id: parent } : {}) })
       return state
     }
     case 'ws_thinking': {
       const sm = state.find((m) => m.role === 'assistant' && m.streaming)
       if (!sm) return state
       const blocks = sm.blocks!
-      const existing = findBlockByTypeBackward(blocks, 'thinking')
+      const parent = action.parentToolCallId
+      const existing = findBlockByTypeBackward(blocks, 'thinking', parent)
       if (existing) existing.text += action.text
-      else blocks.push({ type: 'thinking', text: action.text, ...(action.key ? { _key: action.key } : {}) })
+      else blocks.push({ type: 'thinking', text: action.text, ...(action.key ? { _key: action.key } : {}), ...(parent ? { parent_tool_call_id: parent } : {}) })
       return state
     }
     case 'ws_error': {
@@ -1414,8 +1432,20 @@ export function chatMessageReducer(state: ChatMessage[], action: ChatMessageActi
     case 'ws_thinking_done': {
       const sm = state.find((m) => m.role === 'assistant' && m.streaming)
       if (!sm || !sm.blocks) return state
-      const existing = findBlockByTypeBackward(sm.blocks, 'thinking')
-      if (existing) existing.done = true
+      // thinking_done has no parent in the payload; it marks the most recently
+      // emitted thinking block (which may belong to a sub-agent). Scan backward
+      // with the tool_use boundary (original semantics) but WITHOUT the parent
+      // boundary — a parent-aware lookup returns undefined for the whole
+      // duration of a sub-agent run, leaving child thinking marked done in the
+      // DB but not live.
+      for (let i = sm.blocks.length - 1; i >= 0; i--) {
+        const b = sm.blocks[i]
+        if (b.type === 'thinking') {
+          b.done = true
+          break
+        }
+        if (b.type === 'tool_use') break
+      }
       return state
     }
     case 'ws_content_reset': {
@@ -1439,6 +1469,7 @@ export function chatMessageReducer(state: ChatMessage[], action: ChatMessageActi
         if (data.display_name !== undefined) existing.display_name = data.display_name
         if (data.file_path !== undefined) existing.file_path = data.file_path
         if (data.duration_ms !== undefined) existing.duration_ms = data.duration_ms
+        if (data.parent_tool_call_id) existing.parent_tool_call_id = data.parent_tool_call_id
         if (data.done) existing.done = true
       } else {
         blocks.push({
@@ -1452,6 +1483,7 @@ export function chatMessageReducer(state: ChatMessage[], action: ChatMessageActi
           ...(data.display_name ? { display_name: data.display_name } : {}),
           ...(data.file_path ? { file_path: data.file_path } : {}),
           ...(data.duration_ms !== undefined ? { duration_ms: data.duration_ms } : {}),
+          ...(data.parent_tool_call_id ? { parent_tool_call_id: data.parent_tool_call_id } : {}),
         } as ContentBlock)
       }
       return state
@@ -1464,6 +1496,7 @@ export function chatMessageReducer(state: ChatMessage[], action: ChatMessageActi
       if (block) {
         if (data.name) block.name = data.name
         if (data.status !== undefined) block.status = data.status
+        if (data.parent_tool_call_id) block.parent_tool_call_id = data.parent_tool_call_id
         block.done = true
         if (data.duration_ms !== undefined) block.duration_ms = data.duration_ms
       }


### PR DESCRIPTION
## 概述

在最新 `origin/main`（d11b3e5ec）基础上 rebase，合入 4 个提交，覆盖 ACP 子智能体内容分组、Docker 内自升级、附件抽屉塌陷修复，并补齐单测/回归测试，全量 lint 与覆盖率门槛通过。

## 提交内容

### 1. `feat(chat): ACP 子智能体内容分组显示（codebuddy 全量 + claude/codex 兼容）`
- 新增 `internal/ai/acp_parent_link.go`：从后端 `_meta` 提取子智能体父 tool-call id
  - codebuddy：扁平键 `codebuddy.ai/parentToolCallId`
  - claude/qoder：嵌套 `claudeCode.parentToolUseId`
- `StreamEvent` / `ToolCall` / `ContentBlock` 全链路新增 `ParentToolCallID`（含 slim / interactive 两种序列化路径）
- `AccumulateBlock` / `MergeConsecutiveThinkingBlocks` 在父边界处不再跨子智能体合并 delta
- debouncer 合并时保留父链（部分 ACP update 省略该键）
- WS payload 透传 `parent_tool_call_id`
- 前端 `ContentBlocks.vue` 递归渲染：子智能体 thinking/text/tool 嵌套在父 Agent 卡片下，未展开不实例化子树（大子智能体零成本），绝对索引按对象身份解析保证缓存/详情抽屉正确

### 2. `feat(upgrade): Docker 内允许自升级 + 容器强制就地替换路径`
- 新增 `internal/platform/container.go`：`IsContainer()`（Docker/Podman/k8s）与 `IsDockerLike()`（仅 Docker/Podman，供 UI 提示）
- 容器内升级强制走就地替换（`resolveReplaceInPlace`），避免 PID 1 退出拆除命名空间杀掉 `upgrade-replace` 子进程
- `/api/upgrade/check` 新增 `is_docker` 字段；UI 显示非阻断 advisory（建议 `docker pull`，并警告勿用 `--restart on-failure`）
- 移除已无引用的 `CLAWBENCH_NO_SUPERVISOR` 遗留标记

### 3. `fix(chat): 子智能体分组 review 修复 + 底部收起 + 收起锚定视口`
- 分组底部新增收起按钮；收起时锚定 pill 到视口顶部，避免长 trace 塌陷导致的跳动

### 4. `fix(chat): 附件抽屉上传完成后内容区塌陷`
- `pendingFiles` 改为遍历 `uploadingFiles`，已完成但保留的条目不再用 `v-show` 隐藏全部行同时压制空状态

## 测试

新增/补充单测与回归测试：
- Go：`acp_parent_link_test.go`、`container_test.go`，以及 accumulate / acp_events / acp_debounce / model / ws / service / handler 各包的父链、容器判定、升级路径回归用例
- 前端：`chatStreamUtils.test.ts`（reducer 父边界/thinking_done）、`ContentBlocks.test.ts`（分组、递归、孤儿、绝对索引）、`AttachDrawer.test.ts`（内容区塌陷回归）、`UpgradeDialog`/`useUpgrade`

## 检查

- `golangci-lint run`：0 issues
- `go test ./...`：通过
- ESLint / `vue-tsc`：通过
- Go / 前端覆盖率门槛：通过（Tier 2 diff coverage 94.8%）
- 已 rebase 至最新 `origin/main`，无冲突
