### PR TITLE
fix(apk): 恒定从内嵌 FS 读取 APK，修复 public/ 遮蔽导致的 404

### DIFF
--- a/docs/spec/client/android-integration.md
+++ b/docs/spec/client/android-integration.md
@@ -75,7 +75,7 @@ flowchart LR
 
 | 端点 | 方法 | 用途 |
 |------|------|------|
-| `/api/apk` | GET | APK 下载（从 `go:embed` 读取，路径 `assets/clawbench-android.apk`） |
+| `/api/apk` | GET | APK 下载（恒定从 `go:embed` 读取，路径 `assets/clawbench-android.apk`；不读磁盘 `public/`） |
 | `/api/client-log` | POST | 客户端统一日志（200 条/请求上限；`js` 与 `android` 条目汇入同一 `client.log`，行内 `[js]`/`[android]` 标记区分） |
 | `/api/android-log` | POST | Android 端日志（legacy alias，旧 APK 兼容，同 handler 汇入 `client.log`） |
 | `/api/ssh/info` | GET | SSH 隧道状态轮询（无需鉴权） |
@@ -153,7 +153,7 @@ flowchart LR
 - **Live Updates 是独立开关但共享数据**：Live Updates 不依赖悬浮窗开关——任一消费者存活就拉取 overview，各自的开关控制各自的通知生命周期。设置里独立开关（默认开），Bridge 提供权限检测与跳转，系统不支持实时更新时自动回退为普通常驻通知
 - **WS 优先 + Worker 回退**：常驻 WS 链路是主路径（实时通知），PendingEventsWorker 是 WS 不可达时的兜底（轮询拉取）。两条路径相互独立，BackgroundService 监控 WS 健康度触发 Worker
 - **AppLog 双写 + Anti-Recursion**：`AppLog` 写入 logcat，同时 POST 到 `/api/android-log` 实现集中持久化。`AppLog.java` 自身是允许调用裸 `android.util.Log` 的唯一生产代码位置，以避免日志封装递归；通过 `OemUtils` 和 `SharedCacheUtils` 共享多进程状态
-- **单二进制包含 APK**：`//go:embed all:dist` 把 APK 嵌入 Go 二进制，无需外部 APK 文件即可部署。`internal/frontend/embed.go::GetFS()` 优先读磁盘 `public/`（热替换），否则从 embed 读取
+- **单二进制包含 APK**：`//go:embed all:dist` 把 APK 嵌入 Go 二进制，无需外部 APK 文件即可部署。`internal/frontend/embed.go::GetFS()` 优先读磁盘 `public/`（热替换），否则从 embed 读取。**APK 例外**：`ServeAPK` 恒定读取 `EmbeddedFS()`（纯 embed，不查 CWD），以免 CWD 下的 `public/` 遮蔽内嵌 APK 导致 `/api/apk` 404，同时保证下载的 APK 与运行中二进制的版本一致
 - **日志处理器统一、客户端端点兼容**：Web 的 `appLog.ts` 使用 `/api/client-log`，Android 的 `AppLog.java` 使用兼容路由 `/api/android-log`；两者都由服务端 `ServeClientLog` 处理，汇入单一 `client.log`，行内 `[js]`/`[android]` 源标记区分来源
 - **屏幕常亮双通道**：`useWakeLock` 优先申请标准 Web Wake Lock，并同时调用 Android `setKeepScreenOn`。页面隐藏时浏览器可能释放锁，重新可见且业务仍需要常亮时自动申请；显式释放会同时关闭两条通道
 - **服务器列表由客户端持有**：Android Bridge 保存多个实例地址和密码，使当前服务器不可达时仍可切换到其他实例，完整流程见[多服务器管理](multi-server.md)

--- a/internal/frontend/embed.go
+++ b/internal/frontend/embed.go
@@ -35,6 +35,15 @@ func DiskPublicExists() bool {
 	return err == nil && fi.IsDir()
 }
 
+// EmbeddedFS returns the build-time embedded frontend filesystem (go:embed
+// dist/) unconditionally. Unlike GetFS(), it never consults the working
+// directory, so build-time artifacts that must match the running binary —
+// notably the Android APK — stay consistent no matter where the server was
+// started. Callers needing the hot-swappable disk override should use GetFS().
+func EmbeddedFS() fs.FS {
+	return distFS
+}
+
 // ModeLabel returns a human-readable label for the current frontend serving mode.
 func ModeLabel() string {
 	if DiskPublicExists() {

--- a/internal/frontend/embed_test.go
+++ b/internal/frontend/embed_test.go
@@ -499,3 +499,42 @@ func TestGetFS_ConsistencyWithModeLabel(t *testing.T) {
 	}
 	assert.Equal(t, "disk-content", string(data))
 }
+
+// TestEmbeddedFS_IgnoresDiskPublic locks the contract that EmbeddedFS() always
+// returns the build-time embedded filesystem and never consults the working
+// directory. This is what makes build-time artifacts such as the Android APK
+// immune to a stray public/ dir in the CWD (which previously shadowed the
+// embedded copy and produced a 404 from /api/apk).
+func TestEmbeddedFS_IgnoresDiskPublic(t *testing.T) {
+	origDir, err := os.Getwd()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = os.Chdir(origDir) }()
+
+	// CWD has a public/ dir holding a sentinel that must NOT be reachable.
+	tmpDir := t.TempDir()
+	publicDir := filepath.Join(tmpDir, "public")
+	if err := os.MkdirAll(publicDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(publicDir, "sentinel.txt"), []byte("disk"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Chdir(tmpDir); err != nil {
+		t.Fatal(err)
+	}
+
+	// Sanity check: GetFS() does consult the disk here, so the sentinel is
+	// visible through it. This proves the CWD shadowing scenario is real.
+	diskData, err := fs.ReadFile(GetFS(), "sentinel.txt")
+	if err != nil {
+		t.Fatalf("GetFS() should read the disk sentinel: %v", err)
+	}
+	assert.Equal(t, "disk", string(diskData))
+
+	// EmbeddedFS() must ignore public/ entirely — the sentinel is invisible.
+	if _, err := fs.ReadFile(EmbeddedFS(), "sentinel.txt"); err == nil {
+		t.Fatal("EmbeddedFS() read sentinel.txt from disk; it must never consult the CWD")
+	}
+}

--- a/internal/handler/apk.go
+++ b/internal/handler/apk.go
@@ -17,8 +17,19 @@ const (
 
 // ServeAPK serves the embedded Android APK file for download.
 // No authentication required — APK is a public resource.
+//
+// The APK is always read from the build-time embedded FS, never from disk.
+// The APK must match the running binary's version (the upgrade overlay relies
+// on it), and frontend.GetFS() would instead return the disk public/ dir
+// whenever the server's CWD contains one — shadowing the embedded copy and
+// making /api/apk 404 even though the APK is embedded.
 func ServeAPK(w http.ResponseWriter, r *http.Request) {
-	fsys := frontend.GetFS()
+	serveAPK(frontend.EmbeddedFS(), w, r)
+}
+
+// serveAPK is the testable core of ServeAPK: the frontend FS is injected so
+// tests can supply an in-memory APK without a real --android build.
+func serveAPK(fsys fs.FS, w http.ResponseWriter, r *http.Request) {
 	data, err := fs.ReadFile(fsys, apkEmbedPath)
 	if err != nil {
 		slog.Debug("apk: not found in embed", "err", err)

--- a/internal/handler/apk_test.go
+++ b/internal/handler/apk_test.go
@@ -9,52 +9,48 @@ import (
 	"os"
 	"path/filepath"
 	"testing"
+	"testing/fstest"
 
 	"clawbench/internal/frontend"
 )
 
-func TestServeAPK_NotFound(t *testing.T) {
-	// In dev environment, embed likely has no APK → 404
-	req := httptest.NewRequest(http.MethodGet, "/api/apk", http.NoBody)
-	w := httptest.NewRecorder()
-
-	ServeAPK(w, req)
-
-	// May be 200 (if embed has APK) or 404 (dev build without APK)
-	if w.Code != http.StatusNotFound && w.Code != http.StatusOK {
-		t.Errorf("expected 404 or 200, got %d", w.Code)
+// apkFS builds an in-memory FS containing the APK at the embed path, so tests
+// never depend on the real go:embed payload (which is absent from dev builds
+// unless build.sh --android ran).
+func apkFS(content string) fs.FS {
+	return fstest.MapFS{
+		apkEmbedPath: &fstest.MapFile{Data: []byte(content)},
 	}
 }
 
-func TestServeAPK_FromEmbed(t *testing.T) {
-	// Provide APK via public/assets/ so GetFS() (DirFS) serves it
-	pubAssets := filepath.Join("public", "assets")
-	if err := os.MkdirAll(pubAssets, 0o755); err != nil {
-		t.Fatal(err)
-	}
-	if err := os.WriteFile(filepath.Join(pubAssets, apkFilename), []byte("embedded-apk-content"), 0o644); err != nil {
-		t.Fatal(err)
-	}
-	defer os.RemoveAll("public/assets")
-
-	req := httptest.NewRequest(http.MethodGet, "/api/apk", http.NoBody)
+func TestServeAPK_NotFound(t *testing.T) {
+	// Empty FS → no APK at the embed path → 404.
 	w := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/api/apk", http.NoBody)
 
-	ServeAPK(w, req)
+	serveAPK(fstest.MapFS{}, w, req)
+
+	if w.Code != http.StatusNotFound {
+		t.Errorf("expected 404, got %d", w.Code)
+	}
+}
+
+func TestServeAPK_ServesFromFS(t *testing.T) {
+	w := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/api/apk", http.NoBody)
+
+	serveAPK(apkFS("embedded-apk-content"), w, req)
 
 	if w.Code != http.StatusOK {
-		t.Errorf("expected 200, got %d", w.Code)
+		t.Fatalf("expected 200, got %d", w.Code)
 	}
-	ct := w.Header().Get("Content-Type")
-	if ct != "application/vnd.android.package-archive" {
+	if ct := w.Header().Get("Content-Type"); ct != "application/vnd.android.package-archive" {
 		t.Errorf("expected apk content type, got %s", ct)
 	}
-	cd := w.Header().Get("Content-Disposition")
-	if cd != `attachment; filename="clawbench-android.apk"` {
+	if cd := w.Header().Get("Content-Disposition"); cd != `attachment; filename="clawbench-android.apk"` {
 		t.Errorf("unexpected Content-Disposition: %s", cd)
 	}
-	cc := w.Header().Get("Cache-Control")
-	if cc != "public, max-age=3600" {
+	if cc := w.Header().Get("Cache-Control"); cc != "public, max-age=3600" {
 		t.Errorf("unexpected Cache-Control: %s", cc)
 	}
 	if w.Body.String() != "embedded-apk-content" {
@@ -62,29 +58,109 @@ func TestServeAPK_FromEmbed(t *testing.T) {
 	}
 }
 
-func TestServeAPK_EmbedOnly(t *testing.T) {
-	// Remove public/ dir to test pure embed path
-	if fi, err := os.Stat("public"); err == nil && fi.IsDir() {
-		os.Rename("public", "public_test_bak")
-		defer os.Rename("public_test_bak", "public")
+// TestServeAPK_IgnoresDiskPublic is the regression test for the bug where a
+// public/ directory in the CWD shadowed the embedded APK: ServeAPK used
+// frontend.GetFS() (disk-first) so /api/apk 404'd whenever the server was
+// started from a directory containing public/. ServeAPK must now always serve
+// the build-time embedded copy, regardless of the CWD.
+func TestServeAPK_IgnoresDiskPublic(t *testing.T) {
+	origDir, err := os.Getwd()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = os.Chdir(origDir) }()
+
+	// Reproduce the failing environment: CWD contains public/assets/ with a
+	// DIFFERENT (stale) APK. The served bytes must never come from disk.
+	tmpDir := t.TempDir()
+	pubAssets := filepath.Join(tmpDir, "public", "assets")
+	if err := os.MkdirAll(pubAssets, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(pubAssets, apkFilename), []byte("stale-disk-apk"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Chdir(tmpDir); err != nil {
+		t.Fatal(err)
 	}
 
-	fsys := frontend.GetFS()
-	_, embedErr := fs.ReadFile(fsys, apkEmbedPath)
-	if embedErr != nil {
-		t.Skip("no APK in embedded FS, skipping embed-only test")
-	}
-
-	req := httptest.NewRequest(http.MethodGet, "/api/apk", http.NoBody)
 	w := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/api/apk", http.NoBody)
+
+	ServeAPK(w, req)
+
+	// The stale disk bytes must never be served. Dev builds (no --android) have
+	// no embedded APK, so 404 is the correct outcome there; release builds must
+	// return the embedded copy.
+	if w.Body.String() == "stale-disk-apk" {
+		t.Fatal("served the stale APK from disk; embedded copy must take precedence")
+	}
+	_, embedErr := fs.ReadFile(frontend.EmbeddedFS(), apkEmbedPath)
+	if embedErr != nil {
+		if w.Code != http.StatusNotFound {
+			t.Fatalf("no embedded APK → want 404, got %d", w.Code)
+		}
+		return
+	}
+	if w.Code != http.StatusOK {
+		t.Fatalf("embedded APK present → want 200, got %d", w.Code)
+	}
+	if ct := w.Header().Get("Content-Type"); ct != "application/vnd.android.package-archive" {
+		t.Errorf("expected apk content type, got %s", ct)
+	}
+}
+
+// TestServeAPK_InjectedFSWinsOverDisk proves the injection point itself is
+// disk-agnostic: even with a public/assets/ APK in the CWD, serveAPK serves
+// the FS it was given.
+func TestServeAPK_InjectedFSWinsOverDisk(t *testing.T) {
+	origDir, err := os.Getwd()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = os.Chdir(origDir) }()
+
+	tmpDir := t.TempDir()
+	pubAssets := filepath.Join(tmpDir, "public", "assets")
+	if err := os.MkdirAll(pubAssets, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(pubAssets, apkFilename), []byte("stale-disk-apk"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Chdir(tmpDir); err != nil {
+		t.Fatal(err)
+	}
+
+	w := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/api/apk", http.NoBody)
+
+	serveAPK(apkFS("injected-apk-content"), w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d", w.Code)
+	}
+	if w.Body.String() != "injected-apk-content" {
+		t.Errorf("injected FS must win over disk, got %q", w.Body.String())
+	}
+}
+
+func TestServeAPK_EmbedOnly(t *testing.T) {
+	// Sanity check that the real embedded FS is wired up and reachable through
+	// ServeAPK when it contains an APK. Skips in dev builds without --android.
+	if _, err := fs.ReadFile(frontend.EmbeddedFS(), apkEmbedPath); err != nil {
+		t.Skip("no APK in embedded FS (dev build), skipping")
+	}
+
+	w := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/api/apk", http.NoBody)
 
 	ServeAPK(w, req)
 
 	if w.Code != http.StatusOK {
-		t.Errorf("expected 200, got %d", w.Code)
+		t.Fatalf("expected 200, got %d", w.Code)
 	}
-	ct := w.Header().Get("Content-Type")
-	if ct != "application/vnd.android.package-archive" {
+	if ct := w.Header().Get("Content-Type"); ct != "application/vnd.android.package-archive" {
 		t.Errorf("expected apk content type, got %s", ct)
 	}
 }
@@ -129,5 +205,31 @@ func TestReaderSeeker_SeekEnd(t *testing.T) {
 	n, err := rs.Read(buf)
 	if n != 3 || string(buf) != "llo" {
 		t.Errorf("read after seek end: got %d %q, err %v", n, buf, err)
+	}
+}
+
+func TestReaderSeeker_SeekCurrent(t *testing.T) {
+	rs := NewReaderSeeker([]byte("hello world"))
+
+	if _, err := rs.Seek(6, io.SeekStart); err != nil {
+		t.Fatal(err)
+	}
+	// Relative seek from the current offset.
+	off, err := rs.Seek(1, io.SeekCurrent)
+	if off != 7 || err != nil {
+		t.Errorf("seek current: got %d, err %v", off, err)
+	}
+}
+
+func TestReaderSeeker_SeekInvalid(t *testing.T) {
+	rs := NewReaderSeeker([]byte("hello"))
+
+	// Unsupported whence → fs.ErrInvalid.
+	if _, err := rs.Seek(0, 99); !errors.Is(err, fs.ErrInvalid) {
+		t.Errorf("invalid whence: expected fs.ErrInvalid, got %v", err)
+	}
+	// Negative resulting offset → fs.ErrInvalid.
+	if _, err := rs.Seek(-1, io.SeekStart); !errors.Is(err, fs.ErrInvalid) {
+		t.Errorf("negative offset: expected fs.ErrInvalid, got %v", err)
 	}
 }

--- a/scripts/check-go-coverage.sh
+++ b/scripts/check-go-coverage.sh
@@ -103,7 +103,6 @@ exempt_files = {
     "internal/model/discovery.go",           # model discovery spawns CLI subprocesses and reads external files
     "internal/handler/chat.go",              # executeStreamRun ctx.Done needs mock AI backend + goroutine sync
     "internal/handler/agent.go",              # serveAgentsPatch: multi-field validation branches, DB update, in-memory sync
-    "internal/handler/apk.go",               # ServeAPK: filepath.Abs/f.Close error paths untestable in unit tests
     "internal/handler/scheduler.go",         # TriggerTask spawns CLI subprocesses in goroutine; success path untestable in unit
     "internal/service/scheduler.go",         # executeTask spawns CLI subprocesses
     "internal/service/agent_migration.go",   # new file: saveAgentTx DB error paths, YAML read errors

--- a/web/src/components/media/Lightbox.vue
+++ b/web/src/components/media/Lightbox.vue
@@ -687,26 +687,29 @@ function collectMdImages(container, clickedImg, clickedMermaid, clickedSvg) {
 
     let node = walker.nextNode()
     while (node) {
-        if (node.tagName === 'IMG') {
-            const src = fullImgSrc(node)
+        // Advance the walker before any branch can `continue`; otherwise an
+        // IMG with no resolvable src would re-visit the same node forever.
+        const current = node
+        node = walker.nextNode()
+        if (current.tagName === 'IMG') {
+            const src = fullImgSrc(current)
             if (!src) continue
-            const alt = node.alt || ''
+            const alt = current.alt || ''
             const name = alt || extractImageName(src)
             list.push({ src, name })
-            if (node === clickedImg) startIdx = list.length - 1
-        } else if (node.classList.contains('mermaid')) {
-            const svg = node.querySelector('svg')
+            if (current === clickedImg) startIdx = list.length - 1
+        } else if (current.classList.contains('mermaid')) {
+            const svg = current.querySelector('svg')
             if (!svg) continue
-            const name = deriveMermaidName(node)
+            const name = deriveMermaidName(current)
             list.push({ src: '', name, svg: svg.outerHTML })
-            if (node === clickedMermaid) startIdx = list.length - 1
-        } else if (node.classList.contains('lightbox-svg')) {
+            if (current === clickedMermaid) startIdx = list.length - 1
+        } else if (current.classList.contains('lightbox-svg')) {
             // Inline SVG (non-mermaid) returned directly by the AI
-            const name = node.getAttribute('data-name') || 'diagram.svg'
-            list.push({ src: '', name, svg: node.outerHTML })
-            if (node === clickedSvg) startIdx = list.length - 1
+            const name = current.getAttribute('data-name') || 'diagram.svg'
+            list.push({ src: '', name, svg: current.outerHTML })
+            if (current === clickedSvg) startIdx = list.length - 1
         }
-        node = walker.nextNode()
     }
     return { list, startIdx }
 }

--- a/web/src/components/media/__tests__/Lightbox.test.ts
+++ b/web/src/components/media/__tests__/Lightbox.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it, vi, beforeEach } from 'vitest'
+import { describe, expect, it, vi, beforeEach, afterEach } from 'vitest'
 import { mount } from '@vue/test-utils'
 import { nextTick } from 'vue'
 import Lightbox from '@/components/media/Lightbox.vue'
@@ -82,6 +82,13 @@ vi.mock('@/composables/useBackHandler', () => ({
 }))
 
 describe('Lightbox', () => {
+  // Track every mounted wrapper so each test unmounts on teardown. Lightbox
+  // attaches document-level mousemove/mouseup/click listeners and removes them
+  // only in onUnmounted; without an explicit unmount the leaked listeners keep
+  // the vitest fork worker's event loop alive and it never exits
+  // (vitest-dev/vitest#8766).
+  const mountedWrappers: ReturnType<typeof mount>[] = []
+
   beforeEach(() => {
     mockSelectFile.mockClear()
     mockRegisterBackHandler.mockClear()
@@ -94,10 +101,18 @@ describe('Lightbox', () => {
     ]
   })
 
+  afterEach(() => {
+    while (mountedWrappers.length > 0) {
+      mountedWrappers.pop()?.unmount()
+    }
+  })
+
   function mountLightbox() {
-    return mount(Lightbox, {
+    const wrapper = mount(Lightbox, {
       attachTo: document.body,
     })
+    mountedWrappers.push(wrapper)
+    return wrapper
   }
 
   // ── calcFitScale ──
@@ -1039,6 +1054,43 @@ describe('Lightbox', () => {
       const result = vm.collectMdImages(container, container.querySelectorAll('img')[0], null)
       expect(result.list).toHaveLength(1)
       expect(result.list[0].src).toBeTruthy()
+
+      document.body.removeChild(container)
+    })
+
+    // Regression: an <img> whose src cannot be resolved (no src / no
+    // data-full-src) used to `continue` without advancing the TreeWalker,
+    // re-visiting the same node forever at 100% CPU and hanging the worker.
+    it('terminates on an img with no resolvable src', () => {
+      const wrapper = mountLightbox()
+      const vm = wrapper.vm as any
+
+      const container = document.createElement('div')
+      container.innerHTML = '<img alt="no-src">'
+      document.body.appendChild(container)
+
+      const result = vm.collectMdImages(container, null, null)
+      expect(result.list).toHaveLength(0)
+
+      document.body.removeChild(container)
+    })
+
+    it('terminates when a src-less img precedes valid images', () => {
+      const wrapper = mountLightbox()
+      const vm = wrapper.vm as any
+
+      const container = document.createElement('div')
+      container.innerHTML =
+        '<img alt="no-src">' +
+        '<img src="a.png" alt="A">' +
+        '<img alt="also-no-src">' +
+        '<img src="b.png" alt="B">'
+      document.body.appendChild(container)
+
+      const result = vm.collectMdImages(container, container.querySelectorAll('img')[3], null)
+      expect(result.list).toHaveLength(2)
+      expect(result.list.map((i: { name: string }) => i.name)).toEqual(['A', 'B'])
+      expect(result.startIdx).toBe(1)
 
       document.body.removeChild(container)
     })

--- a/web/src/test-setup.ts
+++ b/web/src/test-setup.ts
@@ -7,6 +7,8 @@
 // reactivity. Without this handler, vitest exits non-zero and the coverage gate
 // reports "Frontend tests failed" even though all test cases pass.
 
+import { createUnhandledRejectionHandler } from '@/utils/unhandledRejectionGuard'
+
 // ── ResizeObserver polyfill for jsdom ──
 // jsdom does not implement ResizeObserver, but components like FileHeader and
 // FileManagerContent use useToolbarOverflow which creates one on mount.
@@ -70,26 +72,17 @@ try {
 // take the synchronous deferred-setup path and keeps tests deterministic.
 delete (globalThis as { __VUE_DEVTOOLS_GLOBAL_HOOK__?: unknown }).__VUE_DEVTOOLS_GLOBAL_HOOK__
 
-function isRecursiveUpdateError(reason: unknown): boolean {
-  if (reason instanceof Error) {
-    return reason.message.includes('Maximum recursive updates')
-  }
-  if (typeof reason === 'string') {
-    return reason.includes('Maximum recursive updates')
-  }
-  return false
-}
-
 // Catch unhandled rejections from Vue's scheduler.
 // Store the handler reference so vitest's own cleanup can remove it —
 // a permanent process.on() listener keeps the worker's event loop alive
 // and prevents clean exit, contributing to the zombie worker problem
 // (vitest-dev/vitest#8766, #9494).
-const unhandledRejectionHandler = (reason: unknown) => {
-  if (isRecursiveUpdateError(reason)) return
-  // Re-throw as async to preserve default behavior
-  Promise.reject(reason)
-}
+//
+// The handler forwards each distinct reason exactly once: re-throwing via
+// Promise.reject() re-enters this same handler (the new rejection is unhandled
+// too), which spins forever at 100% CPU whenever a non-recursive rejection
+// occurs. See createUnhandledRejectionHandler for details.
+const unhandledRejectionHandler = createUnhandledRejectionHandler()
 process.on('unhandledRejection', unhandledRejectionHandler)
 
 // Remove the listener when vitest teardown runs, so the worker process

--- a/web/src/utils/__tests__/unhandledRejectionGuard.test.ts
+++ b/web/src/utils/__tests__/unhandledRejectionGuard.test.ts
@@ -1,0 +1,90 @@
+import { describe, expect, it, vi } from 'vitest'
+import { createUnhandledRejectionHandler, isRecursiveUpdateError } from '../unhandledRejectionGuard'
+
+describe('isRecursiveUpdateError', () => {
+  it('matches Vue recursive-update errors', () => {
+    expect(isRecursiveUpdateError(new Error('Maximum recursive updates exceeded'))).toBe(true)
+    expect(isRecursiveUpdateError('Maximum recursive updates exceeded in component')).toBe(true)
+  })
+
+  it('ignores unrelated reasons', () => {
+    expect(isRecursiveUpdateError(new Error('boom'))).toBe(false)
+    expect(isRecursiveUpdateError('boom')).toBe(false)
+    expect(isRecursiveUpdateError(undefined)).toBe(false)
+    expect(isRecursiveUpdateError({ code: 'EPIPE' })).toBe(false)
+  })
+})
+
+describe('createUnhandledRejectionHandler', () => {
+  it('swallows recursive-update errors without forwarding', () => {
+    const onRethrow = vi.fn()
+    const handler = createUnhandledRejectionHandler(onRethrow)
+
+    handler(new Error('Maximum recursive updates exceeded'))
+
+    expect(onRethrow).not.toHaveBeenCalled()
+  })
+
+  it('forwards an unrelated reason exactly once', () => {
+    const onRethrow = vi.fn()
+    const handler = createUnhandledRejectionHandler(onRethrow)
+    const reason = new Error('boom')
+
+    handler(reason)
+    handler(reason)
+    handler(reason)
+
+    expect(onRethrow).toHaveBeenCalledTimes(1)
+    expect(onRethrow).toHaveBeenCalledWith(reason)
+  })
+
+  // Regression: forwarding the same reason again would re-enter the handler
+  // through the re-thrown rejection, looping forever at 100% CPU.
+  it('does not recurse when the forwarder re-invokes the handler', () => {
+    let calls = 0
+    let handler: (reason: unknown) => void = () => {}
+    // Simulate Promise.reject() re-entering the same handler synchronously.
+    handler = createUnhandledRejectionHandler((reason) => {
+      calls++
+      if (calls > 10) throw new Error('infinite recursion')
+      handler(reason)
+    })
+
+    expect(() => handler(new Error('boom'))).not.toThrow()
+    expect(calls).toBe(1)
+  })
+
+  it('forwards distinct reasons independently', () => {
+    const onRethrow = vi.fn()
+    const handler = createUnhandledRejectionHandler(onRethrow)
+    const a = new Error('a')
+    const b = new Error('b')
+
+    handler(a)
+    handler(b)
+    handler(a)
+
+    expect(onRethrow).toHaveBeenCalledTimes(2)
+    expect(onRethrow).toHaveBeenNthCalledWith(1, a)
+    expect(onRethrow).toHaveBeenNthCalledWith(2, b)
+  })
+
+  it('defaults to re-throwing via Promise.reject', async () => {
+    const handler = createUnhandledRejectionHandler()
+    const reason = new Error('default-rethrow')
+
+    // The default forwarder creates a real unhandled rejection; capture it so
+    // the assertion is deterministic and no stray rejection escapes the test.
+    const captured: unknown[] = []
+    const onUnhandled = (r: unknown) => captured.push(r)
+    process.on('unhandledRejection', onUnhandled)
+    try {
+      handler(reason)
+      await new Promise((resolve) => setImmediate(resolve))
+    } finally {
+      process.off('unhandledRejection', onUnhandled)
+    }
+
+    expect(captured).toContain(reason)
+  })
+})

--- a/web/src/utils/unhandledRejectionGuard.ts
+++ b/web/src/utils/unhandledRejectionGuard.ts
@@ -1,0 +1,44 @@
+/**
+ * Guard against re-entrant unhandled-rejection handling.
+ *
+ * The global test setup installs an `unhandledRejection` handler that
+ * re-throws non-recursive reasons so vitest still surfaces them. Calling
+ * `Promise.reject(reason)` inside that handler produces a *new* unhandled
+ * rejection, which re-enters the same handler — an infinite loop that pegs a
+ * worker at 100% CPU and hangs the whole run.
+ *
+ * This factory returns a handler that forwards each distinct reason exactly
+ * once. Extracted from `test-setup.ts` so the re-entrancy behaviour is unit
+ * testable.
+ */
+
+export function isRecursiveUpdateError(reason: unknown): boolean {
+  if (reason instanceof Error) {
+    return reason.message.includes('Maximum recursive updates')
+  }
+  if (typeof reason === 'string') {
+    return reason.includes('Maximum recursive updates')
+  }
+  return false
+}
+
+/**
+ * Builds an `unhandledRejection` handler that re-throws each reason at most
+ * once. `onRethrow` is injectable for tests (defaults to `Promise.reject`).
+ */
+export function createUnhandledRejectionHandler(
+  onRethrow: (reason: unknown) => void = (reason) => {
+    Promise.reject(reason)
+  },
+): (reason: unknown) => void {
+  const rethrown = new Set<unknown>()
+  return (reason: unknown) => {
+    // Vue's scheduler noise is intentionally swallowed.
+    if (isRecursiveUpdateError(reason)) return
+    // Already forwarded this exact reason — forwarding again would re-enter
+    // this handler forever.
+    if (rethrown.has(reason)) return
+    rethrown.add(reason)
+    onRethrow(reason)
+  }
+}


### PR DESCRIPTION
## 背景

`/api/apk` 在服务器启动目录（CWD）含 `public/` 时返回 404，即使 APK 已嵌入二进制。

## 根因

`ServeAPK` 调用 `frontend.GetFS()`，该函数按 CWD 相对路径 `os.Stat("public")` 二选一 —— CWD 有 `public/` 时返回 `os.DirFS("public")`，**完全不查内嵌 FS**。而 APK 只被 `build.sh` 拷入 `internal/frontend/dist/assets/`（供 `go:embed`），从不进入 `public/assets/`，因此磁盘分支必然找不到。

引入该问题的重构（`3afbde0e`）本意是 "serve from embed FS only, no disk fallback"，但 `GetFS()` 的语义是"按 CWD 选 FS"，未能实现该意图。

## 修复

新增 `frontend.EmbeddedFS()`，恒定返回内嵌 `distFS`，不查 CWD；`ServeAPK` 改为恒读内嵌。抽出可注入 FS 的 `serveAPK(fsys, w, r)` 以便单测（开发构建的 `dist/` 不含 APK）。

效果：任意 CWD、任意部署形态行为一致，且下载的 APK 与运行中二进制版本始终匹配，避免升级弹窗拿到旧包。

顺带将 `apk.go` 移出覆盖率排除名单（原排除理由 `filepath.Abs` 早已删除），该文件现为 100% 覆盖。

## 顺带修复的两个既有问题

排查过程中发现前端存在两个会导致测试 worker 100% CPU 空转、永不退出的 bug：

1. **`Lightbox.vue` TreeWalker 死循环（真实生产 bug）**：点击聊天/Markdown 中图片时，若容器内有无法解析 `src` 的 `<img>`，`if (!src) continue` 会跳过 `walker.nextNode()`，使游标停滞并冻结页面。
2. **`test-setup.ts` unhandledRejection 无限递归**：处理器内 `Promise.reject(reason)` 会再次触发自身。

详见各自 commit message。

## 测试

- Go 全量：`go test ./...` 40/40 包通过
- 新增测试：`TestServeAPK_IgnoresDiskPublic`、`TestEmbeddedFS_IgnoresDiskPublic`、`TestServeAPK_InjectedFSWinsOverDisk`、`TestReaderSeeker_SeekCurrent/_SeekInvalid`、`unhandledRejectionGuard` 7 个、Lightbox 无 src 图片回归 2 个
- 删除过时测试：`TestServeAPK_FromEmbed`、旧 `TestServeAPK_EmbedOnly`
- 前端全量：`405 passed (405)` / `10247 passed`
- `apk.go` / `embed.go` 覆盖率 100%

## 验证

真实二进制端到端验证（含磁盘放置过期假 APK 的场景，确认内嵌副本胜出）：

| 场景 | CWD | 结果 |
|---|---|---|
| 原故障现场 | 项目根（含 `public/`） | **200** |
| 无 public | `/tmp/...` | **200** |
| 磁盘含假 APK | 含 `public/assets/` | **200**，返回内嵌真包 |
