### PR TITLE
feat(web): 单选 AskUserQuestion 支持取消选中 + 修复两处过时测试

### DIFF
--- a/web/src/components/__tests__/fileAttachmentList.test.ts
+++ b/web/src/components/__tests__/fileAttachmentList.test.ts
@@ -68,11 +68,13 @@ describe('FileAttachmentList', () => {
     expect(card.classes()).toContain('attachment-image-only')
   })
 
-  it('emits file-tag-click on card click', async () => {
+  it('emits file-tag-click with the normalized FileEntry on card click', async () => {
     const wrapper = mountComponent(['src/main.go'])
     await wrapper.find('.chat-file-attachment').trigger('click')
     expect(wrapper.emitted('file-tag-click')).toBeTruthy()
-    expect(wrapper.emitted('file-tag-click')[0][0]).toBe('src/main.go')
+    // The component emits the full normalized FileEntry (not a bare path string)
+    // so consumers receive isDir/line-range metadata alongside the path.
+    expect(wrapper.emitted('file-tag-click')[0][0]).toEqual({ path: 'src/main.go', isDir: false })
   })
 
   it('supports {path} object format', () => {

--- a/web/src/utils/__tests__/chatQueueSend.test.ts
+++ b/web/src/utils/__tests__/chatQueueSend.test.ts
@@ -50,7 +50,7 @@ describe('enqueueAndMaybeStart', () => {
     expect(Number.isFinite(msg.seq)).toBe(true)
   })
 
-  it('dedupes pending and attached files into the pending message files', async () => {
+  it('keeps distinct line ranges of one path and dedupes exact duplicates', async () => {
     const pending: FileEntry[] = [{ path: '/a', isDir: false }]
     const attached: FileEntry[] = [
       { path: '/a', isDir: false, startLine: 1, endLine: 5 },
@@ -59,11 +59,14 @@ describe('enqueueAndMaybeStart', () => {
     const opts = makeOpts({ pendingFiles: pending, attachedFiles: attached })
     await enqueueAndMaybeStart(opts)
     const msg = (opts.pushMessage as ReturnType<typeof vi.fn>).mock.calls[0][0]
-    // dedupeFiles keeps the richer entry (with line range) for /a
+    // Attachment identity is the composite key (path, startLine, endLine): the
+    // whole-file /a and the ranged /a are distinct references and both survive,
+    // while an exact duplicate would collapse.
     const paths = msg.files.map((f: FileEntry) => f.path)
-    expect(paths).toEqual(['/a', '/b'])
-    const a = msg.files.find((f: FileEntry) => f.path === '/a')
-    expect(a.startLine).toBe(1)
+    expect(paths).toEqual(['/a', '/a', '/b'])
+    const ranged = msg.files.find((f: FileEntry) => f.path === '/a' && f.startLine === 1)
+    expect(ranged).toBeTruthy()
+    expect(ranged.endLine).toBe(5)
   })
 
   it('calls enqueue with sessionId, text, attachments and queueId', async () => {

--- a/web/src/utils/__tests__/renderToolDetail.test.ts
+++ b/web/src/utils/__tests__/renderToolDetail.test.ts
@@ -974,6 +974,45 @@ describe('AskUserQuestion action handler', () => {
       cleanup(container)
     })
 
+    it('clicking the selected option again deselects it', () => {
+      const { container, emit } = createAskDOM(false)
+      const option = container.querySelector('.ask-question-option') as HTMLElement
+
+      // First click: select
+      const click1 = new MouseEvent('click', { bubbles: true, cancelable: true })
+      Object.defineProperty(click1, 'target', { value: option, writable: false })
+      handleToolAction('AskUserQuestion', click1, emit)
+      expect(option.classList.contains('selected')).toBe(true)
+
+      // Second click on the same option: deselect (undo a mis-tap)
+      const click2 = new MouseEvent('click', { bubbles: true, cancelable: true })
+      Object.defineProperty(click2, 'target', { value: option, writable: false })
+      handleToolAction('AskUserQuestion', click2, emit)
+
+      expect(option.classList.contains('selected')).toBe(false)
+      const indicator = option.querySelector('.ask-option-indicator')
+      expect(indicator?.textContent).toBe('◯')
+      cleanup(container)
+    })
+
+    it('disables submit button again after deselecting the only selection', () => {
+      const { container, emit } = createAskDOM(false)
+      const option = container.querySelector('.ask-question-option') as HTMLElement
+      const submitBtn = container.querySelector('.ask-question-submit') as HTMLButtonElement
+
+      const click1 = new MouseEvent('click', { bubbles: true, cancelable: true })
+      Object.defineProperty(click1, 'target', { value: option, writable: false })
+      handleToolAction('AskUserQuestion', click1, emit)
+      expect(submitBtn.disabled).toBe(false)
+
+      const click2 = new MouseEvent('click', { bubbles: true, cancelable: true })
+      Object.defineProperty(click2, 'target', { value: option, writable: false })
+      handleToolAction('AskUserQuestion', click2, emit)
+
+      expect(submitBtn.disabled).toBe(true)
+      cleanup(container)
+    })
+
     it('enables submit button when an option is selected', () => {
       const { container, emit } = createAskDOM(false)
       const option = container.querySelector('.ask-question-option') as HTMLElement

--- a/web/src/utils/renderToolDetail.ts
+++ b/web/src/utils/renderToolDetail.ts
@@ -1774,17 +1774,23 @@ registerToolActionHandler('AskUserQuestion', (event, emit) => {
         const indicator = optionEl.querySelector('.ask-option-indicator')
         if (indicator) indicator.textContent = optionEl.classList.contains('selected') ? '☑' : '☐'
       } else {
+        // Single-select: clicking the already-selected option clears it (deselect),
+        // otherwise it becomes the sole selection. This lets a user undo a mis-tap
+        // without being forced to pick another option.
+        const wasSelected = optionEl.classList.contains('selected')
         const siblings = optionEl.parentElement!.querySelectorAll('.ask-question-option')
         for (const s of siblings) {
           s.classList.remove('selected')
           const ind = s.querySelector('.ask-option-indicator')
           if (ind) ind.textContent = '◯'
         }
-        optionEl.classList.add('selected')
-        const indicator = optionEl.querySelector('.ask-option-indicator')
-        // Use ● (U+25CF BLACK CIRCLE) — same glyph box/width as the unselected ◯ (U+25EF LARGE CIRCLE),
-        // so the filled state does not render smaller than the hollow one.
-        if (indicator) indicator.textContent = '●'
+        if (!wasSelected) {
+          optionEl.classList.add('selected')
+          const indicator = optionEl.querySelector('.ask-option-indicator')
+          // Use ● (U+25CF BLACK CIRCLE) — same glyph box/width as the unselected ◯ (U+25EF LARGE CIRCLE),
+          // so the filled state does not render smaller than the hollow one.
+          if (indicator) indicator.textContent = '●'
+        }
       }
 
       updateAskSubmitState(view)


### PR DESCRIPTION
## 变更说明

单选（`multiSelect` 未开启）的 AskUserQuestion 卡片，此前点击已选中的选项只会保持选中，用户无法取消，只能改选其他项。误触时错误选项会被拼进发送内容（`renderToolDetail.ts` 提交逻辑会收集所有 `.selected` 的 label）。

本次让单选再次点击已选中项时取消选中：取消后调用 `updateAskSubmitState` 重算提交按钮，回到未作答状态时按钮自动禁用，不绕过"必须作答"校验。

顺带修复两处因实现演进未同步的既有失败测试（非本次功能引入）：
- `fileAttachmentList`：`file-tag-click` 现 emit `normalizeFileEntry` 对象（e2825ef1），断言从裸 path 字符串改为对象。
- `chatQueueSend`：附件去重改为复合键 `(path, startLine, endLine)`（17d82d69），同路径整文件引用与行段引用应共存，断言同步更新。

## 变更类型

- [x] feat: 新功能
- [x] test: 测试

## 关联 Issue

<!-- 无关联 Issue -->

## 测试

- [x] 已通过现有测试（`go test ./...` / `npm test`）
- [x] 已添加新测试覆盖
- [x] 手动验证（描述验证方式）

验证方式：
- `renderToolDetail.test.ts` 385 passed（含新增 2 个：再次点击取消选中、取消后提交按钮重新禁用）
- ask-question 相关 4 个测试文件 590 passed
- 有效性验证：临时还原实现后，新增的 2 个测试如期失败；恢复后转绿
- `vue-tsc --noEmit` typecheck exit 0
- 本地复刻 CI 全量 11 项通过（Go lint/test/build/coverage、前端 lint/typecheck/coverage/build、Android lint/coverage/build），Node v24.20.0

## 自检清单

- [x] 代码遵循项目现有风格
- [x] 无硬编码密钥或敏感信息
- [x] 变更已反映在文档中（如适用，本次无需文档变更）
